### PR TITLE
run-aws integration test 

### DIFF
--- a/integration_tests/test_commands/test_commands.py
+++ b/integration_tests/test_commands/test_commands.py
@@ -13,7 +13,9 @@ class Commands(IntegrationTest):
 
     def run(self):
         """Find all tests and run them."""
-        import_tests(self.logger, self.tests_dir, 'test_*')
+        suffix = os.getenv('COMMAND_SUFFIX', '*')
+        pattern = 'test_{0}'.format(suffix)
+        import_tests(self.logger, self.tests_dir, pattern)
         tests = [test(self.logger) for test in Commands.__subclasses__()]
         if not tests:
             raise Exception('No tests were found.')

--- a/integration_tests/test_commands/tests/test_runaws.py
+++ b/integration_tests/test_commands/tests/test_runaws.py
@@ -1,0 +1,31 @@
+"""Test getting current user."""
+import os
+import json
+
+from subprocess import check_output
+from integration_tests.test_commands.test_commands import Commands
+
+
+class TestRunAWS(Commands):
+    """Tests run-aws subcommand."""
+
+    TEST_NAME = __name__
+
+    def init(self):
+        """Initialize test."""
+        pass  # pylint: disable=unnecessary-pass
+
+    def run(self):
+        """Run test."""
+        response = check_output(
+            ['runway',
+             'run-aws',
+             'sts',
+             'get-caller-identity']
+        ).decode()
+        data = json.loads(response)
+        assert 'Arn' in data, 'response has no Arn property'
+
+    def teardown(self):
+        """Teardown any created resources."""
+        pass  # pylint: disable=unnecessary-pass


### PR DESCRIPTION
**Goal**
Add an integration test for run-aws command.

**Implementation**
The test simply gets the caller identity and checks whether the response is valid.
Added an optional environment variable to to filter the integration tests. This simplifies development because it allows to run a single command test optionally.