### PR TITLE
replace stacker prefixed attrs, args, and config field with cfngin

### DIFF
--- a/docs/source/cfngin/config.rst
+++ b/docs/source/cfngin/config.rst
@@ -70,16 +70,16 @@ updating your stacks. By default it uses a bucket named
 ``stacker-${namespace}``, where the namespace_ is the namespace_ provided the
 config.
 
-If you want to change this, provide the ``stacker_bucket`` top-level keyword
+If you want to change this, provide the ``cfngin_bucket`` top-level keyword
 in the config.
 
 The bucket will be created in the same region that the stacks will be launched
 in.  If you want to change this, or if you already have an existing bucket
-in a different region, you can set the ``stacker_bucket_region`` to
+in a different region, you can set the ``cfngin_bucket_region`` to
 the region where you want to create the bucket.
 
 If you want CFNgin to upload templates directly to CloudFormation, instead of
-first uploading to S3, you can set ``stacker_bucket`` to an empty string.
+first uploading to S3, you can set ``cfngin_bucket`` to an empty string.
 However, note that template size is greatly limited when uploading directly.
 See the `CloudFormation Limits Reference`_.
 
@@ -171,7 +171,7 @@ Use the ``paths`` option when subdirectories of the repo/archive/directory
 should be added to CFNgins's ``sys.path``.
 
 Cloned repos/archives will be cached between builds; the cache location defaults
-to ``~/.runway_cache`` but can be manually specified via the ``stacker_cache_dir``
+to ``~/.runway_cache`` but can be manually specified via the ``cfngin_cache_dir``
 top-level keyword.
 
 
@@ -287,7 +287,7 @@ Tags
 
 CloudFormation supports arbitrary key-value pair tags. All stack-level, including automatically created tags, are
 propagated to resources that AWS CloudFormation supports. See `AWS CloudFormation Resource Tags Type`_ for more details.
-If no tags are specified, the ``stacker_namespace`` tag is applied to your stack with the value of ``namespace`` as the
+If no tags are specified, the ``cfngin_namespace`` tag is applied to your stack with the value of ``namespace`` as the
 tag value.
 
 If you prefer to apply a custom set of tags, specify the top-level keyword ``tags`` as a map.

--- a/docs/source/cfngin/hooks.rst
+++ b/docs/source/cfngin/hooks.rst
@@ -52,7 +52,7 @@ to be skipped in subsequent runs.
 
 **bucket_region (Optional[str])**
     The region in which the bucket should exist.
-    If not given, the region will be either be that of the global ``stacker_bucket_region`` setting, or else the region in use by the provider.
+    If not given, the region will be either be that of the global ``cfngin_bucket_region`` setting, or else the region in use by the provider.
 
 **prefix (Optional[str])**
     S3 key prefix to prepend to the uploaded zip name.

--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -8,6 +8,11 @@
 Lookups
 =======
 
+.. note:: Runway lookups and CFNgin lookups are not interchangeable. While they
+          do share a similar base class and syntax, they exist in two different
+          registries. Runway config files can't use CFNgin lookups just as the
+          CFNgin config cannot use Runway lookups.
+
 CFNgin provides the ability to dynamically replace values in the config via a
 concept called lookups. A lookup is meant to take a value and convert
 it by calling out to another service or system.

--- a/docs/source/cfngin/migrating.rst
+++ b/docs/source/cfngin/migrating.rst
@@ -1,17 +1,21 @@
 .. _CFNgin API Docs: ../apidocs/runway.cfngin.html
+.. _Custom Lookups: lookups.html#custom-lookup
 .. _Stacker: https://github.com/cloudtools/stacker
 
 Migrating from Stacker to CFNgin
 ================================
 
-.. important:: Most current uses of runway with Stacker_ will continue to work.
+.. important:: Most current uses of Runway with Stacker_ will continue to work.
                But, for imports from Stacker_, Runway will automatically redirect them to CFNgin.
                Because of this, you may experience errors depending on how you are consuming the Stacker_ components.
                This "shim" will remain in place until the release of Runway 2.0.0, no sooner then 2020-12.
 
+Blueprints
+----------
+
 All components available in Stacker_ 1.7.0 are available in CFNgin at the same path within ``runway.cfngin``.
 
-.. rubric:: Blueprint Example
+.. rubric:: Example
 .. code-block:: python
 
     # what use to be this
@@ -22,7 +26,32 @@ All components available in Stacker_ 1.7.0 are available in CFNgin at the same p
     from runway.cfngin.blueprints.base import Blueprint
     from runway.cfngin.blueprints.variables.types import CFNString
 
