### PR TITLE
pinned pyhcl version to less then 0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- pinned `pyhcl` to `<0.3.14`
+    - `0.3.14` vendored ply instead of having it as a dependency which breaks our embedded, patched copy
 
 ## [1.3.6] - 2019-12-28
 ### Fixed

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ awacs = "*"
 awscli = ">=1.16.191<2.0"
 docopt = "*"
 future = "*"
-pyhcl = "*"
+pyhcl = "<0.3.14"
 typing = {version = "~= 3.7",markers = "python_version < '3.5'"}
 yamllint = "*"
 zgitignore = "*"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     # with the LICENSE file added to its root folder
     # and the following patches applied
     # https://github.com/virtuald/pyhcl/pull/57
-    'pyhcl~=0.3',
+    'pyhcl<0.3.14',
     'pyOpenSSL',  # For embedded hook & associated script usage
     'six',
     'typing;python_version<"3.5"',


### PR DESCRIPTION
`0.3.14` vendored ply instead of having it as a dependency which breaks our embedded, patched copy