### PR TITLE
use bundled yamllint when running tests in single binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow single-binary use of bundled yamllint
 
 ## [1.3.3] - 2019-11-26
 ### Changed

--- a/src/runway/commands/runway/test.py
+++ b/src/runway/commands/runway/test.py
@@ -36,6 +36,7 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
             for i in ['tests:',
                       '  - name: example-test',
                       '    type: script',
+                      '    required: true',
                       '    args:',
                       '      commands:',
                       '        - echo "Success!"',


### PR DESCRIPTION
Since yamllint is getting pulled in anyway, this will allow the bundled version to be used in single-binary mode