-.. rubric:: Hook Example
+Config Files
+------------
+
+There are some config top-level keys that have changed when used CFNgin.
+Below is a table of the Stacker key and what they have been changed to for CFNgin
+
+.. important:: The Stacker keys can still be used with CFNgin for the time being.
+               This will remain in place until the release of Runway 2.0.0, no sooner then 2020-12.
+
++---------------------------+----------------------------+
+| Stacker                   | CFNgin                     |
++===========================+============================+
+| ``stacker_bucket``        | ``cfngin_bucket``          |
++---------------------------+----------------------------+
+| ``stacker_bucket_region`` | ``cfngin_bucket_region``   |
++---------------------------+----------------------------+
+| ``stacker_cache_dir``     | ``cfngin_cache_dir``       |
++---------------------------+----------------------------+
+
+
+Build-in Hooks
+~~~~~~~~~~~~~~
+
+All hooks available in Stacker_ 1.7.0 are available in CFNgin at the same path within ``runway.cfngin``.
+
+.. rubric:: Example Definition
 .. code-block:: yaml
 
     pre_build:
@@ -36,3 +65,13 @@ All components available in Stacker_ 1.7.0 are available in CFNgin at the same p
           command: echo "Hello $USER!"
 
 .. seealso:: `CFNgin API Docs`_
+
+
+Custom Lookups
+~~~~~~~~~~~~~~
+
+See the `Custom Lookups`_ section of the docs for detailed instructions on how lookups should be written.
+
+.. important:: Stacker lookups (function and class styles) are supported for the time being.
+               It is recommended to update them to the CFNgin format outlined in `Custom Lookups`_.
+               Support for Stacker style lookups will remain in place until the release of Runway 2.0.0, no sooner then 2020-12.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -100,7 +100,7 @@ Deploying Your First Module
    ``sampleapp.cfn/``. Here is where we will define values for our stacks that
    will be deployed as part of the **dev** environment in the **us-east-1**
    region. Replace the place holder values in this file with your own
-   information. It is important that the ``stacker_bucket_name`` value is
+   information. It is important that the ``cfngin_bucket_name`` value is
    globally unique for this example as it will be used to create a new S3
    bucket.
 
@@ -110,8 +110,8 @@ Deploying Your First Module
        customer: onica
        environment: dev
        region: us-east-1
-       # The stacker bucket is used for CFN template uploads to AWS
-       stacker_bucket_name: stacker-onica-us-east-1
+       # The CFNgin bucket is used for CFN template uploads to AWS
+       cfngin_bucket_name: cfngin-onica-us-east-1
 
 #. With the :ref:`module<runway-module>` ready to deploy, now we need to create
    our :ref:`Runway config file<runway-config>`. Do to this, use the

--- a/docs/source/runway_config.rst
+++ b/docs/source/runway_config.rst
@@ -1,7 +1,7 @@
 .. _AWS CDK: https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html
 .. _CloudFormation: https://aws.amazon.com/cloudformation/
 .. _Serverless Framework: https://serverless.com/
-.. _Stacker: https://stacker.readthedocs.io/en/stable/
+.. _CFNgin: cfngin/index.html
 .. _Terraform: https://www.terraform.io
 .. _Troposphere: https://github.com/cloudtools/troposphere
 .. _Kubernetes: https://kubernetes.io/

--- a/runway/cfngin/actions/base.py
+++ b/runway/cfngin/actions/base.py
@@ -146,7 +146,7 @@ class BaseAction(object):
         self.provider_builder = provider_builder
         self.bucket_name = context.bucket_name
         self.cancel = cancel or threading.Event()
-        self.bucket_region = context.config.stacker_bucket_region
+        self.bucket_region = context.config.cfngin_bucket_region
         if not self.bucket_region and provider_builder:
             self.bucket_region = provider_builder.region
         self.s3_conn = get_session(self.bucket_region).client('s3')

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -182,7 +182,8 @@ def process_remote_sources(raw_config, environment=None):
     if config and config.get('package_sources'):
         processor = SourceProcessor(
             sources=config['package_sources'],
-            stacker_cache_dir=config.get('stacker_cache_dir')
+            cfngin_cache_dir=config.get('cfngin_cache_dir',
+                                        config.get('stacker_cache_dir'))
         )
         processor.get_package_sources()
         if processor.configs_to_merge:
@@ -421,28 +422,45 @@ class Config(Model):
         print dump(config)
 
     Attributes:
