### PR TITLE
[BUGFIX] process selected deployments instead of all deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- runway was now respect the selected deployments/modules
 
 ## [1.3.0] - 2019-11-15
 ### Fixed

--- a/src/runway/commands/modules_command.py
+++ b/src/runway/commands/modules_command.py
@@ -398,7 +398,7 @@ class ModulesCommand(RunwayCommand):
         LOGGER.info("")
         LOGGER.info("Found %d deployment(s)", len(deployments_to_run))
 
-        self._process_deployments(deployments, context)
+        self._process_deployments(deployments_to_run, context)
 
     def execute(self):
         # type: () -> None


### PR DESCRIPTION
# Bug Report

when trying to select a specific deployment/module, it does not process only the selected deployment/module. it instead processes everything, regardless of selection.