### PR TITLE
update error message for test execution with no defined tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated `runway test` error message to give direction on next steps when no tests are defined
 
 ## [1.3.2] - 2019-11-22
 ### Fixed

--- a/src/runway/commands/runway/test.py
+++ b/src/runway/commands/runway/test.py
@@ -9,6 +9,7 @@ References:
     - :ref:`Defining Tests<defining-tests>`
 
 """
+from __future__ import print_function
 import logging
 import sys
 import traceback
@@ -27,9 +28,19 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
         test_definitions = self.runway_config.tests
 
         if not test_definitions:
-            LOGGER.warning('Use of "runway test" without defining '
-                           'tests in the runway config file has been '
-                           'deprecated.')
+            LOGGER.error('Use of "runway test" without defining '
+                         'tests in the runway config file has been '
+                         'removed. See '
+                         'https://docs.onica.com/projects/runway/en/release/defining_tests.html')
+            LOGGER.error('E.g.:')
+            for i in ['tests:',
+                      '  - name: example-test',
+                      '    type: script',
+                      '    args:',
+                      '      commands:',
+                      '        - echo "Success!"',
+                      '']:
+                print(i, file=sys.stderr)
             sys.exit(1)
 
         LOGGER.info('Found %i test(s)', len(test_definitions))


### PR DESCRIPTION
Avoids semantic issue about deprecated message and gives more direction on how to fix the error