### PR TITLE
Improve Resilency on Approval Options when making changes to stack

### DIFF
--- a/runway/embedded/stacker/providers/aws/default.py
+++ b/runway/embedded/stacker/providers/aws/default.py
@@ -155,7 +155,7 @@ def ask_for_approval(full_changeset=None, params_diff=None,
         approval_options.append('v')
 
     approve = ui.ask("Execute the above changes? [{}] ".format(
-        '/'.join(approval_options)))
+        '/'.join(approval_options))).lower()
 
     if include_verbose and approve == "v":
         if params_diff:


### PR DESCRIPTION
By making it all lowercase the usable options become Y/y, v/V and anything else skips.

This addresses perhaps a small issue but one which may be confusing if you've accidentally turned on caps lock while coding.

I'm also a big believer that in cases like this there shouldn't be a difference between uppercase and lowercase options.