### PR TITLE
Added support for passing in alternate runway.yml files at runtime.

### DIFF
--- a/runway/commands/runway/whichenv.py
+++ b/runway/commands/runway/whichenv.py
@@ -14,12 +14,12 @@ class WhichEnv(RunwayCommand):
         """Output environment name."""
         # Disable other runway logging so the only response is the env name
         logging.getLogger('runway').setLevel(logging.ERROR)
-
+        runway_file = os.getenv('RUNWAY', 'runway.yml')
         # This may be invoked from a module directory in an environment;
         # account for that here if necessary
-        if not os.path.isfile('runway.yml'):
+        if not os.path.isfile(runway_file):
             self.env_root = os.path.dirname(os.getcwd())
-            self.runway_config_path = os.path.join(self.env_root, 'runway.yml')
+            self.runway_config_path = os.path.join(self.env_root, runway_file)
 
         print(get_env(
             self.env_root,

--- a/runway/commands/runway_command.py
+++ b/runway/commands/runway_command.py
@@ -28,12 +28,12 @@ class RunwayCommand(object):
         if runway_config_dir is None:
             self.runway_config_path = os.path.join(
                 self.env_root,
-                'runway.yml'
+                os.getenv('RUNWAY', 'runway.yml')
             )
         else:
             self.runway_config_path = os.path.join(
                 runway_config_dir,
-                'runway.yml'
+                os.getenv('RUNWAY', 'runway.yml')
             )
         self._runway_config = None
 


### PR DESCRIPTION
Added support to retrieve a runway path from the environment variable `RUNWAY` and defaulting to `runway.yml`

```
$ RUNWAY=deployments/alarm-manager-role.yml runway takeoff
INFO:runway:Deriving environment name from git branch master...
INFO:runway:Translating git branch "master" to environment "common"
INFO:runway:
INFO:runway:Environment "common" was determined from the current git branch or parent directory.
INFO:runway:If this is not the environment name, update the branch/folder name or set an override value via the DEPLOY_ENVIRONMENT environment variable
INFO:runway:
INFO:runway:Found 1 deployment(s)
INFO:runway:
INFO:runway:
INFO:runway:======= Processing deployment 'deployment_1' ===========================
INFO:runway:
INFO:runway:Attempting to deploy 'common' to region(s): us-west-2
INFO:runway:
INFO:runway:======= Processing region us-west-2 ===========================
INFO:runway:Verified current AWS account matches required account id 079900963187.
INFO:runway:
INFO:runway:---- Processing module 'alarm-manager-role.tf' for 'common' in us-west-2 --------------
INFO:runway:Module options: {'path': 'alarm-manager-role.tf'}
INFO:runway:Skipping Terraform apply of alarm-manager-role.tf
INFO:runway:(no tfvars file for this environment/region found -- looking for one of "common-us-west-2.tfvars, common.tfvars")
```