-        log_formats (DictType)
-        lookups (DictType)
-        mappings (DictType)
-        namespace (StringType)
-        namespace_delimiter (StringType)
-        package_sources (ModelType)
-        post_build (ListType)
-        post_destroy (ListType)
-        pre_build (ListType)
-        pre_destroy (ListType)
-        service_role (StringType)
-        stacker_bucket (StringType)
-        stacker_bucket_region (StringType)
-        stacker_cache_dir (StringType)
-        stacks (ListType)
-        sys_path (StringType)
-        tags (DictType)
-        targets (ListType)
-        template_indent (StringType)
+        cfngin_bucket (StringType): Bucket to use for CFNgin resources (e.g.
+            CloudFormation templates). May be an empty string.
+        cfngin_bucket_region (StringType): Explicit region to use for
+            ``cfngin_bucket``.
+        cfngin_cache_dir (StringType): Local directory to use for caching.
+        log_formats (DictType): Custom formatting for log messages.
+        lookups (DictType): Register custom lookups.
+        mappings (DictType): Mappings that will be added to all stacks.
+        namespace (StringType): Namespace to prepend to everything.
+        namespace_delimiter (StringType): Character used to separate
+            ``namespace`` and anything it prepends.
+        package_sources (ModelType): Remote source locations.
+        post_build (ListType): Hooks to run after a build action.
+        post_destroy (ListType): Hooks to run after a destroy action.
+        pre_build (ListType): Hooks to run before a build action.
+        pre_destroy (ListType): Hooks to run before a destroy action.
+        service_role (StringType): IAM role for CloudFormation to use.
+        stacker_bucket (StringType): [DEPRECATED] Replaced by
+            ``cfngin_bucket``, support will be retained until the release
+            of version 2.0.0 at the earliest.
+        stacker_bucket_region (StringType): [DEPRECATED] Replaced by
+            ``cfngin_bucket_region``, support will be retained until the
+            release of version 2.0.0 at the earliest.
+        stacker_cache_dir (StringType): [DEPRECATED] Replaced by
+            ``cfngin_cache_dir``, support will be retained until the release
+            of version 2.0.0 at the earliest.
+        stacks (ListType): Stacks to be processed.
+        sys_path (StringType): Relative or absolute path to use as the work
+            directory.
+        tags (DictType): Tags to apply to all resources.
+        targets (ListType): Stag grouping.
+        template_indent (StringType): Spaces to use per-indent level when
+            outputing a template to json.
 
     """
 
+    cfngin_bucket = StringType(serialize_when_none=False)
+    cfngin_bucket_region = StringType(serialize_when_none=False)
+    cfngin_cache_dir = StringType(serialize_when_none=False)
     log_formats = DictType(StringType, serialize_when_none=False)
     lookups = DictType(StringType, serialize_when_none=False)
     mappings = DictType(
@@ -465,6 +483,38 @@ class Config(Model):
     targets = ListType(
         ModelType(Target), serialize_when_none=False)
     template_indent = StringType(serialize_when_none=False)
+
+    def __init__(self, raw_data=None, trusted_data=None,
+                 deserialize_mapping=None, init=True, partial=True,
+                 strict=True, validate=False, app_data=None, lazy=False,
+                 **kwargs):
+        """Extend functionality of the parent class.
+
+        Manipulation here allows us to _clone_ the values of legacy stacker
+        field into their new names. Doing so we can retain support for Stacker
+        configs and CFNgin configs.
+
+        """
+        if raw_data:  # this can be empty when running unittests
+            for field_suffix in ['bucket', 'bucket_region', 'cache_dir']:
+                cfngin_field = 'cfngin_' + field_suffix
+                stacker_field = 'stacker_' + field_suffix
+                # explicitly check for an empty string since it has specific logic
+                if (
+                        raw_data.get(stacker_field) or
+                        raw_data.get(stacker_field) == ''
+                ):
+                    raw_data[cfngin_field] = raw_data[stacker_field]
+        super(Config, self).__init__(raw_data=raw_data,
+                                     trusted_data=trusted_data,
+                                     deserialize_mapping=deserialize_mapping,
+                                     init=init,
+                                     partial=partial,
+                                     strict=strict,
+                                     validate=validate,
+                                     app_data=app_data,
+                                     lazy=lazy,
+                                     **kwargs)
 
     def _remove_excess_keys(self, data):
         excess_keys = set(data.keys())
@@ -530,3 +580,36 @@ class Config(Model):
                         raise ValidationError(
                             "Duplicate stack %s found at index %d."
                             % (stack_name, i))
+
+    def validate_cfngin_bucket(self, _data, _value):
+        """Validate legacy field has been promoted to new field."""
+        if self.stacker_bucket:
+            if self.stacker_bucket == self.cfngin_bucket:
+                return
+            raise ValidationError(
+                'stacker_bucket ({}) provided and does not match '
+                'cfngin_bucket ({})'.format(self.stacker_bucket,
+                                            self.cfngin_bucket)
+            )
+
+    def validate_cfngin_bucket_region(self, _data, _value):
+        """Validate legacy field has been promoted to new field."""
+        if self.stacker_bucket_region:
+            if self.stacker_bucket_region == self.cfngin_bucket_region:
+                return
+            raise ValidationError(
+                'stacker_bucket ({}) provided and does not match '
+                'cfngin_bucket ({})'.format(self.stacker_bucket_region,
+                                            self.cfngin_bucket_region)
+            )
+
+    def validate_cfngin_cache_dir(self, _data, _value):
+        """Validate legacy field has been promoted to new field."""
+        if self.stacker_cache_dir:
+            if self.stacker_cache_dir == self.cfngin_cache_dir:
+                return
+            raise ValidationError(
+                'stacker_bucket ({}) provided and does not match '
+                'cfngin_bucket ({})'.format(self.stacker_cache_dir,
+                                            self.cfngin_cache_dir)
+            )

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -499,10 +499,13 @@ class Config(Model):
             for field_suffix in ['bucket', 'bucket_region', 'cache_dir']:
                 cfngin_field = 'cfngin_' + field_suffix
                 stacker_field = 'stacker_' + field_suffix
-                # explicitly check for an empty string since it has specific logic
+                # explicitly check for an empty string since it has specific logic.
+                # cfngin fields with a value take precedence.
                 if (
-                        raw_data.get(stacker_field) or
-                        raw_data.get(stacker_field) == ''
+                        not (raw_data.get(cfngin_field) or
+                             raw_data.get(cfngin_field) == '') and
+                        (raw_data.get(stacker_field) or
+                         raw_data.get(stacker_field) == '')
                 ):
                     raw_data[cfngin_field] = raw_data[stacker_field]
         super(Config, self).__init__(raw_data=raw_data,
@@ -580,36 +583,3 @@ class Config(Model):
                         raise ValidationError(
                             "Duplicate stack %s found at index %d."
                             % (stack_name, i))
-
-    def validate_cfngin_bucket(self, _data, _value):
-        """Validate legacy field has been promoted to new field."""
-        if self.stacker_bucket:
-            if self.stacker_bucket == self.cfngin_bucket:
-                return
-            raise ValidationError(
-                'stacker_bucket ({}) provided and does not match '
-                'cfngin_bucket ({})'.format(self.stacker_bucket,
-                                            self.cfngin_bucket)
-            )
-
-    def validate_cfngin_bucket_region(self, _data, _value):
-        """Validate legacy field has been promoted to new field."""
-        if self.stacker_bucket_region:
-            if self.stacker_bucket_region == self.cfngin_bucket_region:
-                return
-            raise ValidationError(
-                'stacker_bucket ({}) provided and does not match '
-                'cfngin_bucket ({})'.format(self.stacker_bucket_region,
-                                            self.cfngin_bucket_region)
-            )
-
-    def validate_cfngin_cache_dir(self, _data, _value):
-        """Validate legacy field has been promoted to new field."""
-        if self.stacker_cache_dir:
-            if self.stacker_cache_dir == self.cfngin_cache_dir:
-                return
-            raise ValidationError(
-                'stacker_bucket ({}) provided and does not match '
-                'cfngin_bucket ({})'.format(self.stacker_cache_dir,
-                                            self.cfngin_cache_dir)
-            )

--- a/runway/cfngin/context.py
+++ b/runway/cfngin/context.py
@@ -83,36 +83,36 @@ class Context(object):
 
     @property
     def bucket_name(self):
-        """Return ``stacker_bucket`` from config, calculated name, or None."""
+        """Return ``cfngin_bucket`` from config, calculated name, or None."""
         if not self.upload_templates_to_s3:
             return None
 
-        return self.config.stacker_bucket \
+        return self.config.cfngin_bucket \
             or "stacker-%s" % (self.get_fqn(),)
 
     @property
     def upload_templates_to_s3(self):
         """Condition result determining if templates will be uploaded to s3.
 
