### PR TITLE
ignore docker-compose in the root of cfn modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix cross-platform subprocess execution (e.g. yarn specified without a file extension in staticsite build_steps)
 - Better error messages for subprocess commands that fail to run
+- cloudformation modules now ignore `docker-compose.yml` in the root of the module directory
 
 ### Added
 - run-python & run-stacker commands (for single-binary compatibility)

--- a/src/runway/module/cloudformation.py
+++ b/src/runway/module/cloudformation.py
@@ -162,9 +162,11 @@ class CloudFormation(RunwayModule):
                         sorted_files = reversed(sorted_files)
                     for name in sorted_files:
                         if re.match(r"runway(\..*)?\.yml", name) or (
-                                name.startswith('.')):
-                            # Hidden files (e.g. .gitlab-ci.yml) or runway configs
-                            # definitely aren't stacker config files
+                                name.startswith('.') or
+                                name == 'docker-compose.yml'):
+                            # Hidden files (e.g. .gitlab-ci.yml), runway configs,
+                            # and docker-compose files definitely aren't stacker
+                            # config files
                             continue
                         if os.path.splitext(name)[1] in ['.yaml', '.yml']:
                             ensure_stacker_compat_config(


### PR DESCRIPTION
if `docker-compose.yml` is in the root of a cloudformation module, runway will try to process it as a stacker config file.