### PR TITLE
Remove duplicate word from log in "runway module module"

### DIFF
--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -30,7 +30,7 @@ def generate_node_command(command, command_opts, path):
                     "''%s %s''" % (command, ' '.join(command_opts))]
     else:
         LOGGER.debug('npx not found; falling back invoking %s shell script '
-                     'script directly.', command)
+                     'directly.', command)
         cmd_list = [
             os.path.join(path,
                          'node_modules',


### PR DESCRIPTION
Previously this would print:

```
npx not found; falling back invoking foo shell script script directly.
```

(assuming command = `foo`)

But with this changeset it'll now print:

```
npx not found; falling back invoking foo shell script directly.
```

Which I believe to be the original intent.