-        False if ``stacker_bucket`` provided in config is explicitly an empty
-        string or if ``stacker_bucket`` and ``namespace`` are not provided.
+        False if ``cfngin_bucket`` provided in config is explicitly an empty
+        string or if ``cfngin_bucket`` and ``namespace`` are not provided.
 
         """
-        # Don't upload stack templates to S3 if `stacker_bucket` is explicitly
+        # Don't upload stack templates to S3 if `cfngin_bucket` is explicitly
         # set to an empty string.
-        if self.config.stacker_bucket == '':
+        if self.config.cfngin_bucket == '':
             LOGGER.debug("Not uploading templates to s3 because "
-                         "`stacker_bucket` is explicitly set to an "
+                         "`cfngin_bucket` is explicitly set to an "
                          "empty string")
             return False
 
-        # If no namespace is specificied, and there's no explicit stacker
+        # If no namespace is specificied, and there's no explicit cfngin
         # bucket specified, don't upload to s3. This makes sense because we
-        # can't realistically auto generate a stacker bucket name in this case.
-        if not self.namespace and not self.config.stacker_bucket:
+        # can't realistically auto generate a cfngin bucket name in this case.
+        if not self.namespace and not self.config.cfngin_bucket:
             LOGGER.debug("Not uploading templates to s3 because "
                          "there is no namespace set, and no "
-                         "stacker_bucket set")
+                         "cfngin_bucket set")
             return False
 
         return True
@@ -124,7 +124,7 @@ class Context(object):
         if tags is not None:
             return tags
         if self.namespace:
-            return {"stacker_namespace": self.namespace}
+            return {"cfngin_namespace": self.namespace}
         return {}
 
     @property

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -331,7 +331,7 @@ def _upload_function(s3_conn, bucket, prefix, name, options, follow_symlinks,
                         content_hash, payload_acl)
 
 
-def select_bucket_region(custom_bucket, hook_region, stacker_bucket_region,
+def select_bucket_region(custom_bucket, hook_region, cfngin_bucket_region,
                          provider_region):
     """Return the appropriate region to use when uploading functions.
 
