### PR TITLE
Fix: Honor skip-npm-ci

### DIFF
--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -101,8 +101,10 @@ class Serverless(RunwayModule):
             if os.path.isfile(os.path.join(self.path, 'package.json')):
                 with change_dir(self.path):
                     # Use npm ci if available (npm v5.7+)
-                    if not self.options.get('skip_npm_ci') and (
-                            self.context.env_vars.get('CI') and use_npm_ci(self.path)):  # noqa
+                    if self.options.get('skip_npm_ci'):
+                        LOGGER.info("Skipping npm ci or npm install on %s...",
+                                    os.path.basename(self.path))
+                    elif self.context.env_vars.get('CI') and use_npm_ci(self.path):  # noqa
                         LOGGER.info("Running npm ci on %s...",
                                     os.path.basename(self.path))
                         subprocess.check_call(['npm', 'ci'])


### PR DESCRIPTION
**Steps to reproduce**

1. Add `skip-npm-ci: true` to a module in `runway.yml`
1. `runway deploy`

**Expected outcome**

An npm command (ci or install) should not be executed.

**Actual outcome**

An npm command (ci or install) is executed.

**Diagnosis**

The logic for determining which npm command to run, or not, doesn't honor `skip_npm_ci =true` in all cases.

The problem seems to have been introduced in [this commit](https://github.com/onicagroup/runway/commit/e3e5239d97733723ad25ddbc108748384223de8d).

**Fix**
Restructure the logic so that no npm command is executed when the skip flag has been set.
