### PR TITLE
upgrade nodejs runtime in serverless integration tests

### DIFF
--- a/integration_tests/test_serverless/templates/promotezip-multisrc-multizip.sls/serverless.yml
+++ b/integration_tests/test_serverless/templates/promotezip-multisrc-multizip.sls/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-test-pzmsmz
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 package:
   individually: true

--- a/integration_tests/test_serverless/templates/promotezip-multisrc-single-zip.sls/serverless.yml
+++ b/integration_tests/test_serverless/templates/promotezip-multisrc-single-zip.sls/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-test-pzmssz
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 functions:
   helloWorld:

--- a/integration_tests/test_serverless/templates/promotezip-singlesrc-singlezip.sls/serverless.yml
+++ b/integration_tests/test_serverless/templates/promotezip-singlesrc-singlezip.sls/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-test-sssz
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 functions:
   helloWorld:


### PR DESCRIPTION
Goal
Upgrade nodejs runtime to prevent using nodejs 8 because it's deprecated by AWS