### PR TITLE
Fix for setuptools-based installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,4 @@ prune .cache
 prune .git
 prune build
 prune dist
-recursive-exclude *.egg-info *
 recursive-include runway/templates *


### PR DESCRIPTION
Is there a reason for the "recursive-exclude *.egg-info *" line in MANIFEST.in?

It breaks setuptools-based installations (I want to use Buildout, but it also breaks easy_install) with this error:

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/Users/kteague/.buildout/eggs/zc.buildout-2.12.2-py3.7.egg/zc/buildout/buildout.py", line 2128, in main
    getattr(buildout, command)(args)
  File "/Users/kteague/.buildout/eggs/zc.buildout-2.12.2-py3.7.egg/zc/buildout/buildout.py", line 768, in install
    installed_files = self[part]._call(update)
  File "/Users/kteague/.buildout/eggs/zc.buildout-2.12.2-py3.7.egg/zc/buildout/buildout.py", line 1558, in _call
    return f()
  File "/Users/kteague/.buildout/eggs/zc.recipe.egg-2.0.7-py3.7.egg/zc/recipe/egg/egg.py", line 227, in install
    reqs, ws = self.working_set()
  File "/Users/kteague/.buildout/eggs/zc.recipe.egg-2.0.7-py3.7.egg/zc/recipe/egg/egg.py", line 87, in working_set
    allow_unknown_extras=bool_option(buildout_section, 'allow-unknown-extras')
  File "/Users/kteague/.buildout/eggs/zc.recipe.egg-2.0.7-py3.7.egg/zc/recipe/egg/egg.py", line 168, in _working_set
    allow_unknown_extras=allow_unknown_extras)
  File "/Users/kteague/.buildout/eggs/zc.buildout-2.12.2-py3.7.egg/zc/buildout/easy_install.py", line 957, in install
    return installer.install(specs, working_set)
  File "/Users/kteague/.buildout/eggs/zc.buildout-2.12.2-py3.7.egg/zc/buildout/easy_install.py", line 682, in install
    for dist in self._get_dist(requirement, ws):
  File "/Users/kteague/.buildout/eggs/zc.buildout-2.12.2-py3.7.egg/zc/buildout/easy_install.py", line 574, in _get_dist
    dists = [_move_to_eggs_dir_and_compile(dist, self._dest)]
  File "/Users/kteague/.buildout/eggs/zc.buildout-2.12.2-py3.7.egg/zc/buildout/easy_install.py", line 1740, in _move_to_eggs_dir_and_compile
    [tmp_loc] = glob.glob(os.path.join(tmp_dest, '*'))
ValueError: not enough values to unpack (expected 1, got 0)