### PR TITLE
allow access to runway.yml env_vars from Terraform

### DIFF
--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -225,6 +225,9 @@ class Terraform(RunwayModule):
             for (key, val) in self.options['environments'][self.context.env_name].items():  # noqa
                 tf_cmd.extend(['-var', "%s=%s" % (key, val)])
 
+        for (key, val) in self.context.env_vars.items():  # noqa
+            tf_cmd.extend(['-var', "%s=%s" % (key, val)])
+
         if self.options.get('environments', {}).get(self.context.env_name) or (
                 workspace_tfvar_present):
             LOGGER.info("Preparing to run terraform %s on %s...",


### PR DESCRIPTION
It *seems* that you can't use these values currently?

e.g. if I have a TF file with the following
```
data "aws_route53_zone" "hosted_zone" {
  name         = "${var.app_domain}."
  private_zone = false
}
```
And then in `runway.yml` I have this in my deployment:
```
    env_vars:
      '*':
        app_domain: lab.foo.com
```
Then it doesn't work, without this code change.  

From what I can tell,  TF only has access to values in `context.env_vars` if they are prefixed by `TF_VAR_`.