### PR TITLE
add run-stacker integration tests

### DIFF
--- a/integration_tests/test_commands/fixtures/stacker/ssm.yaml
+++ b/integration_tests/test_commands/fixtures/stacker/ssm.yaml
@@ -1,0 +1,7 @@
+Resources:
+  SSMString:
+    Type: AWS::SSM::Parameter
+    Properties: 
+      Name: /runway/integration-test/stacker
+      Type: String
+      Value: foo

--- a/integration_tests/test_commands/fixtures/stacker/stack.yaml
+++ b/integration_tests/test_commands/fixtures/stacker/stack.yaml
@@ -1,0 +1,6 @@
+namespace: dev
+stacker_bucket: ''
+
+stacks:
+  stackerintegrationtest:
+    template_path: ssm.yaml

--- a/integration_tests/test_commands/test_commands.py
+++ b/integration_tests/test_commands/test_commands.py
@@ -13,7 +13,9 @@ class Commands(IntegrationTest):
 
     def run(self):
         """Find all tests and run them."""
-        import_tests(self.logger, self.tests_dir, 'test_*')
+        suffix = os.getenv('COMMAND_SUFFIX', '*')
+        pattern = 'test_{0}'.format(suffix)
+        import_tests(self.logger, self.tests_dir, pattern)
         tests = [test(self.logger) for test in Commands.__subclasses__()]
         if not tests:
             raise Exception('No tests were found.')

--- a/integration_tests/test_commands/tests/test_stacker.py
+++ b/integration_tests/test_commands/tests/test_stacker.py
@@ -1,0 +1,29 @@
+"""Test deploying stacker."""
+import os
+from subprocess import check_output
+
+from integration_tests.test_commands.test_commands import Commands
+
+
+class TestRunStacker(Commands):
+    """Tests run-stacker subcommand."""
+
+    TEST_NAME = __name__
+
+    def init(self):
+        """Initialize test."""
+        pass  # pylint: disable=unnecessary-pass
+
+    def run(self):
+        """Run tests."""
+        response = check_output(
+            ['runway',
+             'run-stacker',
+             '--',
+             '--version']).decode().strip()
+        print(response)
+        assert response == 'stacker 1.7.0'
+
+    def teardown(self):
+        """Teardown any created resources."""
+        pass  # pylint: disable=unnecessary-pass

--- a/integration_tests/test_commands/tests/test_stacker.py
+++ b/integration_tests/test_commands/tests/test_stacker.py
@@ -21,7 +21,6 @@ class TestRunStacker(Commands):
              'run-stacker',
              '--',
              '--version']).decode().strip()
-        print(response)
         assert response == 'stacker 1.7.0'
 
     def teardown(self):

--- a/integration_tests/test_commands/tests/test_stacker.py
+++ b/integration_tests/test_commands/tests/test_stacker.py
@@ -1,8 +1,13 @@
 """Test deploying stacker."""
 import os
 from subprocess import check_output
+import boto3
 
 from integration_tests.test_commands.test_commands import Commands
+
+CLIENT = boto3.client('ssm')
+KEY = "/runway/integration-test/stacker"
+VALUE = "foo"
 
 
 class TestRunStacker(Commands):
@@ -10,19 +15,38 @@ class TestRunStacker(Commands):
 
     TEST_NAME = __name__
 
+    def get_stack_path(self):
+        """Gets the stacker itest path."""
+        return os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'fixtures',
+            'stacker')
+
     def init(self):
         """Initialize test."""
         pass  # pylint: disable=unnecessary-pass
 
     def run(self):
         """Run tests."""
-        response = check_output(
+        path = self.get_stack_path()
+        check_output(
             ['runway',
              'run-stacker',
              '--',
-             '--version']).decode().strip()
-        assert response == 'stacker 1.7.0'
+             'build',
+             'stack.yaml'],
+            cwd=path).decode()
+        parameter = CLIENT.get_parameter(Name=KEY)
+        assert parameter['Parameter']['Value'] == VALUE
 
     def teardown(self):
         """Teardown any created resources."""
-        pass  # pylint: disable=unnecessary-pass
+        path = self.get_stack_path()
+        check_output(
+            ['runway',
+             'run-stacker',
+             '--',
+             'destroy',
+             'stack.yaml',
+             '--force'],
+            cwd=path).decode()


### PR DESCRIPTION
**Goal**
Add an integration test for run-stacker command.

**Implementation**
The test creates simply calls stacker --version.
Added an optional environment variable to filter the integration tests. This simplifies development because it allows to run a single command test optionally.