### PR TITLE
Bugfix/py2 pydocstyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- conditional requirement for `pydocstyle<=3.0.0` for python2
+
 
 ## [0.46.5] - 2019-06-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.46.6] - 2019-07-08
 ### Added
 - conditional requirement for `pydocstyle<=3.0.0` for python2
-
 
 ## [0.46.5] - 2019-06-04
 ### Fixed

--- a/runway/__init__.py
+++ b/runway/__init__.py
@@ -1,2 +1,2 @@
 """Set package version."""
-__version__ = '0.46.5'
+__version__ = '0.46.6'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ INSTALL_REQUIRES = [
     'troposphere>=2.4.2',
     # botocore pins its urllib3 dependency like this, so we need to do the
     # same to ensure v1.25+ isn't pulled in by pip
-    'urllib3>=1.20,<1.25'
+    'urllib3>=1.20,<1.25',
+    "pydocstyle<=3.0.0; python_version<'3'"
 ]
 
 # pylint v2+ is only py3 compatible


### PR DESCRIPTION
When used with python2, the following error is received:

```
ERROR: Could not find a version that satisfies the requirement pydocstyle==4.0.0 (from -r /var/folders/jx/qm4g61y11s77l_s594df_6k00000gn/T/pipenv-4TjKfA-requirements/pipenv-97UMNY-requirement.txt (line 1)) (from versions: 1.0.0, 1.1.0, 1.1.1, 2.0.0, 2.1.0, 2.1.1, 3.0.0)'
```