### PR TITLE
Resolve issues with quickstart for Windows users

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.insertFinalNewline": true,
     "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": false
+    "python.linting.mypyEnabled": false,
+    "restructuredtext.confPath": "${workspaceFolder}\\docs\\source"
 }

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -131,7 +131,7 @@ simple demonstration of using Runway to deploy a Serverless Framework backend wi
     Remove-Item v1.0.0.zip -Force
     Rename-Item realworld-dynamodb-lambda-1.0.0 backend
     cd backend
-    (gc .\.gitignore -raw).Replace("package-lock.json`r`n", "") | sc .\.gitignore
+    (gc .\.gitignore -raw).Replace("package-lock.json`n", "") | sc .\.gitignore
     ".dynamodb`r`n" | Out-File .\.gitignore -Append -Encoding UTF8
     $(gc .\package.json) -replace "dynamodb install .*$", "dynamodb install`"" | Out-File .\package.json -Force -Encoding UTF8
     npm install
@@ -141,8 +141,11 @@ simple demonstration of using Runway to deploy a Serverless Framework backend wi
     Remove-Item 35a66d144d8def340278cd55080d5c745714aca4.zip -Force
     Rename-Item angular-realworld-example-app-35a66d144d8def340278cd55080d5c745714aca4 frontend
     cd frontend
-    $(gc .\package.json) -replace "^\s*`"build`":\s.*$", "    `"build`": `"if test \`"`$(pipenv run runway whichenv)\`" = \`"prod\`" ; then ng build --prod --base-href .\/ && cp CNAME dist\/CNAME; else ng build --base-href .\/ && cp CNAME dist\/CNAME; fi`"," | Out-File .\package.json -Force -Encoding UTF8
+    (gc .\package.json -raw).Replace("`"rxjs`": `"^6.2.1`"", "`"rxjs`": `"~6.3.3`"") | sc .\package.json
+    Invoke-WebRequest https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/build.js -OutFile scripts/build.js
+    $(gc .\package.json) -replace "^\s*`"build`":\s.*$", "    `"build`": `"node scripts/build`"," | Out-File .\package.json -Force -Encoding UTF8
     npm install
+    mkdir scripts
     Invoke-WebRequest https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/update_env_endpoint.py -OutFile update_env_endpoint.py
     cd ..
     Invoke-WebRequest https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/Pipfile -OutFile Pipfile

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -110,7 +110,10 @@ simple demonstration of using Runway to deploy a Serverless Framework backend wi
     rm 35a66d144d8def340278cd55080d5c745714aca4
     mv angular-realworld-example-app-35a66d144d8def340278cd55080d5c745714aca4 frontend
     cd frontend
-    sed -i 's/^\s*"build":\s.*$/    "build": "if test \\"$(pipenv run runway whichenv)\\" = \\"prod\\" ; then ng build --prod --base-href .\/ \&\& cp CNAME dist\/CNAME; else ng build --base-href .\/ \&\& cp CNAME dist\/CNAME; fi",/' package.json
+    mkdir scripts
+    cd scripts && { curl -O https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/build.js ; cd -; }
+    sed -i 's/^\s*"build":\s.*$/    "build": "node scripts/build",/' package.json
+    sed -i 's/^\s*"rxjs":\s.*$/    "rxjs": "~6.3.3",/' package.json
     npm install
     curl -O https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/update_env_endpoint.py
     cd ..
@@ -142,10 +145,10 @@ simple demonstration of using Runway to deploy a Serverless Framework backend wi
     Rename-Item angular-realworld-example-app-35a66d144d8def340278cd55080d5c745714aca4 frontend
     cd frontend
     (gc .\package.json -raw).Replace("`"rxjs`": `"^6.2.1`"", "`"rxjs`": `"~6.3.3`"") | sc .\package.json
+    mkdir scripts
     Invoke-WebRequest https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/build.js -OutFile scripts/build.js
     $(gc .\package.json) -replace "^\s*`"build`":\s.*$", "    `"build`": `"node scripts/build`"," | Out-File .\package.json -Force -Encoding UTF8
     npm install
-    mkdir scripts
     Invoke-WebRequest https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/update_env_endpoint.py -OutFile update_env_endpoint.py
     cd ..
     Invoke-WebRequest https://raw.githubusercontent.com/onicagroup/runway/master/quickstarts/conduit/Pipfile -OutFile Pipfile

--- a/quickstarts/conduit/build.js
+++ b/quickstarts/conduit/build.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const util = require("util");
+const { exec } = require("child_process");
+const execAsync = util.promisify(exec);
+
+(async () => {
+  let env = "dev";
+  try {
+    dev = execAsync("pipenv run runway whichenv");
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+
+  if (env === "prod") {
+    try {
+      await execAsync(`npx ng build --prod --base-href .`);
+    } catch (error) {
+      console.error(error);
+      return;
+    }
+  } else {
+    try {
+      await execAsync(`npx ng build --base-href .`);
+    } catch (error) {
+      console.error(error);
+      return;
+    }
+    fs.copyFileSync("./CNAME", "./dist/CNAME");
+  }
+})();


### PR DESCRIPTION
This updates the quickstart instructions for deploying the Conduit quickstart example.
- A build.js file breaks up the build command and makes it Windows friendly for those following along the setup instructions for Windows.
- `npm` references changed to `npm.cmd` since the commands executing the runway build_steps were not finding the implicit `npm` command.
- Removed `CRLF` line endings in favor of `LF`
- Added a setting for vscode users that have reStructuredText extension for syntax highlighting.