### PR TITLE
don't re-check for commands when fixing windows commmands

### DIFF
--- a/src/runway/util.py
+++ b/src/runway/util.py
@@ -201,7 +201,7 @@ def run_commands(commands,  # type: List[Union[str, List[str], Dict[str, Union[s
             command_list = fix_windows_command_list(command_list)
 
         if not which(command_list[0]):
-            raise OSError('"{0}" not found. Are you sure "{0}" is installed and added to your PATH?'.format(command_list[0]))
+            raise OSError('"{0}" not found. Are you sure "{0}" is installed and added to your PATH?'.format(command_list[0]))  # noqa pylint: disable=line-too-long
 
         with change_dir(execution_dir):
             check_call(command_list, env=env)

--- a/src/runway/util.py
+++ b/src/runway/util.py
@@ -200,6 +200,9 @@ def run_commands(commands,  # type: List[Union[str, List[str], Dict[str, Union[s
         if platform.system().lower() == 'windows':
             command_list = fix_windows_command_list(command_list)
 
+        if not which(command_list[0]):
+            raise OSError('"{0}" not found. Are you sure "{0}" is installed and added to your PATH?'.format(command_list[0]))
+
         with change_dir(execution_dir):
             check_call(command_list, env=env)
 

--- a/src/runway/util.py
+++ b/src/runway/util.py
@@ -253,8 +253,8 @@ def which(program):
         return exts.split(';')
 
     fpath, fname = os.path.split(program)
-    fname, ext = os.path.splitext(program)
-    if not ext and platform.system().lower() == 'windows':
+    fname, file_ext = os.path.splitext(program)
+    if not file_ext and platform.system().lower() == 'windows':
         fnames = [fname + ext for ext in get_extensions()]
     else:
         fnames = [fname]

--- a/src/runway/util.py
+++ b/src/runway/util.py
@@ -234,7 +234,7 @@ def use_embedded_pkgs(embedded_lib_path=None):
         sys.path = old_sys_path
 
 
-def which(program, add_win_suffixes=True):
+def which(program):
     """Mimic 'which' command behavior.
 
     Adapted from https://stackoverflow.com/a/377028
@@ -243,10 +243,19 @@ def which(program, add_win_suffixes=True):
         """Determine if program exists and is executable."""
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
+    def get_extensions():
+        """Get PATHEXT if the exist, otherwise use default."""
+        exts = ['.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC']
+
+        if os.environ.get('PATHEXT', []):
+            exts = os.environ['PATHEXT']
+
+        return exts.split(';')
+
     fpath, fname = os.path.split(program)
-    if add_win_suffixes and platform.system().lower() == 'windows' and not (
-            fname.endswith('.exe') or fname.endswith('.cmd')):
-        fnames = [fname + '.exe', fname + '.cmd']
+    fname, ext = os.path.splitext(program)
+    if not ext and platform.system().lower() == 'windows':
+        fnames = [fname + ext for ext in get_extensions()]
     else:
         fnames = [fname]
 

--- a/src/runway/util.py
+++ b/src/runway/util.py
@@ -173,8 +173,7 @@ def fix_windows_command_list(commands):
     a windows-only suffix applied to them
     """
     fully_qualified_cmd_path = which(commands[0])
-    if fully_qualified_cmd_path and (
-            not which(commands[0], add_win_suffixes=False)):
+    if fully_qualified_cmd_path:
         commands[0] = os.path.basename(fully_qualified_cmd_path)
     return commands
 


### PR DESCRIPTION
when calling `fix_windows_command_list`, if there is both a .cmd and non-extension executable, (e.g. `yarn.cmd` and a file `yarn` that is also executable `os.access(fpath, os.X_OK)`) then the if statement will return false and the wrong command will be used on windows when using subprocess. In this case `yarn` will be used instead of the proper `yarn.cmd` and subprocess will error with `FileNotFoundError: [WinError 2] The system cannot find the file specified`