@@ -342,8 +342,8 @@ def select_bucket_region(custom_bucket, hook_region, stacker_bucket_region,
             `bucket` kwarg of the aws_lambda hook, if provided.
         hook_region (str): The contents of the `bucket_region` argument to
             the hook.
-        stacker_bucket_region (str): The contents of the
-            `stacker_bucket_region` global setting.
+        cfngin_bucket_region (str): The contents of the
+            ``cfngin_bucket_region`` global setting.
         provider_region (str): The region being used by the provider.
 
     Returns:
@@ -354,7 +354,7 @@ def select_bucket_region(custom_bucket, hook_region, stacker_bucket_region,
     if custom_bucket:
         region = hook_region
     else:
-        region = stacker_bucket_region
+        region = cfngin_bucket_region
     return region or provider_region
 
 
@@ -388,7 +388,7 @@ def upload_lambda_functions(context, provider, **kwargs):
             Omitting it will cause the default CFNgin bucket to be used.
         bucket_region (Optional[str]): The region in which the bucket should
             exist. If not given, the region will be either be that of the
-            global ``stacker_bucket_region`` setting, or else the region in
+            global ``cfngin_bucket_region`` setting, or else the region in
             use by the provider.
         prefix (Optional[str]): S3 key prefix to prepend to the uploaded
             zip name.
@@ -498,7 +498,7 @@ def upload_lambda_functions(context, provider, **kwargs):
     bucket_region = select_bucket_region(
         custom_bucket,
         custom_bucket_region,
-        context.config.stacker_bucket_region,
+        context.config.cfngin_bucket_region,
         provider.region
     )
 

--- a/runway/cfngin/util.py
+++ b/runway/cfngin/util.py
@@ -529,20 +529,20 @@ class SourceProcessor(object):
 
     ISO8601_FORMAT = '%Y%m%dT%H%M%SZ'
 
-    def __init__(self, sources, stacker_cache_dir=None):
+    def __init__(self, sources, cfngin_cache_dir=None):
         """Process a config's defined package sources.
 
         Args:
             sources (Dict[str, Any]): Package sources from CFNgin config
                 dictionary.
-            stacker_cache_dir (str): Path where remote sources will be
+            cfngin_cache_dir (str): Path where remote sources will be
                 cached.
 
         """
-        if not stacker_cache_dir:
-            stacker_cache_dir = os.path.expanduser("~/.runway_cache")
-        package_cache_dir = os.path.join(stacker_cache_dir, 'packages')
-        self.stacker_cache_dir = stacker_cache_dir
+        if not cfngin_cache_dir:
+            cfngin_cache_dir = os.path.expanduser("~/.runway_cache")
+        package_cache_dir = os.path.join(cfngin_cache_dir, 'packages')
+        self.cfngin_cache_dir = cfngin_cache_dir
         self.package_cache_dir = package_cache_dir
         self.sources = sources
         self.configs_to_merge = []
@@ -551,8 +551,8 @@ class SourceProcessor(object):
     def create_cache_directories(self):
         """Ensure that SourceProcessor cache directories exist."""
         if not os.path.isdir(self.package_cache_dir):
-            if not os.path.isdir(self.stacker_cache_dir):
-                os.mkdir(self.stacker_cache_dir)
+            if not os.path.isdir(self.cfngin_cache_dir):
+                os.mkdir(self.cfngin_cache_dir)
             os.mkdir(self.package_cache_dir)
 
     def get_package_sources(self):

--- a/runway/config.py
+++ b/runway/config.py
@@ -40,7 +40,7 @@ class ConfigComponent(object):
 class ModuleDefinition(ConfigComponent):  # pylint: disable=too-many-instance-attributes
     """A module defines the directory to be processed and applicable options.
 
-    It can consist of `CloudFormation`_ (using `Stacker`_),
+    It can consist of `CloudFormation`_ (using `CFNgin`_),
     `Terraform`_, `Serverless Framework`_, `AWS CDK`_, or `Kubernetes`_.
     It is recommended to place the appropriate extension on each directory
     for identification (but it is not required). See
@@ -182,7 +182,7 @@ class ModuleDefinition(ConfigComponent):  # pylint: disable=too-many-instance-at
             - `AWS CDK`_
             - `CloudFormation`_
             - `Serverless Framework`_
-            - `Stacker`_
+            - `CFNgin`_
             - `Troposphere`_
             - `Terraform`_
             - `Kubernetes`_

--- a/tests/cfngin/test_config.py
+++ b/tests/cfngin/test_config.py
@@ -555,6 +555,22 @@ stacks:
         with self.assertRaises(exceptions.InvalidConfig):
             parse(yaml_config)
 
+    def test_stacker_to_runway_field_conversion(self):
+        """Ensure the correct value is being presented by the config."""
+        yaml_config = """
+        namespace: test
+        cfngin_bucket: ''
+        stacker_bucket: test-bucket
+        cfngin_bucket_region: us-east-1
+        stacker_cache_dir: ./test/path
+        """
+        config = parse(yaml_config)
+        # config.validate()
+
+        assert config.cfngin_bucket == ''
+        assert config.cfngin_bucket_region == 'us-east-1'
+        assert config.cfngin_cache_dir == './test/path'
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cfngin/test_config.py
+++ b/tests/cfngin/test_config.py
@@ -485,6 +485,7 @@ stacks:
               CIDR: 192.168.2.0/24
         """
         doc = parse(yaml_config)
+        print(doc.to_primitive())
         self.assertEqual(
             doc["stacks"][0]["variables"]["CIDR"], "192.168.2.0/24"
         )

--- a/tests/cfngin/test_context.py
+++ b/tests/cfngin/test_context.py
@@ -125,7 +125,7 @@ class TestContext(unittest.TestCase):
         """Test context no tags specified."""
         config = Config({"namespace": "test"})
         context = Context(config=config)
-        self.assertEqual(context.tags, {"stacker_namespace": "test"})
+        self.assertEqual(context.tags, {"cfngin_namespace": "test"})
 
     def test_hook_with_sys_path(self):
         """Test hook with sys path."""


### PR DESCRIPTION
A Stacker config file uses 3 keys that are prefixed with `stacker_`. These are then consumed from the config object as attributes. Some functions also have `stacker_` prefixed arguments to match the config attributes that should be passed to it. This was retained in the initial integration of CFNgin.

This PR _replaces_ all of the above with `cfngin_` prefixes. The config will still accept the `stacker_` prefixed keys and _merge_ them into the `cfngin_` prefixed keys (with `cfngin_` taking precedence). While the config does still support these keys, using the `cfngin_` prefixed attributes is preferred since it will contain the calculated value. CFNgin has been updated to reflect this. It will not be breaking for any typical use cases of Stacker but edge cases that access the attributes through `context.config` will run into issues when transitioning configs to use `cfngin_` prefixes.