### PR TITLE
Bugfix/cdk py sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- `gen-sample cdk-py` now correctly generates a sample instead of trying to copy files that don't exist
 
 ## [1.2.1] - 2019-11-13
 ### Fixed

--- a/src/runway/commands/runway/gen_sample.py
+++ b/src/runway/commands/runway/gen_sample.py
@@ -309,8 +309,10 @@ def generate_sample_cdk_py_module(env_root, module_dir=None):
     if module_dir is None:
         module_dir = os.path.join(env_root, 'sampleapp.cdk')
     generate_sample_module(module_dir)
-    for i in ['app.py', 'cdk.json', 'lambda-index.py', 'package.json',
-              'runway.module.yml', 'Pipfile']:
+    os.mkdir(os.path.join(module_dir, 'hello'))
+    for i in ['hello/__init__.py', 'hello/hello_construct.py',
+              'hello/hello_stack.py', '.gitignore', 'app.py', 'cdk.json',
+              'package.json', 'Pipfile', 'Pipfile.lock', 'runway.module.yml']:
         shutil.copyfile(
             os.path.join(ROOT,
                          'templates',


### PR DESCRIPTION
`gen-sample cdk-py` previously resulted in the following error

```
FileNotFoundError: [Errno 2] No such file or directory: '.../site-packages/runway/templates/cdk-py/lambda-index.py'
```

This was introduced in the v1.0.0 release.