### PR TITLE
Add error when no regions configured

### DIFF
--- a/runway/commands/env.py
+++ b/runway/commands/env.py
@@ -390,6 +390,9 @@ class Env(Base):
                                 command)()
                 if deployment.get('assume-role'):
                     post_deploy_assume_role(deployment['assume-role'], context)
+            else:
+                LOGGER.error('No region configured for any deployment')
+                sys.exit(1)
 
     def plan(self, deployments=None):
         """Plan apps/code deployment."""


### PR DESCRIPTION
This PR is to add a simple feature to return an error when no regions are defined. Without this Runway will "complete" without executing on any modules (even if the module doesn't specifically require an AWS region (such as Terraform with the PagerDuty provider).