### PR TITLE
cfngin persistent graph

### DIFF
--- a/docs/source/cfngin/config.rst
+++ b/docs/source/cfngin/config.rst
@@ -130,7 +130,7 @@ like the below.
 When executing an action that will be modifying the persistent graph
 (build or destroy), the S3 object is *"locked"*. The lock is a tag applied to
 the object at the start of one of these actions. The tag-key is
-**stacker_lock_code** and the tag-value is UUID generated each time a command
+**cfngin_lock_code** and the tag-value is UUID generated each time a command
 is run. In order for CFNgin to lock a persistent graph object, the tag must
 not be present on the object. For CFNgin to act on the graph_ (modify or
 unlock) the value of the tag must match the UUID of the current CFNgin
@@ -141,7 +141,7 @@ condition.
 
 .. note::
   A persistent graph object can be unlocked manually by removing the
-  **stacker_lock_code** tag from it. This should be done with caution as it
+  **cfngin_lock_code** tag from it. This should be done with caution as it
   will cause any active sessions to raise an error.
 
 Persistent Graph Example

--- a/docs/source/cfngin/config.rst
+++ b/docs/source/cfngin/config.rst
@@ -2,10 +2,13 @@
 .. _`AWS profiles`: https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html
 .. _Blueprint: ../terminology.html#blueprint
 .. _Blueprints: ../terminology.html#blueprint
+.. _config file: ../terminology.html#config
+.. _graph: ../terminology.html#graph
 .. _hook: ../terminology.html#hook
 .. _hooks: ../terminology.html#hook
 .. _Mappings: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html
 .. _Outputs: ../terminology.html#output
+.. _stack: ../terminology.html#stack
 
 
 ==================
@@ -84,6 +87,105 @@ However, note that template size is greatly limited when uploading directly.
 See the `CloudFormation Limits Reference`_.
 
 .. _`CloudFormation Limits Reference`: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
+
+
+Persistent Graph
+----------------
+
+Each time CFNgin is run, it creates a dependency graph_ of Stacks_. This is
+used to determine the order in which to execute them. This graph_ can be
+persisted between runs to track the removal of Stacks_ the `config file`_.
+
+When a stack_ is present in the persistent graph but not in the graph_
+constructed from the `config file`_, CFNgin will delete the stack_ from
+CloudFormation. This takes effect during both build and destroy actions.
+
+The persistent graph is also used with the `graph command <commands.html#graph>`_
+where it is merged with the graph_ constructed from the `config file`_.
+
+To enable persistent graph, set **persistent_graph_key** to a unique value
+that will be used to construct the path to the persistent graph object in S3.
+This object is stored in the CFNgin `S3 Bucket`_ which is also used for
+CloudFormation templates. The fully qualified path to the object will look
+like the below.
+
+.. code-block::
+
+  s3://${cfngin_bucket}/${namespace}/persistent_graphs/${namespace}/${persistent_graph_key}.json
+
+.. note::
+  It is recommended to enable versioning on the CFNgin `S3 Bucket`_ when
+  using persistent graph to have a backup version in the event something
+  unintended happens. A warning will be logged if this is not enabled.
+
+  If CFNgin creates an `S3 Bucket`_ for you when persistent graph is enabled,
+  it will be created with versioning enabled.
+
+.. important::
+  When choosing a value for **persistent_graph_key**, it is vital to ensure
+  the value is unique for the **namespace** being used. If the key is a
+  duplicate, `stacks <../terminology.html#stack>`_ that are not intended to be
+  destroyed will be destroyed.
+
+When executing an action that will be modifying the persistent graph
+(build or destroy), the S3 object is *"locked"*. The lock is a tag applied to
+the object at the start of one of these actions. The tag-key is
+**stacker_lock_code** and the tag-value is UUID generated each time a command
+is run. In order for CFNgin to lock a persistent graph object, the tag must
+not be present on the object. For CFNgin to act on the graph_ (modify or
+unlock) the value of the tag must match the UUID of the current CFNgin
+session. If the object is locked or the code does not match, an error will be
+raised and no action will be taken. This prevents two parties from acting on
+the same persistent graph object concurrently which would create a race
+condition.
+
+.. note::
+  A persistent graph object can be unlocked manually by removing the
+  **stacker_lock_code** tag from it. This should be done with caution as it
+  will cause any active sessions to raise an error.
+
+Persistent Graph Example
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: config.yml
+.. code-block:: yaml
+
+  namespace: example
+  cfngin_bucket: cfngin-bucket
+  persistent_graph_key: my_graph  # .json - will be appended if not provided
+  stacks:
+    first_stack:
+      ...
+    new_stack:
+      ...
+
+.. rubric:: s3://cfngin-bucket/persistent_graphs/example/my_graph.json
+.. code-block:: json
+
+  {
+    "first_stack": [],
+    "removed_stack": [
+      "first_stack"
+    ]
+  }
+
+.. rubric:: Result
+
+Given the above `config file`_ and persistent graph,
+when running ``runway deploy``, the following will occur.
+
+#. The ``{"Key": "cfngin_lock_code", "Value": "123456"}`` tag is applied to
+   **s3://cfngin-bucket/persistent_graphs/example/my_graph.json** to lock it
+   to the current session.
+#. **removed_stack** is deleted from CloudFormation and deleted from the
+   persistent graph object in S3.
+#. **first_stack** is updated in CloudFormation and updated in the persistent
+   graph object in S3 (incase dependencies change).
+#. **new_stack** is created in CloudFormation and added to the persistent graph
+   object in S3.
+#. The ``{"Key": "cfngin_lock_code", "Value": "123456"}`` tag is removed from
+   **s3://cfngin-bucket/persistent_graphs/example/my_graph.json** to unlock it
+   for use in other sessions.
 
 
 Module Paths

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -40,6 +40,28 @@ A set of variables that can be used inside the config, allowing you to
 slightly adjust configs based on which environment you are launching.
 
 
+graph
+-----
+
+A mapping of **object name** to **set/list of dependencies**.
+
+A graph is constructed for each execution of CFNgin from the contents of the
+config_ file.
+
+.. rubric:: Example
+
+.. code-block:: json
+    {
+        "stack1": [],
+        "stack2": [
+            "stack1"
+        ]
+    }
+
+- **stack1** depends on nothing.
+- **stack2** depends on **stack1**
+
+
 hook
 ----
 
@@ -69,6 +91,13 @@ A CloudFormation Template concept. Stacks can output values, allowing easy
 access to those values. Often used to export the unique ID's of resources that
 templates create. CFNgin makes it simple to pull outputs from one stack and
 then use them as a variable_ in another stack.
+
+
+persistent graph
+----------------
+
+A graph_ that is persisted between CFNgin executions. It is stored in in the
+Stack `S3 bucket <cfngin/config.html#s3-bucket>`_.
 
 
 provider

--- a/integration_tests/test_cfngin/tests/15_destroy_removed.py
+++ b/integration_tests/test_cfngin/tests/15_destroy_removed.py
@@ -8,8 +8,8 @@ from integration_tests.test_cfngin.test_cfngin import Cfngin
 FILE_BASENAME = '.'.join(basename(__file__).split('.')[:-1])
 
 
-class TestSimpleBuild(Cfngin):
-    """Test CFNgin simple build.
+class DestroyRemoved(Cfngin):
+    """Test CFNgin persistent graph destroying removed stacks.
 
     Requires valid AWS credentials.
 

--- a/integration_tests/test_cfngin/tests/15_destroy_removed.py
+++ b/integration_tests/test_cfngin/tests/15_destroy_removed.py
@@ -43,5 +43,5 @@ class DestroyRemoved(Cfngin):
 
     def teardown(self):
         """Teardown any created resources and delete files."""
-        _code, _stdout, stderr = self.runway_cmd('destroy')
+        self.runway_cmd('destroy')
         self.cleanup_fixtures()

--- a/integration_tests/test_cfngin/tests/15_destroy_removed.py
+++ b/integration_tests/test_cfngin/tests/15_destroy_removed.py
@@ -1,0 +1,47 @@
+"""CFNgin test."""
+# flake8: noqa
+# pylint: disable=invalid-name
+from os.path import basename
+
+from integration_tests.test_cfngin.test_cfngin import Cfngin
+
+FILE_BASENAME = '.'.join(basename(__file__).split('.')[:-1])
+
+
+class TestSimpleBuild(Cfngin):
+    """Test CFNgin simple build.
+
+    Requires valid AWS credentials.
+
+    """
+
+    REQUIRED_FIXTURE_FILES = [FILE_BASENAME + '.1.yaml',
+                              FILE_BASENAME + '.2.yaml']
+    TEST_NAME = __name__
+
+    def _build(self):
+        """Execute and assert initial build."""
+        code, _stdout, stderr = self.runway_cmd('deploy')
+        assert code == 0, 'exit code should be zero'
+        expected_lines = [
+            'other was removed from the Stacker config file so it is being destroyed.',
+            'other: submitted (submitted for destruction)',
+            'other: complete (stack destroyed)'
+        ]
+        for stack in ['vpc', 'bastion', 'other']:
+            expected_lines.append(f'{stack}: submitted (creating new stack)')
+            expected_lines.append(f'{stack}: complete (creating new stack)')
+            if stack != 'other':
+                expected_lines.append(f'{stack}: skipped (nochange)')
+        for line in expected_lines:
+            assert line in stderr, f'"{line}" missing from output'
+
+    def run(self):
+        """Run the test."""
+        self.copy_fixtures()
+        self._build()
+
+    def teardown(self):
+        """Teardown any created resources and delete files."""
+        _code, _stdout, stderr = self.runway_cmd('destroy')
+        self.cleanup_fixtures()

--- a/integration_tests/test_cfngin/tests/fixtures/15_destroy_removed.1.yaml
+++ b/integration_tests/test_cfngin/tests/fixtures/15_destroy_removed.1.yaml
@@ -1,0 +1,14 @@
+namespace: ${CFNGIN_NAMESPACE}
+persistent_graph_key: test.json
+
+sys_path: ./
+
+stacks:
+  - name: vpc
+    class_path: fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: fixtures.mock_blueprints.Dummy
+    requires:
+      - vpc
+  - name: other
+    class_path: fixtures.mock_blueprints.Dummy

--- a/integration_tests/test_cfngin/tests/fixtures/15_destroy_removed.2.yaml
+++ b/integration_tests/test_cfngin/tests/fixtures/15_destroy_removed.2.yaml
@@ -1,0 +1,12 @@
+namespace: ${CFNGIN_NAMESPACE}
+persistent_graph_key: test.json
+
+sys_path: ./
+
+stacks:
+  - name: vpc
+    class_path: fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: fixtures.mock_blueprints.Dummy
+    requires:
+      - vpc

--- a/runway/cfngin/actions/base.py
+++ b/runway/cfngin/actions/base.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
 # https://github.com/boto/botocore/blob/1.6.1/botocore/data/cloudformation/2010-05-15/waiters-2.json#L22
 #
 # This can be controlled via an environment variable, mostly for testing.
-STACK_POLL_TIME = int(os.environ.get("STACKER_STACK_POLL_TIME", 30))
+STACK_POLL_TIME = int(os.environ.get("CFNGIN_STACK_POLL_TIME", 30))
 
 
 def build_walker(concurrency):

--- a/runway/cfngin/actions/base.py
+++ b/runway/cfngin/actions/base.py
@@ -8,8 +8,7 @@ import botocore.exceptions
 
 from ..dag import ThreadedWalker, UnlimitedSemaphore, walk
 from ..exceptions import PlanFailed
-from ..plan import Step, build_graph, build_plan
-from ..session_cache import get_session
+from ..plan import Graph, Plan, Step, merge_graphs
 from ..status import COMPLETE
 from ..util import ensure_s3_bucket, get_s3_endpoint, stack_template_key_name
 
@@ -56,43 +55,6 @@ def build_walker(concurrency):
     return ThreadedWalker(semaphore).walk
 
 
-def plan(description, stack_action, context, tail=None, reverse=False):
-    """Build a graph based plan from a set of stacks.
-
-    Args:
-        description (str): A description of the plan.
-        stack_action (Callable[..., Any]): A function to call for each stack.
-        context (:class:`runway.cfngin.context.Context`): a
-            :class:`runway.cfngin.context.Context` to build the plan from.
-        tail (Optional[Callable[..., Any]]): an optional function to call to
-            tail the stack progress.
-        reverse (bool): if True, execute the graph in reverse (useful for
-            destroy actions).
-
-    Returns:
-        :class:`plan.Plan`: The resulting plan object
-
-    """
-    def target_fn(*_args, **_kwargs):
-        """Target function."""
-        return COMPLETE
-
-    steps = [
-        Step(stack, fn=stack_action, watch_func=tail)
-        for stack in context.get_stacks()]
-
-    steps += [
-        Step(target, fn=target_fn) for target in context.get_targets()]
-
-    graph = build_graph(steps)
-
-    return build_plan(
-        description=description,
-        graph=graph,
-        targets=context.stack_names,
-        reverse=reverse)
-
-
 def stack_template_url(bucket_name, blueprint, endpoint):
     """Produce an s3 url for a given blueprint.
 
@@ -119,6 +81,7 @@ class BaseAction(object):
     will be executed to perform that command.
 
     Attributes:
+        DESCRIPTION (str): Description used when creating a plan for an action.
         bucket_name (str): S3 bucket used by the action.
         bucket_region (str): AWS region where S3 bucket is located.
         cancel (threading.Event): Cancel handler.
@@ -130,6 +93,8 @@ class BaseAction(object):
         s3_conn (boto3.client.Client): Boto3 S3 client.
 
     """
+
+    DESCRIPTION = 'Base action'
 
     def __init__(self, context, provider_builder=None, cancel=None):
         """Instantiate class.
@@ -150,7 +115,39 @@ class BaseAction(object):
         self.bucket_region = context.config.cfngin_bucket_region
         if not self.bucket_region and provider_builder:
             self.bucket_region = provider_builder.region
-        self.s3_conn = get_session(self.bucket_region).client('s3')
+        self.s3_conn = self.context.s3_conn
+
+    @property
+    def _stack_action(self):
+        """Run against a step."""
+        raise NotImplementedError
+
+    @property
+    def provider(self):
+        """Return a generic provider using the default region.
+
+        Used for running things like hooks.
+
+        Returns:
+            :class:`runway.cfngin.providers.base.BaseProvider`
+
+        """
+        return self.provider_builder.build()
+
+    def build_provider(self, stack):
+        """Build a :class:`runway.cfngin.providers.base.BaseProvider`.
+
+        Args:
+            stack (:class:`runway.cfngin.stack.Stack`): Stack the action will
+                be executed on.
+
+        Returns:
+            :class:`runway.cfngin.providers.base.BaseProvider`: Suitable for
+            operating on the given :class:`runway.cfngin.stack.Stack`.
+
+        """
+        return self.provider_builder.build(region=stack.region,
+                                           profile=stack.profile)
 
     def ensure_cfn_bucket(self):
         """CloudFormation bucket where templates will be stored."""
@@ -159,16 +156,25 @@ class BaseAction(object):
                              self.bucket_name,
                              self.bucket_region)
 
-    def stack_template_url(self, blueprint):
-        """S3 URL for CloudFormation template object.
+    def execute(self, **kwargs):
+        """Run the action with pre and post steps."""
+        try:
+            self.pre_run(**kwargs)
+            self.run(**kwargs)
+            self.post_run(**kwargs)
+        except PlanFailed as err:
+            LOGGER.error(str(err))
+            sys.exit(1)
 
-        Returns:
-            str
+    def pre_run(self, **kwargs):
+        """Perform steps before running the action."""
 
-        """
-        return stack_template_url(
-            self.bucket_name, blueprint, get_s3_endpoint(self.s3_conn)
-        )
+    def post_run(self, **kwargs):
+        """Perform steps after running the action."""
+
+    def run(self, **kwargs):
+        """Abstract method for running the action."""
+        raise NotImplementedError("Subclass must implement \"run\" method")
 
     def s3_stack_push(self, blueprint, force=False):
         """Push the rendered blueprint's template to S3.
@@ -204,52 +210,69 @@ class BaseAction(object):
                      template_url)
         return template_url
 
-    def execute(self, **kwargs):
-        """Run the action with pre and post steps."""
-        try:
-            self.pre_run(**kwargs)
-            self.run(**kwargs)
-            self.post_run(**kwargs)
-        except PlanFailed as err:
-            LOGGER.error(str(err))
-            sys.exit(1)
+    def stack_template_url(self, blueprint):
+        """S3 URL for CloudFormation template object.
 
-    def pre_run(self, **kwargs):
-        """Perform steps before running the action."""
+        Returns:
+            str
 
-    def run(self, **kwargs):
-        """Abstract method for running the action."""
-        raise NotImplementedError("Subclass must implement \"run\" method")
+        """
+        return stack_template_url(
+            self.bucket_name, blueprint, get_s3_endpoint(self.s3_conn)
+        )
 
-    def post_run(self, **kwargs):
-        """Perform steps after running the action."""
-
-    def build_provider(self, stack):
-        """Build a :class:`runway.cfngin.providers.base.BaseProvider`.
+    def _generate_plan(self, tail=False, reverse=False,
+                       require_unlocked=True,
+                       include_persistent_graph=False):
+        """Create a plan for this action.
 
         Args:
-            stack (:class:`runway.cfngin.stack.Stack`): Stack the action will
-                be executed on.
+            tail (Union[bool, Callable]): An optional function to call
+                to tail the stack progress.
+            reverse (bool): If True, execute the graph in reverse (useful for
+                destroy actions).
+            require_unlocked (bool): If the persistent graph is locked, an
+                error is raised.
+            include_persistent_graph (bool): Include the persistent graph
+                in the :class:`runway.cfngin.plan.Plan` (if there is one).
+                This will handle basic merging of the local and persistent
+                graphs if an action does not require more complex logic.
 
         Returns:
-            :class:`runway.cfngin.providers.base.BaseProvider`: Suitable for
-            operating on the given :class:`runway.cfngin.stack.Stack`.
+            :class:`runway.cfngin.plan.Plan`: The resulting plan object
 
         """
-        return self.provider_builder.build(region=stack.region,
-                                           profile=stack.profile)
+        tail = self._tail_stack if tail else None
 
-    @property
-    def provider(self):
-        """Return a generic provider using the default region.
+        def target_fn(*_args, **_kwargs):
+            return COMPLETE
 
-        Used for running things like hooks.
+        steps = [
+            Step(stack, fn=self._stack_action, watch_func=tail)
+            for stack in self.context.get_stacks()]
 
-        Returns:
-            :class:`runway.cfngin.providers.base.BaseProvider`
+        steps += [
+            Step(target, fn=target_fn)
+            for target in self.context.get_targets()]
 
-        """
-        return self.provider_builder.build()
+        graph = Graph.from_steps(steps)
+
+        if include_persistent_graph and self.context.persistent_graph:
+            persist_steps = Step.from_persistent_graph(
+                self.context.persistent_graph.to_dict(),
+                self.context,
+                fn=self._stack_action,
+                watch_func=tail
+            )
+            persist_graph = Graph.from_steps(persist_steps)
+            graph = merge_graphs(graph, persist_graph)
+
+        return Plan(
+            context=self.context,
+            description=self.DESCRIPTION,
+            graph=graph,
+            reverse=reverse,
+            require_unlocked=require_unlocked)
 
     def _tail_stack(self, stack, cancel, retries=0, **kwargs):
         """Tail a stack's event stream."""

--- a/runway/cfngin/actions/build.py
+++ b/runway/cfngin/actions/build.py
@@ -209,7 +209,7 @@ class Action(BaseAction):
 
         Args:
             stack (:class:`runway.cfngin.stack.Stack`): A CFNgin stack.
-            provider_stack (Dict[str, Any]): An optional Stacker provider object.
+            provider_stack (Dict[str, Any]): An optional CFNgin provider object.
 
         Returns:
             Dict[str, Any]: The parameters for the given stack

--- a/runway/cfngin/actions/info.py
+++ b/runway/cfngin/actions/info.py
@@ -7,7 +7,7 @@ from .base import BaseAction
 LOGGER = logging.getLogger(__name__)
 
 
-class Action(BaseAction):
+class Action(BaseAction):  # pylint: disable=abstract-method
     """Get information on CloudFormation stacks.
 
     Displays the outputs for the set of CloudFormation stacks.

--- a/runway/cfngin/commands/stacker/__init__.py
+++ b/runway/cfngin/commands/stacker/__init__.py
@@ -43,6 +43,7 @@ class Stacker(BaseCommand):
         options.context = Context(
             environment=options.environment,
             config=self.config,
+            region=options.region,
             # Allow subcommands to provide any specific kwargs to the Context
             # that it wants.
             **options.get_context_kwargs(options)

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -434,6 +434,8 @@ class Config(Model):
         namespace_delimiter (StringType): Character used to separate
             ``namespace`` and anything it prepends.
         package_sources (ModelType): Remote source locations.
+        persistent_graph_key (str): S3 object key were the persistent graph
+            is stored.
         post_build (ListType): Hooks to run after a build action.
         post_destroy (ListType): Hooks to run after a destroy action.
         pre_build (ListType): Hooks to run before a build action.
@@ -468,6 +470,7 @@ class Config(Model):
     namespace = StringType(required=True)
     namespace_delimiter = StringType(serialize_when_none=False)
     package_sources = ModelType(PackageSources, serialize_when_none=False)
+    persistent_graph_key = StringType(serialize_when_none=False)
     post_build = ListType(ModelType(Hook), serialize_when_none=False)
     post_destroy = ListType(ModelType(Hook), serialize_when_none=False)
     pre_build = ListType(ModelType(Hook), serialize_when_none=False)

--- a/runway/cfngin/context.py
+++ b/runway/cfngin/context.py
@@ -1,10 +1,18 @@
 """CFNgin context."""
 import collections
+import json
 import logging
 
 from .config import Config
+from .exceptions import (PersistentGraphCannotLock,
+                         PersistentGraphCannotUnlock,
+                         PersistentGraphLockCodeMissmatch,
+                         PersistentGraphLocked, PersistentGraphUnlocked)
+from .plan import Graph
+from .session_cache import get_session
 from .stack import Stack
 from .target import Target
+from .util import ensure_s3_bucket
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +45,7 @@ class Context(object):
     def __init__(self, environment=None,
                  stack_names=None,
                  config=None,
+                 region=None,
                  force_stacks=None):
         """Instantiate class.
 
@@ -48,17 +57,62 @@ class Context(object):
                 operated on.
             config (:class:`runway.cfngin.config.Config`): The CFNgin
                 configuration being operated on.
+            region (str): Name of an AWS region if provided as a CLI argument.
             force_stacks (list): A list of stacks to force work on. Used to
                 work on locked stacks.
 
         """
-        self.environment = environment
-        self.stack_names = stack_names or []
+        self._bucket_name = None
+        self._persistent_graph = None
+        self._persistent_graph_lock_code = None
+        self._persistent_graph_lock_tag = 'cfngin_lock_code'
+        self._s3_bucket_verified = None
+        self._stacks = None
+        self._targets = None
+        self._upload_to_s3 = None
         self.config = config or Config()
+        self.bucket_region = self.config.cfngin_bucket_region or region
+        self.environment = environment
         self.force_stacks = force_stacks or []
         self.hook_data = {}
-        self._stacks = []
-        self._targets = []
+        self.s3_conn = get_session(self.bucket_region).client('s3')
+        self.stack_names = stack_names or []
+
+    @property
+    def _base_fqn(self):
+        """Return ``namespace`` sanitized for use as an S3 Bucket name."""
+        return self.namespace.replace(".", "-").lower()
+
+    @property
+    def _persistent_graph_tags(self):
+        """Cache of tags on the persistent graph object.
+
+        Returns:
+            Dict[str, str]
+
+        """
+        try:
+            return {t['Key']: t['Value'] for t in
+                    self.s3_conn.get_object_tagging(
+                        **self.persistent_graph_location).get('TagSet', {})}
+        except self.s3_conn.exceptions.NoSuchKey:
+            LOGGER.debug('Persistant graph object does not exist in S3; '
+                         'could not get tags')
+            return {}
+
+    @property
+    def bucket_name(self):
+        """Return ``cfngin_bucket`` from config, calculated name, or None."""
+        if not self.upload_to_s3:
+            return None
+
+        return self.config.cfngin_bucket \
+            or "stacker-%s" % (self.get_fqn(),)
+
+    @property
+    def mappings(self):
+        """Return ``mappings`` from config."""
+        return self.config.mappings or {}
 
     @property
     def namespace(self):
@@ -74,48 +128,116 @@ class Context(object):
         return DEFAULT_NAMESPACE_DELIMITER
 
     @property
-    def template_indent(self):
-        """Return ``template_indent`` from config or default."""
-        indent = self.config.template_indent
-        if indent is not None:
-            return int(indent)
-        return DEFAULT_TEMPLATE_INDENT
+    def persistent_graph(self):
+        """Graph if a persistent graph is being used.
 
-    @property
-    def bucket_name(self):
-        """Return ``cfngin_bucket`` from config, calculated name, or None."""
-        if not self.upload_templates_to_s3:
-            return None
+        Will create an "empty" object in S3 if one is not found.
 
-        return self.config.cfngin_bucket \
-            or "stacker-%s" % (self.get_fqn(),)
-
-    @property
-    def upload_templates_to_s3(self):
-        """Condition result determining if templates will be uploaded to s3.
-
-        False if ``cfngin_bucket`` provided in config is explicitly an empty
-        string or if ``cfngin_bucket`` and ``namespace`` are not provided.
+        Returns:
+            :class:`runway.cfngin.plan.Graph`
 
         """
-        # Don't upload stack templates to S3 if `cfngin_bucket` is explicitly
-        # set to an empty string.
-        if self.config.cfngin_bucket == '':
-            LOGGER.debug("Not uploading templates to s3 because "
-                         "`cfngin_bucket` is explicitly set to an "
-                         "empty string")
-            return False
+        if not self._persistent_graph:
+            if not self.persistent_graph_location:
+                return None
 
-        # If no namespace is specificied, and there's no explicit cfngin
-        # bucket specified, don't upload to s3. This makes sense because we
-        # can't realistically auto generate a cfngin bucket name in this case.
-        if not self.namespace and not self.config.cfngin_bucket:
-            LOGGER.debug("Not uploading templates to s3 because "
-                         "there is no namespace set, and no "
-                         "cfngin_bucket set")
-            return False
+            content = '{}'
 
+            if self.s3_bucket_verified:
+                try:
+                    LOGGER.debug('Getting persistent graph from s3:\n%s',
+                                 json.dumps(self.persistent_graph_location,
+                                            indent=4))
+                    content = self.s3_conn.get_object(
+                        ResponseContentType='application/json',
+                        **self.persistent_graph_location
+                    )['Body'].read().decode('utf-8')
+                except self.s3_conn.exceptions.NoSuchKey:
+                    LOGGER.info('Persistant graph object does not exist '
+                                'in S3; creating one now.')
+                    self.s3_conn.put_object(
+                        Body=content,
+                        ServerSideEncryption='AES256',
+                        ACL='bucket-owner-full-control',
+                        ContentType='application/json',
+                        **self.persistent_graph_location
+                    )
+            self.persistent_graph = json.loads(content)
+
+        return self._persistent_graph
+
+    @persistent_graph.setter
+    def persistent_graph(self, graph_dict):
+        """Load a persistent graph dict as a :class:`runway.cfngin.plan.Graph`."""
+        self._persistent_graph = Graph.from_dict(graph_dict, self)
+
+    @property
+    def persistent_graph_location(self):
+        """Location of the persistent graph in s3.
+
+        Returns:
+            Dict[str, str] Bucket and Key for the object in S3.
+
+        """
+        if not self.upload_to_s3 or not self.config.persistent_graph_key:
+            return {}
+
+        return {
+            'Bucket': self.bucket_name,
+            'Key': 'persistent_graphs/{namespace}/{key}'.format(
+                namespace=self.config.namespace,
+                key=(self.config.persistent_graph_key + '.json' if not
+                     self.config.persistent_graph_key.endswith('.json')
+                     else self.config.persistent_graph_key)
+            )
+        }
+
+    @property
+    def persistent_graph_lock_code(self):
+        """Code used to lock the persistent graph S3 object.
+
+        Returns:
+            Optional[str]
+
+        """
+        if (not self._persistent_graph_lock_code and
+                self.persistent_graph_location):
+            self._persistent_graph_lock_code = self._persistent_graph_tags.get(
+                self._persistent_graph_lock_tag
+            )
+        return self._persistent_graph_lock_code
+
+    @property
+    def persistent_graph_locked(self):
+        """Check if persistent graph is locked.
+
+        Returns:
+            bool
+
+        """
+        if not self.persistent_graph:
+            return False
+        if not self.persistent_graph_lock_code:
+            return False
         return True
+
+    @property
+    def s3_bucket_verified(self):
+        """Check Stacker bucket exists and you have access.
+
+        If the Stacker bucket does not exist, will try to create one.
+
+        Returns:
+            bool
+
+        """
+        if not self._s3_bucket_verified and self.bucket_name:
+            ensure_s3_bucket(self.s3_conn,
+                             self.bucket_name,
+                             self.bucket_region,
+                             persist_graph=bool(self.persistent_graph_location))
+            self._s3_bucket_verified = True
+        return self._s3_bucket_verified
 
     @property
     def tags(self):
@@ -128,14 +250,39 @@ class Context(object):
         return {}
 
     @property
-    def _base_fqn(self):
-        """Return ``namespace`` sanitized for use as an S3 Bucket name."""
-        return self.namespace.replace(".", "-").lower()
+    def template_indent(self):
+        """Return ``template_indent`` from config or default."""
+        indent = self.config.template_indent
+        if indent is not None:
+            return int(indent)
+        return DEFAULT_TEMPLATE_INDENT
 
     @property
-    def mappings(self):
-        """Return ``mappings`` from config."""
-        return self.config.mappings or {}
+    def upload_to_s3(self):
+        """Check if S3 should be used for caching/persistent graph.
+
+        Returns:
+            (bool)
+
+        """
+        if not self._upload_to_s3:
+            # Don't upload stack templates to S3 if `cfngin_bucket` is
+            # explicitly set to an empty string.
+            if self.config.cfngin_bucket == '':
+                LOGGER.debug("Not uploading to s3 because `cfngin_bucket` "
+                             "is explicitly set to an empty string")
+                return False
+
+            # If no namespace is specificied, and there's no explicit
+            # cfngin bucket specified, don't upload to s3. This makes
+            # sense because we can't realistically auto generate a cfngin
+            # bucket name in this case.
+            if not self.namespace and not self.config.cfngin_bucket:
+                LOGGER.debug("Not uploading to s3 because there is no "
+                             "namespace set, and no cfngin_bucket set")
+                return False
+
+        return True
 
     def _get_stack_definitions(self):
         """Return ``stacks`` from config."""
@@ -155,6 +302,18 @@ class Context(object):
                 targets.append(target)
             self._targets = targets
         return self._targets
+
+    def get_stack(self, name):
+        """Get a stack by name.
+
+        Args:
+            name (str): Name of a stack to retrieve.
+
+        """
+        for stack in self.get_stacks():
+            if stack.name == name:
+                return stack
+        return None
 
     def get_stacks(self):
         """Get the stacks for the current action.
@@ -183,18 +342,6 @@ class Context(object):
             self._stacks = stacks
         return self._stacks
 
-    def get_stack(self, name):
-        """Get a stack by name.
-
-        Args:
-            name (str): Name of a stack to retrieve.
-
-        """
-        for stack in self.get_stacks():
-            if stack.name == name:
-                return stack
-        return None
-
     def get_stacks_dict(self):
         """Construct a dict of {stack.fqn: stack} for easy access to stacks."""
         return dict((stack.fqn, stack) for stack in self.get_stacks())
@@ -207,6 +354,80 @@ class Context(object):
 
         """
         return get_fqn(self._base_fqn, self.namespace_delimiter, name)
+
+    def lock_persistent_graph(self, lock_code):
+        """Locks the persistent graph in s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`runway.cfngin.exceptions.PersistentGraphLocked`
+            :class:`runway.cfngin.exceptions.PersistentGraphCannotLock`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        if self.persistent_graph_locked:
+            raise PersistentGraphLocked
+
+        try:
+            self.s3_conn.put_object_tagging(
+                Tagging={'TagSet': [
+                    {'Key': self._persistent_graph_lock_tag,
+                     'Value': lock_code}
+                ]},
+                **self.persistent_graph_location
+            )
+            LOGGER.info('Locked persistent graph "%s" with lock ID "%s".',
+                        '/'.join([self.persistent_graph_location['Bucket'],
+                                  self.persistent_graph_location['Key']]),
+                        lock_code)
+        except self.s3_conn.exceptions.NoSuchKey:
+            raise PersistentGraphCannotLock('s3 object does not exist')
+
+    def put_persistent_graph(self, lock_code):
+        """Upload persistent graph to s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`runway.cfngin.exceptions.PersistentGraphUnlocked`
+            :class:`runway.cfngin.exceptions.PersistentGraphLockCodeMissmatch`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        if not self.persistent_graph.to_dict():
+            self.s3_conn.delete_object(**self.persistent_graph_location)
+            LOGGER.debug('Removed empty persistent graph object from S3')
+            return
+
+        if not self.persistent_graph_locked:
+            raise PersistentGraphUnlocked(
+                reason='It must be locked by the current session to be '
+                       'updated.'
+            )
+
+        if self.persistent_graph_lock_code != lock_code:
+            raise PersistentGraphLockCodeMissmatch(
+                lock_code, self.persistent_graph_lock_code
+            )
+
+        self.s3_conn.put_object(
+            Body=self.persistent_graph.dumps(4),
+            ServerSideEncryption='AES256',
+            ACL='bucket-owner-full-control',
+            ContentType='application/json',
+            Tagging='{}={}'.format(self._persistent_graph_lock_tag,
+                                   lock_code),
+            **self.persistent_graph_location
+        )
+        LOGGER.debug('Persistent graph updated:\n%s',
+                     self.persistent_graph.dumps(indent=4))
 
     def set_hook_data(self, key, data):
         """Set hook data for the given key.
@@ -227,3 +448,55 @@ class Context(object):
                            "must have a unique data_key." % key)
 
         self.hook_data[key] = data
+
+    def unlock_persistent_graph(self, lock_code):
+        """Unlocks the persistent graph in s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`runway.cfngin.exceptions.PersistentGraphCannotUnlock`
+
+        """
+        if not self.persistent_graph:
+            return False
+
+        if not self.persistent_graph.to_dict():
+            try:
+                self.s3_conn.get_object(
+                    ResponseContentType='application/json',
+                    **self.persistent_graph_location
+                )
+            except self.s3_conn.exceptions.NoSuchKey:
+                LOGGER.info('Persistent graph was deleted and does not '
+                            'need to be unlocked.')
+                return False
+
+        LOGGER.debug('Unlocking persistent graph "%s".',
+                     self.persistent_graph_location)
+
+        if not self.persistent_graph_locked:
+            raise PersistentGraphCannotUnlock(PersistentGraphUnlocked(
+                reason='It must be locked by the current session to be '
+                       'unlocked.'
+            ))
+
+        if self.persistent_graph_lock_code == lock_code:
+            try:
+                self.s3_conn.delete_object_tagging(
+                    **self.persistent_graph_location
+                )
+            except self.s3_conn.exceptions.NoSuchKey:
+                pass
+            self._persistent_graph_lock_code = None
+            LOGGER.info('Unlocked persistent graph "%s".',
+                        '/'.join([self.persistent_graph_location['Bucket'],
+                                  self.persistent_graph_location['Key']]))
+            return True
+        raise PersistentGraphCannotUnlock(
+            PersistentGraphLockCodeMissmatch(
+                lock_code,
+                self.persistent_graph_lock_code
+            )
+        )

--- a/runway/cfngin/context.py
+++ b/runway/cfngin/context.py
@@ -460,7 +460,7 @@ class Context(object):
 
         """
         if not self.persistent_graph:
-            return False
+            return True
 
         if not self.persistent_graph.to_dict():
             try:
@@ -471,7 +471,7 @@ class Context(object):
             except self.s3_conn.exceptions.NoSuchKey:
                 LOGGER.info('Persistent graph was deleted and does not '
                             'need to be unlocked.')
-                return False
+                return True
 
         LOGGER.debug('Unlocking persistent graph "%s".',
                      self.persistent_graph_location)

--- a/runway/cfngin/context.py
+++ b/runway/cfngin/context.py
@@ -223,9 +223,9 @@ class Context(object):
 
     @property
     def s3_bucket_verified(self):
-        """Check Stacker bucket exists and you have access.
+        """Check CFNgin bucket exists and you have access.
 
-        If the Stacker bucket does not exist, will try to create one.
+        If the CFNgin bucket does not exist, will try to create one.
 
         Returns:
             bool

--- a/runway/cfngin/exceptions.py
+++ b/runway/cfngin/exceptions.py
@@ -261,6 +261,73 @@ class OutputDoesNotExist(Exception):
         super(OutputDoesNotExist, self).__init__(message, *args, **kwargs)
 
 
+class PersistentGraphCannotLock(Exception):
+    """Raised when the persistent graph in S3 cannot be locked."""
+
+    def __init__(self, reason):
+        """Instantiate class."""
+        message = "Could not lock persistent graph; %s" % reason
+        super(PersistentGraphCannotLock, self).__init__(message)
+
+
+class PersistentGraphCannotUnlock(Exception):
+    """Raised when the persistent graph in S3 cannot be unlocked."""
+
+    def __init__(self, reason):
+        """Instantiate class."""
+        message = "Could not unlock persistent graph; %s" % reason
+        super(PersistentGraphCannotUnlock, self).__init__(message)
+
+
+class PersistentGraphLocked(Exception):
+    """Raised when the persistent graph in S3 is lock.
+
+    The action being executed requires it to be unlocked before attempted.
+
+    """
+
+    def __init__(self, message=None, reason=None):
+        """Instantiate class."""
+        if not message:
+            message = ("Persistant graph is locked. {}".format(
+                reason or ("This action requires the graph to be "
+                           "unlocked to be executed.")
+            ))
+        super(PersistentGraphLocked, self).__init__(message)
+
+
+class PersistentGraphLockCodeMissmatch(Exception):
+    """Raised when the provided persistent graph lock code does not match.
+
+    The code used to unlock the persistent graph must match the s3 object lock
+    code.
+
+    """
+
+    def __init__(self, provided_code, s3_code):
+        """Instantiate class."""
+        message = ("The provided lock code '%s' does not match the S3 "
+                   "object lock code '%s'" % (provided_code, s3_code))
+        super(PersistentGraphLockCodeMissmatch, self).__init__(message)
+
+
+class PersistentGraphUnlocked(Exception):
+    """Raised when the persistent graph in S3 is unlock.
+
+    The action being executed requires it to be locked before attempted.
+
+    """
+
+    def __init__(self, message=None, reason=None):
+        """Instantiate class."""
+        if not message:
+            message = ("Persistant graph is unlocked. {}".format(
+                reason or ("This action requires the graph to be "
+                           "locked to be executed.")
+            ))
+        super(PersistentGraphUnlocked, self).__init__(message)
+
+
 class PlanFailed(Exception):
     """Raised if any step of a plan fails."""
 

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -754,9 +754,9 @@ class Provider(BaseProvider):
             force_interactive (bool): Always ask for approval.
 
         """
-        action = kwargs.get('action', 'destroy')
-        approval = kwargs.get('approval')
-        force_interactive = kwargs.get('force_interactive', False)
+        action = kwargs.pop('action', 'destroy')
+        approval = kwargs.pop('approval', None)
+        force_interactive = kwargs.pop('force_interactive', False)
         fqn = self.get_stack_name(stack)
         LOGGER.debug("Attempting to delete stack %s", fqn)
 

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -542,7 +542,7 @@ class ProviderBuilder(object):  # pylint: disable=too-few-public-methods
 class Provider(BaseProvider):
     """AWS CloudFormation Provider."""
 
-    DELETEING_STATUS = "DELETE_IN_PROGRESS"
+    DELETING_STATUS = "DELETE_IN_PROGRESS"
 
     DELETED_STATUS = "DELETE_COMPLETE"
 
@@ -614,7 +614,7 @@ class Provider(BaseProvider):
 
     def is_stack_being_destroyed(self, stack, **kwargs):  # pylint: disable=unused-argument
         """Whether the status of the stack indicates it is 'being destroyed'."""
-        return self.get_stack_status(stack) == self.DELETEING_STATUS
+        return self.get_stack_status(stack) == self.DELETING_STATUS
 
     def is_stack_completed(self, stack):
         """Whether the status of the stack indicates it is 'complete'."""

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,7 @@ INSTALL_REQUIRES = [
     'gitpython>=2.0,<3.0',
     'jinja2>=2.7,<3.0',
     'schematics>=2.0.1,<2.1.0',
-    'formic2',
-    'python-dateutil>=2.0,<3.0'
+    'formic2'
 ]
 
 

--- a/tests/cfngin/actions/test_base.py
+++ b/tests/cfngin/actions/test_base.py
@@ -1,8 +1,11 @@
 """Tests for runway.cfngin.actions.base."""
-# pylint: disable=protected-access,unused-argument
+# pylint: disable=no-self-use,protected-access,unused-argument
 import unittest
 
 from mock import MagicMock, PropertyMock, patch
+
+import botocore.exceptions
+from botocore.stub import ANY, Stubber
 
 from runway.cfngin.actions.base import BaseAction
 from runway.cfngin.blueprints.base import Blueprint
@@ -56,6 +59,97 @@ class TestBaseAction(unittest.TestCase):
                  'requires': ['stack1']}
             ]
         }
+
+    def test_ensure_cfn_bucket_exists(self):
+        """Test ensure cfn bucket exists."""
+        session = get_session("us-east-1")
+        provider = Provider(session)
+        action = BaseAction(
+            context=mock_context("mynamespace"),
+            provider_builder=MockProviderBuilder(provider)
+        )
+        stubber = Stubber(action.s3_conn)
+        stubber.add_response(
+            "head_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+            }
+        )
+        with stubber:
+            action.ensure_cfn_bucket()
+
+    def test_ensure_cfn_bucket_does_not_exist_us_east(self):
+        """Test ensure cfn bucket does not exist us east."""
+        session = get_session("us-east-1")
+        provider = Provider(session)
+        action = BaseAction(
+            context=mock_context("mynamespace"),
+            provider_builder=MockProviderBuilder(provider)
+        )
+        stubber = Stubber(action.s3_conn)
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="NoSuchBucket",
+            service_message="Not Found",
+            http_status_code=404,
+        )
+        stubber.add_response(
+            "create_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+            }
+        )
+        with stubber:
+            action.ensure_cfn_bucket()
+
+    def test_ensure_cfn_bucket_does_not_exist_us_west(self):
+        """Test ensure cfn bucket does not exist us west."""
+        session = get_session("us-west-1")
+        provider = Provider(session)
+        action = BaseAction(
+            context=mock_context("mynamespace"),
+            provider_builder=MockProviderBuilder(provider, region="us-west-1")
+        )
+        stubber = Stubber(action.s3_conn)
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="NoSuchBucket",
+            service_message="Not Found",
+            http_status_code=404,
+        )
+        stubber.add_response(
+            "create_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+                "CreateBucketConfiguration": {
+                    "LocationConstraint": "us-west-1",
+                }
+            }
+        )
+        with stubber:
+            action.ensure_cfn_bucket()
+
+    def test_ensure_cfn_forbidden(self):
+        """Test ensure cfn forbidden."""
+        session = get_session("us-west-1")
+        provider = Provider(session)
+        action = BaseAction(
+            context=mock_context("mynamespace"),
+            provider_builder=MockProviderBuilder(provider)
+        )
+        stubber = Stubber(action.s3_conn)
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="AccessDenied",
+            service_message="Forbidden",
+            http_status_code=403,
+        )
+        with stubber:
+            with self.assertRaises(botocore.exceptions.ClientError):
+                action.ensure_cfn_bucket()
 
     @patch('runway.cfngin.context.Context._persistent_graph_tags',
            new_callable=PropertyMock)

--- a/tests/cfngin/actions/test_base.py
+++ b/tests/cfngin/actions/test_base.py
@@ -1,12 +1,12 @@
 """Tests for runway.cfngin.actions.base."""
+# pylint: disable=protected-access,unused-argument
 import unittest
 
-import botocore.exceptions
-from botocore.stub import ANY, Stubber
-import mock
+from mock import MagicMock, PropertyMock, patch
 
 from runway.cfngin.actions.base import BaseAction
 from runway.cfngin.blueprints.base import Blueprint
+from runway.cfngin.plan import Graph, Plan, Step
 from runway.cfngin.providers.aws.default import Provider
 from runway.cfngin.session_cache import get_session
 
@@ -34,96 +34,176 @@ class MockBlueprint(Blueprint):
 class TestBaseAction(unittest.TestCase):
     """Tests for runway.cfngin.actions.base.BaseAction."""
 
-    def test_ensure_cfn_bucket_exists(self):
-        """Test ensure cfn bucket exists."""
-        session = get_session("us-east-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider)
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_response(
-            "head_bucket",
-            service_response={},
-            expected_params={
-                "Bucket": ANY,
-            }
-        )
-        with stubber:
-            action.ensure_cfn_bucket()
+    def setUp(self):
+        """Run before tests."""
+        self.region = 'us-east-1'
+        self.session = get_session(self.region)
+        self.provider = Provider(self.session)
 
-    def test_ensure_cfn_bucket_does_not_exist_us_east(self):
-        """Test ensure cfn bucket does not exist us east."""
-        session = get_session("us-east-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider)
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_client_error(
-            "head_bucket",
-            service_error_code="NoSuchBucket",
-            service_message="Not Found",
-            http_status_code=404,
-        )
-        stubber.add_response(
-            "create_bucket",
-            service_response={},
-            expected_params={
-                "Bucket": ANY,
-            }
-        )
-        with stubber:
-            action.ensure_cfn_bucket()
+        self.config_no_persist = {
+            'stacks': [
+                {'name': 'stack1'},
+                {'name': 'stack2',
+                 'requires': ['stack1']}
+            ]
+        }
 
-    def test_ensure_cfn_bucket_does_not_exist_us_west(self):
-        """Test ensure cfn bucket does not exist us west."""
-        session = get_session("us-west-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider, region="us-west-1")
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_client_error(
-            "head_bucket",
-            service_error_code="NoSuchBucket",
-            service_message="Not Found",
-            http_status_code=404,
-        )
-        stubber.add_response(
-            "create_bucket",
-            service_response={},
-            expected_params={
-                "Bucket": ANY,
-                "CreateBucketConfiguration": {
-                    "LocationConstraint": "us-west-1",
-                }
-            }
-        )
-        with stubber:
-            action.ensure_cfn_bucket()
+        self.config_persist = {
+            'persistent_graph_key': 'test.json',
+            'stacks': [
+                {'name': 'stack1'},
+                {'name': 'stack2',
+                 'requires': ['stack1']}
+            ]
+        }
 
-    def test_ensure_cfn_forbidden(self):
-        """Test ensure cfn forbidden."""
-        session = get_session("us-west-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider)
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_client_error(
-            "head_bucket",
-            service_error_code="AccessDenied",
-            service_message="Forbidden",
-            http_status_code=403,
-        )
-        with stubber:
-            with self.assertRaises(botocore.exceptions.ClientError):
-                action.ensure_cfn_bucket()
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('runway.cfngin.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_no_persist_exclude(self, mock_stack_action,
+                                              mock_tags):
+        """Test generate plan no persist exclude."""
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_no_persist,
+                               region=self.region)
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=False)
+
+        mock_tags.assert_not_called()
+        self.assertIsInstance(plan, Plan)
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('runway.cfngin.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_no_persist_include(self, mock_stack_action,
+                                              mock_tags):
+        """Test generate plan no persist include."""
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_no_persist,
+                               region=self.region)
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=True)
+
+        mock_tags.assert_not_called()
+        self.assertIsInstance(plan, Plan)
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('runway.cfngin.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_with_persist_exclude(self, mock_stack_action,
+                                                mock_tags):
+        """Test generate plan with persist exclude."""
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_persist,
+                               region=self.region)
+        persist_step = Step.from_stack_name('removed', context)
+        context._persistent_graph = Graph.from_steps([persist_step])
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=False)
+
+        self.assertIsInstance(plan, Plan)
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('runway.cfngin.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_with_persist_include(self, mock_stack_action,
+                                                mock_tags):
+        """Test generate plan with persist include."""
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_persist,
+                               region=self.region)
+        persist_step = Step.from_stack_name('removed', context)
+        context._persistent_graph = Graph.from_steps([persist_step])
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=True)
+
+        self.assertIsInstance(plan, Plan)
+        mock_tags.assert_called_once()
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(3, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(set(), result_graph_dict['removed'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('runway.cfngin.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_with_persist_no_lock_req(self, mock_stack_action,
+                                                    mock_tags):
+        """Test generate plan with persist no lock req."""
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_persist,
+                               region=self.region)
+        persist_step = Step.from_stack_name('removed', context)
+        context._persistent_graph = Graph.from_steps([persist_step])
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=True,
+                                     require_unlocked=False)
+
+        self.assertIsInstance(plan, Plan)
+        mock_tags.assert_called_once()
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(3, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(set(), result_graph_dict['removed'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertFalse(plan.require_unlocked)
 
     def test_stack_template_url(self):
         """Test stack template url."""
@@ -139,8 +219,8 @@ class TestBaseAction(unittest.TestCase):
             provider_builder=MockProviderBuilder(provider, region=region)
         )
 
-        with mock.patch('runway.cfngin.actions.base.get_s3_endpoint',
-                        autospec=True, return_value=endpoint):
+        with patch('runway.cfngin.actions.base.get_s3_endpoint',
+                   autospec=True, return_value=endpoint):
             self.assertEqual(
                 action.stack_template_url(blueprint),
                 "%s/%s/stack_templates/%s/%s-%s.json" % (

--- a/tests/cfngin/actions/test_destroy.py
+++ b/tests/cfngin/actions/test_destroy.py
@@ -14,7 +14,7 @@ from ..factories import MockProviderBuilder, MockThreadingEvent
 
 
 class MockStack(object):  # pylint: disable=too-few-public-methods
-    """Mock our local Stacker stack and an AWS provider stack."""
+    """Mock our local CFNgin stack and an AWS provider stack."""
 
     def __init__(self, name, tags=None, **kwargs):
         """Instantiate class."""

--- a/tests/cfngin/actions/test_destroy.py
+++ b/tests/cfngin/actions/test_destroy.py
@@ -1,18 +1,19 @@
 """Tests for runway.cfngin.actions.destroy."""
-# pylint: disable=protected-access,unused-argument
+# pylint: disable=no-self-use,protected-access,unused-argument
 import unittest
 
-import mock
+from mock import MagicMock, PropertyMock, patch
 
 from runway.cfngin.actions import destroy
 from runway.cfngin.context import Config, Context
 from runway.cfngin.exceptions import StackDoesNotExist
+from runway.cfngin.plan import Graph, Step
 from runway.cfngin.status import COMPLETE, PENDING, SKIPPED, SUBMITTED
 
 from ..factories import MockProviderBuilder, MockThreadingEvent
 
 
-class MockStack(object):
+class MockStack(object):  # pylint: disable=too-few-public-methods
     """Mock our local Stacker stack and an AWS provider stack."""
 
     def __init__(self, name, tags=None, **kwargs):
@@ -29,7 +30,13 @@ class TestDestroyAction(unittest.TestCase):
 
     def setUp(self):
         """Run before tests."""
-        config = Config({
+        self.context = self._get_context()
+        self.action = destroy.Action(self.context,
+                                     cancel=MockThreadingEvent())
+
+    def _get_context(self, extra_config_args=None, **kwargs):
+        """Get context."""
+        config = {
             "namespace": "namespace",
             "stacks": [
                 {"name": "vpc"},
@@ -37,15 +44,15 @@ class TestDestroyAction(unittest.TestCase):
                 {"name": "instance", "requires": ["vpc", "bastion"]},
                 {"name": "db", "requires": ["instance", "vpc", "bastion"]},
                 {"name": "other", "requires": ["db"]},
-            ],
-        })
-        self.context = Context(config=config)
-        self.action = destroy.Action(self.context,
-                                     cancel=MockThreadingEvent())
+            ]
+        }
+        if extra_config_args:
+            config.update(extra_config_args)
+        return Context(config=Config(config), **kwargs)
 
     def test_generate_plan(self):
         """Test generate plan."""
-        plan = self.action._generate_plan()
+        plan = self.action._generate_plan(reverse=True)
         self.assertEqual(
             {
                 'vpc': set(
@@ -62,14 +69,14 @@ class TestDestroyAction(unittest.TestCase):
 
     def test_only_execute_plan_when_forced(self):
         """Test only execute plan when forced."""
-        with mock.patch.object(self.action, "_generate_plan") as \
+        with patch.object(self.action, "_generate_plan") as \
                 mock_generate_plan:
             self.action.run(force=False)
             self.assertEqual(mock_generate_plan().execute.call_count, 0)
 
     def test_execute_plan_when_forced(self):
         """Test execute plan when forced."""
-        with mock.patch.object(self.action, "_generate_plan") as \
+        with patch.object(self.action, "_generate_plan") as \
                 mock_generate_plan:
             self.action.run(force=True)
             self.assertEqual(mock_generate_plan().execute.call_count, 1)
@@ -78,7 +85,7 @@ class TestDestroyAction(unittest.TestCase):
         """Test destroy stack complete if state submitted."""
         # Simulate the provider not being able to find the stack (a result of
         # it being successfully deleted)
-        provider = mock.MagicMock()
+        provider = MagicMock()
         provider.get_stack.side_effect = StackDoesNotExist("mock")
         self.action.provider_builder = MockProviderBuilder(provider)
         status = self.action._destroy_stack(MockStack("vpc"), status=PENDING)
@@ -92,7 +99,7 @@ class TestDestroyAction(unittest.TestCase):
 
     def test_destroy_stack_step_statuses(self):
         """Test destroy stack step statuses."""
-        mock_provider = mock.MagicMock()
+        mock_provider = MagicMock()
         stacks_dict = self.context.get_stacks_dict()
 
         def get_stack(stack_name):
@@ -128,3 +135,28 @@ class TestDestroyAction(unittest.TestCase):
 
         step._run_once()
         self.assertEqual(step.status, COMPLETE)
+
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('runway.cfngin.context.Context.lock_persistent_graph',
+           new_callable=MagicMock)
+    @patch('runway.cfngin.context.Context.unlock_persistent_graph',
+           new_callable=MagicMock)
+    @patch('runway.cfngin.plan.Plan.execute', new_callable=MagicMock)
+    def test_run_persist(self, mock_execute, mock_unlock, mock_lock,
+                         mock_graph_tags):
+        """Test run persist."""
+        mock_graph_tags.return_value = {}
+        context = self._get_context(
+            extra_config_args={'persistent_graph_key': 'test.json'}
+        )
+        context._persistent_graph = Graph.from_steps(
+            [Step.from_stack_name('removed', context)]
+        )
+        destroy_action = destroy.Action(context=context)
+        destroy_action.run(force=True)
+
+        mock_graph_tags.assert_called_once()
+        mock_lock.assert_called_once()
+        mock_execute.assert_called_once()
+        mock_unlock.assert_called_once()

--- a/tests/cfngin/providers/aws/test_default.py
+++ b/tests/cfngin/providers/aws/test_default.py
@@ -460,6 +460,16 @@ class TestProviderDefaultMode(unittest.TestCase):
             self.session, region=region, recreate_failed=False)
         self.stubber = Stubber(self.provider.cloudformation)
 
+    def test_destroy_stack(self):
+        """Test destroy stack."""
+        stack = {'StackName': 'MockStack'}
+
+        self.stubber.add_response('delete_stack', {}, stack)
+
+        with self.stubber:
+            self.assertIsNone(self.provider.destroy_stack(stack))
+            self.stubber.assert_no_pending_responses()
+
     def test_get_stack_stack_does_not_exist(self):
         """Test get stack stack does not exist."""
         stack_name = "MockStack"
@@ -490,6 +500,15 @@ class TestProviderDefaultMode(unittest.TestCase):
             response = self.provider.get_stack(stack_name)
 
         self.assertEqual(response["StackName"], stack_name)
+
+    def test_select_destroy_method(self):
+        """Test select destroy method."""
+        for i in [[{'force_interactive': False},
+                   self.provider.noninteractive_destroy_stack],
+                  [{'force_interactive': True},
+                   self.provider.interactive_destroy_stack]]:
+            self.assertEqual(self.provider.select_destroy_method(**i[0]),
+                             i[1])
 
     def test_select_update_method(self):
         """Test select update method."""
@@ -857,6 +876,27 @@ class TestProviderInteractiveMode(unittest.TestCase):
             self.session, interactive=True, recreate_failed=True)
         self.stubber = Stubber(self.provider.cloudformation)
 
+    @patch('runway.cfngin.ui.get_raw_input')
+    def test_destroy_stack(self, patched_input):
+        """Test destroy stack."""
+        stack = {'StackName': 'MockStack'}
+        patched_input.return_value = 'y'
+
+        self.stubber.add_response('delete_stack', {}, stack)
+
+        with self.stubber:
+            self.assertIsNone(self.provider.destroy_stack(stack))
+            self.stubber.assert_no_pending_responses()
+
+    @patch('runway.cfngin.ui.get_raw_input')
+    def test_destroy_stack_canceled(self, patched_input):
+        """Test destroy stack canceled."""
+        stack = {'StackName': 'MockStack'}
+        patched_input.return_value = 'n'
+
+        with self.assertRaises(exceptions.CancelExecution):
+            self.provider.destroy_stack(stack)
+
     def test_successful_init(self):
         """Test successful init."""
         replacements = True
@@ -943,8 +983,17 @@ class TestProviderInteractiveMode(unittest.TestCase):
 
         self.assertEqual(patched_approval.call_count, 1)
 
+    def test_select_destroy_method(self):
+        """Test select destroy method."""
+        for i in [[{'force_interactive': False},
+                   self.provider.interactive_destroy_stack],
+                  [{'force_interactive': True},
+                   self.provider.interactive_destroy_stack]]:
+            self.assertEqual(self.provider.select_destroy_method(**i[0]),
+                             i[1])
+
     def test_select_update_method(self):
-        """."""
+        """Test select update method."""
         for i in [[{'force_interactive': False,
                     'force_change_set': False},
                    self.provider.interactive_update_stack],

--- a/tests/cfngin/providers/aws/test_default.py
+++ b/tests/cfngin/providers/aws/test_default.py
@@ -589,7 +589,7 @@ class TestProviderDefaultMode(unittest.TestCase):
             with self.stubber:
                 self.provider.prepare_stack_for_update(
                     stack,
-                    tags=[{'Key': 'stacker_namespace', 'Value': 'test'}])
+                    tags=[{'Key': 'cfngin_namespace', 'Value': 'test'}])
 
         self.assertIn('tags differ', str(raised.exception).lower())
 

--- a/tests/cfngin/test_context.py
+++ b/tests/cfngin/test_context.py
@@ -1,9 +1,46 @@
 """Tests for runway.cfngin.context."""
+# pylint: disable=protected-access,too-many-public-methods
+import io
+import json
 import unittest
+
+from botocore.exceptions import ClientError
+from botocore.response import StreamingBody
+from botocore.stub import ANY, Stubber
+from mock import PropertyMock, patch
 
 from runway.cfngin.config import Config, load
 from runway.cfngin.context import Context, get_fqn
+from runway.cfngin.exceptions import (PersistentGraphCannotLock,
+                                      PersistentGraphCannotUnlock,
+                                      PersistentGraphLockCodeMissmatch,
+                                      PersistentGraphLocked,
+                                      PersistentGraphUnlocked)
 from runway.cfngin.hooks.utils import handle_hooks
+from runway.cfngin.plan import Graph, json_serial
+
+
+def gen_tagset(tags):
+    """Create TagSet value from a dict."""
+    return [{'Key': key, 'Value': value} for key, value in tags.items()]
+
+
+def gen_s3_object_content(content):
+    """Convert a string or dict to S3 object body.
+
+    Args:
+        content (Union[str, Dict[str, Any]]): S3 object body
+
+    Returns:
+        botocore.response.StreamingBody Used in the Body of a
+            s3.get_object response.
+
+    """
+    if isinstance(content, dict):
+        content = json.dumps(content, default=json_serial)
+    encoded_content = content.encode()
+    return StreamingBody(io.BytesIO(encoded_content),
+                         len(encoded_content))
 
 
 class TestContext(unittest.TestCase):
@@ -15,6 +52,15 @@ class TestContext(unittest.TestCase):
             "namespace": "namespace",
             "stacks": [
                 {"name": "stack1"}, {"name": "stack2"}]})
+        self.persist_graph_raw_config = {
+            'namespace': 'test',
+            'cfngin_bucket': 'cfngin-test',
+            'cfngin_bucket_region': 'us-east-1',
+            'persistent_graph_key': 'test.json',
+            'stacks': [
+                {'name': 'stack1'}, {'name': 'stack2', 'requires': ['stack1']}]
+        }
+        self.persist_graph_config = Config(self.persist_graph_raw_config)
 
     def test_context_optional_keys_set(self):
         """Test context optional keys set."""
@@ -75,17 +121,17 @@ class TestContext(unittest.TestCase):
 
     def test_context_bucket_name_is_overridden_but_is_none(self):
         """Test context bucket name is overridden but is none."""
-        config = Config({"namespace": "test", "stacker_bucket": ""})
+        config = Config({"namespace": "test", "cfngin_bucket": ""})
         context = Context(config=config)
         self.assertEqual(context.bucket_name, None)
 
-        config = Config({"namespace": "test", "stacker_bucket": None})
+        config = Config({"namespace": "test", "cfngin_bucket": None})
         context = Context(config=config)
         self.assertEqual(context.bucket_name, "stacker-test")
 
     def test_context_bucket_name_is_overridden(self):
         """Test context bucket name is overridden."""
-        config = Config({"namespace": "test", "stacker_bucket": "bucket123"})
+        config = Config({"namespace": "test", "cfngin_bucket": "bucket123"})
         context = Context(config=config)
         self.assertEqual(context.bucket_name, "bucket123")
 
@@ -98,7 +144,7 @@ class TestContext(unittest.TestCase):
         self.assertEqual(context.bucket_name, None)
 
         context = Context(
-            config=Config({"namespace": None, "stacker_bucket": ""}))
+            config=Config({"namespace": None, "cfngin_bucket": ""}))
         self.assertEqual(context.bucket_name, None)
 
     def test_context_namespace_delimiter_is_overridden_and_not_none(self):
@@ -144,6 +190,483 @@ class TestContext(unittest.TestCase):
         stage = "pre_build"
         handle_hooks(stage, context.config[stage], "mock-region-1", context)
         self.assertEqual("mockResult", context.hook_data["myHook"]["result"])
+
+    def test_persistent_graph_location(self):
+        """Test persistent graph location."""
+        context = Context(config=self.persist_graph_config)
+        expected = {
+            'Bucket': 'cfngin-test',
+            'Key': 'persistent_graphs/test/test.json'
+        }
+        self.assertEqual(expected, context.persistent_graph_location)
+
+    def test_persistent_graph_location_no_json(self):
+        """'.json' appended to the key if it does not exist."""
+        cp_config = self.persist_graph_raw_config.copy()
+        cp_config['persistent_graph_key'] = 'test'
+
+        context = Context(config=Config(cp_config))
+        expected = {
+            'Bucket': 'cfngin-test',
+            'Key': 'persistent_graphs/test/test.json'
+        }
+        self.assertEqual(expected, context.persistent_graph_location)
+
+    def test_persistent_graph_location_no_key(self):
+        """Return an empty dict if key is not set."""
+        context = Context(config=self.config)
+        self.assertEqual({}, context.persistent_graph_location)
+
+    def test_persistent_graph_location_no_bucket(self):
+        """Return an empty dict if key is set but no bucket name."""
+        cp_config = self.persist_graph_raw_config.copy()
+        cp_config['cfngin_bucket'] = ''
+
+        context = Context(config=Config(cp_config))
+        self.assertEqual({}, context.persistent_graph_location)
+
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    def test_persistent_graph_lock_code_disabled(self, mock_prop):
+        """Return 'None' when not used."""
+        mock_prop.return_value = None
+        context = Context(config=Config(self.config))
+        mock_prop.assert_not_called()
+        self.assertIsNone(context.persistent_graph_lock_code)
+
+    def test_persistent_graph_lock_code_present(self):
+        """Return the value of the lock tag when it exists."""
+        context = Context(config=self.persist_graph_config)
+        stubber = Stubber(context.s3_conn)
+        code = '0000'
+
+        stubber.add_response('get_object_tagging', {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }, context.persistent_graph_location)
+
+        with stubber:
+            self.assertIsNone(context._persistent_graph_lock_code)
+            self.assertEqual(code, context.persistent_graph_lock_code)
+            self.assertEqual(code, context._persistent_graph_lock_code)
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_lock_code_none(self):
+        """Return 'None' when the tag is not set."""
+        context = Context(config=self.persist_graph_config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging', {'TagSet': []},
+                             context.persistent_graph_location)
+
+        with stubber:
+            self.assertIsNone(context.persistent_graph_lock_code)
+            self.assertIsNone(context._persistent_graph_lock_code)
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_lock_code_no_object(self):
+        """Return 'None' when object does not exist."""
+        context = Context(config=self.persist_graph_config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            'get_object_tagging', 'NoSuchKey',
+            expected_params=context.persistent_graph_location)
+
+        with stubber:
+            self.assertIsNone(context.persistent_graph_lock_code)
+            self.assertIsNone(context._persistent_graph_lock_code)
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph(self):
+        """Return Graph from S3 object."""
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'ResponseContentType': 'application/json'}
+        expected_params.update(context.persistent_graph_location)
+        expected_content = {
+            'stack1': set(),
+            'stack2': set(['stack1'])
+        }
+
+        stubber.add_response('get_object',
+                             {'Body': gen_s3_object_content(expected_content)},
+                             expected_params)
+
+        with stubber:
+            self.assertIsNone(context._persistent_graph)
+            self.assertIsInstance(context.persistent_graph, Graph)
+            self.assertIsInstance(context._persistent_graph, Graph)
+            self.assertEqual(expected_content,
+                             context.persistent_graph.to_dict())
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_no_object(self):
+        """Create object if one does not exist and return empty Graph."""
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        stubber = Stubber(context.s3_conn)
+        expected_get_params = {'ResponseContentType': 'application/json'}
+        expected_get_params.update(context.persistent_graph_location)
+        expected_put_params = {'Body': '{}',
+                               'ServerSideEncryption': 'AES256',
+                               'ACL': 'bucket-owner-full-control',
+                               'ContentType': 'application/json'}
+        expected_put_params.update(context.persistent_graph_location)
+
+        stubber.add_client_error('get_object', 'NoSuchKey',
+                                 expected_params=expected_get_params)
+        stubber.add_response('put_object', {}, expected_put_params)
+
+        with stubber:
+            self.assertIsNone(context._persistent_graph)
+            self.assertIsInstance(context.persistent_graph, Graph)
+            self.assertIsInstance(context._persistent_graph, Graph)
+            self.assertEqual({}, context.persistent_graph.to_dict())
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_disabled(self):
+        """Return 'None' when key is not set."""
+        context = Context(config=self.config)
+        self.assertIsNone(context._persistent_graph)
+        self.assertIsNone(context.persistent_graph)
+
+    def test_lock_persistent_graph(self):
+        """Return 'None' when lock is successful."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Tagging': {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_response('get_object_tagging', {'TagSet': []},
+                             context.persistent_graph_location)
+        stubber.add_response('put_object_tagging', {}, expected_params)
+
+        with stubber:
+            self.assertIsNone(context.lock_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    def test_lock_persistent_graph_locked(self):
+        """Error raised when when object is locked."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Tagging': {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: '1111'}
+                             )},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphLocked):
+                context.lock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_lock_persistent_graph_no_object(self):
+        """Error raised when when there is no object to lock."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Tagging': {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_client_error(
+            'get_object_tagging', 'NoSuchKey',
+            expected_params=context.persistent_graph_location
+        )
+        stubber.add_client_error('put_object_tagging', 'NoSuchKey',
+                                 expected_params=expected_params)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphCannotLock):
+                context.lock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph(self):
+        """Return 'None' when put is successful."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        graph_dict = {
+            'stack1': [],
+            'stack2': ['stack1']
+        }
+        context._persistent_graph = Graph.from_dict(graph_dict, context)
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Body': json.dumps(graph_dict, indent=4),
+                           'ServerSideEncryption': 'AES256',
+                           'ACL': 'bucket-owner-full-control',
+                           'ContentType': 'application/json',
+                           'Tagging': '{}={}'.format(
+                               context._persistent_graph_lock_tag,
+                               code)}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: code}
+                             )},
+                             context.persistent_graph_location)
+        stubber.add_response('put_object', {}, expected_params)
+
+        with stubber:
+            self.assertIsNone(context.put_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph_unlocked(self):
+        """Error raised when trying to update an unlocked object."""
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging', {'TagSet': []},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphUnlocked):
+                context.put_persistent_graph('')
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph_code_missmatch(self):
+        """Error raised when provided lock code does not match object."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: '1111'}
+                             )},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphLockCodeMissmatch):
+                context.put_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph_empty(self):
+        """Object deleted when persistent graph is empty."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('delete_object', {},
+                             context.persistent_graph_location)
+
+        with stubber:
+            self.assertFalse(context.persistent_graph.to_dict())
+            self.assertIsNone(context.put_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    @patch('runway.cfngin.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    def test_persistent_graph_locked(self, mock_prop):
+        """Return 'True' or 'False' based on code property."""
+        mock_prop.return_value = {}
+        context = Context(config=self.persist_graph_config)
+        context._persistent_graph = True
+
+        context._persistent_graph_lock_code = True
+        self.assertTrue(context.persistent_graph_locked)
+
+        context._persistent_graph_lock_code = None
+        self.assertFalse(context.persistent_graph_locked)
+        mock_prop.assert_called_once()
+
+    def test_persistent_graph_locked_disabled(self):
+        """Return 'None' when key is not set."""
+        context = Context(config=self.config)
+        self.assertFalse(context.persistent_graph_locked)
+
+    def test_s3_bucket_exists(self):
+        """Test s3 bucket exists."""
+        context = Context(config=self.config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response(
+            "head_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+            }
+        )
+
+        with stubber:
+            self.assertIsNone(context._s3_bucket_verified)
+            self.assertTrue(context.s3_bucket_verified)
+            self.assertTrue(context._s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_s3_bucket_does_not_exist_us_east(self):
+        """Create S3 bucket when it does not exist."""
+        context = Context(config=self.config, region='us-east-1')
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="NoSuchBucket",
+            service_message="Not Found",
+            http_status_code=404,
+        )
+        stubber.add_response(
+            "create_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+            }
+        )
+
+        with stubber:
+            self.assertIsNone(context._s3_bucket_verified)
+            self.assertTrue(context.s3_bucket_verified)
+            self.assertTrue(context._s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_s3_bucket_does_not_exist_us_west(self):
+        """Create S3 bucket with loc constraints when it does not exist."""
+        region = 'us-west-1'
+        context = Context(config=self.config, region=region)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="NoSuchBucket",
+            service_message="Not Found",
+            http_status_code=404,
+        )
+        stubber.add_response(
+            "create_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+                "CreateBucketConfiguration": {
+                    "LocationConstraint": region,
+                }
+            }
+        )
+
+        with stubber:
+            self.assertIsNone(context._s3_bucket_verified)
+            self.assertTrue(context.s3_bucket_verified)
+            self.assertTrue(context._s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_s3_bucket_forbidden(self):
+        """Error raised when S3 bucket exists but cannot access."""
+        context = Context(config=self.config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="AccessDenied",
+            service_message="Forbidden",
+            http_status_code=403,
+        )
+
+        with stubber:
+            with self.assertRaises(ClientError):
+                self.assertFalse(context.s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph(self):
+        """Return 'True' when delete tag is successful."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: code}
+                             )},
+                             context.persistent_graph_location)
+        stubber.add_response('delete_object_tagging', {},
+                             context.persistent_graph_location)
+
+        with stubber:
+            self.assertTrue(context.unlock_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph_not_locked(self):
+        """Error raised when object is not locked."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': []},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphCannotUnlock):
+                context.unlock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph_code_missmatch(self):
+        """Error raised when local code does not match object."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: '1111'}
+                             )},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphCannotUnlock):
+                context.unlock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph_no_object(self):
+        """Return 'None' when object does not exist.
+
+        This can occur if the object is deleted by 'put_persistent_graph'.
+
+        """
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+        expected_params = context.persistent_graph_location.copy()
+        expected_params.update({'ResponseContentType': 'application/json'})
+
+        stubber.add_client_error(
+            'get_object', 'NoSuchKey',
+            expected_params=expected_params
+        )
+
+        with stubber:
+            assert context.unlock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/cfngin/test_plan.py
+++ b/tests/cfngin/test_plan.py
@@ -1,5 +1,6 @@
 """Tests for runway.cfngin.plan."""
-# pylint: disable=unused-argument
+# pylint: disable=protected-access,unused-argument
+import json
 import os
 import shutil
 import tempfile
@@ -9,15 +10,16 @@ import mock
 
 from runway.cfngin.context import Config, Context
 from runway.cfngin.dag import walk
-from runway.cfngin.exceptions import CancelExecution, GraphError, PlanFailed
+from runway.cfngin.exceptions import (CancelExecution, GraphError,
+                                      PersistentGraphLocked, PlanFailed)
 from runway.cfngin.lookups.registry import (register_lookup_handler,
                                             unregister_lookup_handler)
-from runway.cfngin.plan import Step, build_graph, build_plan
+from runway.cfngin.plan import Graph, Plan, Step
 from runway.cfngin.stack import Stack
 from runway.cfngin.status import COMPLETE, FAILED, SKIPPED, SUBMITTED
 from runway.cfngin.util import stack_template_key_name
 
-from .factories import generate_definition
+from .factories import generate_definition, mock_context
 
 
 class TestStep(unittest.TestCase):
@@ -50,6 +52,94 @@ class TestStep(unittest.TestCase):
         self.assertNotEqual(self.step.status, False)
         self.assertNotEqual(self.step.status, 'banana')
 
+    def test_from_stack_name(self):
+        """Return step from step name."""
+        context = mock_context()
+        stack_name = 'test-stack'
+        result = Step.from_stack_name(stack_name, context)
+
+        self.assertIsInstance(result, Step)
+        self.assertEqual(stack_name, result.stack.name)
+
+    def test_from_persistent_graph(self):
+        """Return list of steps from graph dict."""
+        context = mock_context()
+        graph_dict = {
+            'stack1': [],
+            'stack2': ['stack1']
+        }
+        result = Step.from_persistent_graph(graph_dict, context)
+
+        self.assertEqual(2, len(result))
+        self.assertIsInstance(result, list)
+
+        for step in result:
+            self.assertIsInstance(step, Step)
+            self.assertIn(step.stack.name, graph_dict.keys())
+
+
+class TestGraph(unittest.TestCase):
+    """Tests for runway.cfngin.plan.Graph."""
+
+    def setUp(self):
+        """Run before tests."""
+        self.context = mock_context()
+        self.graph_dict = {
+            'stack1': [],
+            'stack2': ['stack1']
+        }
+        self.graph_dict_expected = {
+            'stack1': set(),
+            'stack2': set(['stack1'])
+        }
+        self.steps = Step.from_persistent_graph(self.graph_dict,
+                                                self.context)
+
+    def test_add_steps(self):
+        """Test add steps."""
+        graph = Graph()
+        graph.add_steps(self.steps)
+
+        self.assertEqual(self.steps, list(graph.steps.values()))
+        self.assertEqual([step.name for step in self.steps],
+                         list(graph.steps.keys()))
+        self.assertEqual(self.graph_dict_expected, graph.to_dict())
+
+    def test_pop(self):
+        """Test pop."""
+        graph = Graph()
+        graph.add_steps(self.steps)
+
+        stack2 = next(step for step in self.steps if step.name == 'stack2')
+
+        self.assertEqual(stack2, graph.pop(stack2))
+        self.assertEqual({'stack1': set()}, graph.to_dict())
+
+    def test_dumps(self):
+        """Test dumps."""
+        graph = Graph()
+        graph.add_steps(self.steps)
+
+        self.assertEqual(json.dumps(self.graph_dict), graph.dumps())
+
+    def test_from_dict(self):
+        """Test from dict."""
+        graph = Graph.from_dict(self.graph_dict, self.context)
+
+        self.assertIsInstance(graph, Graph)
+        self.assertEqual([step.name for step in self.steps],
+                         list(graph.steps.keys()))
+        self.assertEqual(self.graph_dict_expected, graph.to_dict())
+
+    def test_from_steps(self):
+        """Test from steps."""
+        graph = Graph.from_steps(self.steps)
+
+        self.assertEqual(self.steps, list(graph.steps.values()))
+        self.assertEqual([step.name for step in self.steps],
+                         list(graph.steps.keys()))
+        self.assertEqual(self.graph_dict_expected, graph.to_dict())
+
 
 class TestPlan(unittest.TestCase):
     """Tests for runway.cfngin.plan.Plan."""
@@ -74,35 +164,114 @@ class TestPlan(unittest.TestCase):
             definition=generate_definition('bastion', 1, requires=[vpc.name]),
             context=self.context)
 
-        graph = build_graph([
-            Step(vpc, fn=None), Step(bastion, fn=None)])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([Step(vpc, fn=None), Step(bastion, fn=None)])
+        plan = Plan(description="Test", graph=graph)
 
         self.assertEqual(plan.graph.to_dict(), {
             'bastion.1': set(['vpc.1']),
             'vpc.1': set([])})
 
-    def test_execute_plan(self):
-        """Test execute plan."""
+    def test_plan_reverse(self):
+        """Test plan reverse."""
         vpc = Stack(
             definition=generate_definition('vpc', 1),
             context=self.context)
         bastion = Stack(
             definition=generate_definition('bastion', 1, requires=[vpc.name]),
             context=self.context)
+        graph = Graph.from_steps([Step(vpc, fn=None), Step(bastion, fn=None)])
+        plan = Plan(description="Test", graph=graph, reverse=True)
+
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(set(), result_graph_dict.get('bastion.1'))
+        self.assertEqual(set(['bastion.1']), result_graph_dict.get('vpc.1'))
+
+    def test_plan_targeted(self):
+        """Test plan targeted."""
+        context = Context(config=self.config)
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.name]),
+            context=context)
+        context.stack_names = [vpc.name]
+        graph = Graph.from_steps([Step(vpc, fn=None), Step(bastion, fn=None)])
+        plan = Plan(description="Test", graph=graph, context=context)
+
+        self.assertEqual({vpc.name: set()}, plan.graph.to_dict())
+
+    def test_execute_plan(self):
+        """Test execute plan."""
+        context = Context(config=self.config)
+        context.put_persistent_graph = mock.MagicMock()
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.name]),
+            context=context)
+        removed = Stack(
+            definition=generate_definition('removed', 1, requires=[]),
+            context=context)
+        context._persistent_graph = Graph.from_steps([removed])
 
         calls = []
 
-        def fn(stack, status=None):
+        def _launch_stack(stack, status=None):
             calls.append(stack.fqn)
             return COMPLETE
 
-        graph = build_graph([Step(vpc, fn), Step(bastion, fn)])
-        plan = build_plan(
-            description="Test", graph=graph)
+        def _destroy_stack(stack, status=None):
+            calls.append(stack.fqn)
+            return COMPLETE
+
+        graph = Graph.from_steps([Step(removed, _destroy_stack),
+                                  Step(vpc, _launch_stack),
+                                  Step(bastion, _launch_stack)])
+        plan = Plan(description="Test", graph=graph, context=context)
+        plan.context._persistent_graph_lock_code = plan.lock_code
+        plan.execute(walk)
+
+        # the order these are appended changes between python2/3
+        self.assertIn('namespace-vpc.1', calls)
+        self.assertIn('namespace-bastion.1', calls)
+        self.assertIn('namespace-removed.1', calls)
+        context.put_persistent_graph.assert_called()
+
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = context.persistent_graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict.get('vpc.1'))
+        self.assertEqual(set(['vpc.1']), result_graph_dict.get('bastion.1'))
+        self.assertIsNone(result_graph_dict.get('namespace-removed.1'))
+
+    def test_execute_plan_no_persist(self):
+        """Test execute plan with no persistent graph."""
+        context = Context(config=self.config)
+        context.put_persistent_graph = mock.MagicMock()
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.name]),
+            context=context)
+
+        calls = []
+
+        def _launch_stack(stack, status=None):
+            calls.append(stack.fqn)
+            return COMPLETE
+
+        graph = Graph.from_steps([Step(vpc, _launch_stack),
+                                  Step(bastion, _launch_stack)])
+        plan = Plan(description="Test", graph=graph, context=context)
+
         plan.execute(walk)
 
         self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+        context.put_persistent_graph.assert_not_called()
 
     def test_execute_plan_locked(self):
         """Test execute plan locked.
@@ -125,9 +294,8 @@ class TestPlan(unittest.TestCase):
             calls.append(stack.fqn)
             return COMPLETE
 
-        graph = build_graph([Step(vpc, fn), Step(bastion, fn)])
-        plan = build_plan(
-            description="Test", graph=graph)
+        graph = Graph.from_steps([Step(vpc, fn), Step(bastion, fn)])
+        plan = Plan(description="Test", graph=graph)
         plan.execute(walk)
 
         self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
@@ -150,12 +318,14 @@ class TestPlan(unittest.TestCase):
             calls.append(stack.fqn)
             return COMPLETE
 
-        graph = build_graph([
-            Step(vpc, fn), Step(db, fn), Step(app, fn)])
-        plan = build_plan(
+        context = mock.MagicMock()
+        context.persistent_graph_locked = False
+        context.stack_names = ['db.1']
+        graph = Graph.from_steps([Step(vpc, fn), Step(db, fn), Step(app, fn)])
+        plan = Plan(
+            context=context,
             description="Test",
-            graph=graph,
-            targets=['db.1'])
+            graph=graph)
         plan.execute(walk)
 
         self.assertEqual(calls, [
@@ -181,8 +351,8 @@ class TestPlan(unittest.TestCase):
         vpc_step = Step(vpc, fn)
         bastion_step = Step(bastion, fn)
 
-        graph = build_graph([vpc_step, bastion_step])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([vpc_step, bastion_step])
+        plan = Plan(description="Test", graph=graph)
 
         with self.assertRaises(PlanFailed):
             plan.execute(walk)
@@ -210,8 +380,8 @@ class TestPlan(unittest.TestCase):
         vpc_step = Step(vpc, fn)
         bastion_step = Step(bastion, fn)
 
-        graph = build_graph([vpc_step, bastion_step])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([vpc_step, bastion_step])
+        plan = Plan(description="Test", graph=graph)
         plan.execute(walk)
 
         self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
@@ -240,9 +410,8 @@ class TestPlan(unittest.TestCase):
         bastion_step = Step(bastion, fn)
         db_step = Step(db, fn)
 
-        graph = build_graph([
-            vpc_step, bastion_step, db_step])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([vpc_step, bastion_step, db_step])
+        plan = Plan(description="Test", graph=graph)
         with self.assertRaises(PlanFailed):
             plan.execute(walk)
 
@@ -270,11 +439,22 @@ class TestPlan(unittest.TestCase):
         vpc_step = Step(vpc, fn)
         bastion_step = Step(bastion, fn)
 
-        graph = build_graph([vpc_step, bastion_step])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([vpc_step, bastion_step])
+        plan = Plan(description="Test", graph=graph)
         plan.execute(walk)
 
         self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+
+    def test_execute_plan_graph_locked(self):
+        """Test execute plan with locked persistent graph."""
+        context = Context(config=self.config)
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
+        context._persistent_graph_lock_code = '1111'
+        plan = Plan(description='Test', graph=Graph(), context=context)
+        print(plan.locked)
+
+        with self.assertRaises(PersistentGraphLocked):
+            plan.execute()
 
     def test_build_graph_missing_dependency(self):
         """Test build graph missing dependency."""
@@ -284,7 +464,7 @@ class TestPlan(unittest.TestCase):
             context=self.context)
 
         with self.assertRaises(GraphError) as expected:
-            build_graph([Step(bastion, None)])
+            Graph.from_steps([Step(bastion, None)])
         message_starts = (
             "Error detected when adding 'vpc.1' "
             "as a dependency of 'bastion.1':"
@@ -309,7 +489,7 @@ class TestPlan(unittest.TestCase):
             context=self.context)
 
         with self.assertRaises(GraphError) as expected:
-            build_graph([Step(vpc, None), Step(db, None), Step(app, None)])
+            Graph.from_steps([Step(vpc, None), Step(db, None), Step(app, None)])
         message = ("Error detected when adding 'db.1' "
                    "as a dependency of 'app.1': graph is "
                    "not acyclic")
@@ -338,8 +518,8 @@ class TestPlan(unittest.TestCase):
 
             steps += [Step(stack, None)]
 
-        graph = build_graph(steps)
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps(steps)
+        plan = Plan(description="Test", graph=graph)
 
         tmp_dir = tempfile.mkdtemp()
         try:


### PR DESCRIPTION
adapted from cloudtools/stacker#749

> Using a persistent graph enables a Terraform-like experience. When a stack is removed from the local config file, it will be removed from AWS. This will occur for both `build` and `destroy` actions. The `graph` and `diff` commands also take the persistent graph into account (if used).
> 
> This feature requires users **opt-in** to prevent any unexpected results in current environments. This is done by adding a the `persistent_graph_key` directive to any config file. The user is responsible for ensuring that this value is unique per cfngin bucket + namespace.
> 
> The graph is persisted in the existing cfngin bucket (meaning it requires use of a cfngin bucket). No additional resources are required to ensure a low cost and minimally intrusive solution. It is recommended to enable versioning for the bucket to rollback any unintended changes to the object but it is not required and is not actively used by CFNgin. The user is warned each use when it is not enabled and if CFNgin created the bucket when the feature is opted-in, it creates the bucket with versioning enabled.
> 
> The persistent graph object is locked using tags on the S3 object (instead of a DynamoDB table like Terraform) to reduce cost and requirements. When the graph is locked, no other action that acts on the persistent graph (`build`/`destroy`) can be started.
> 
> # What Changed
> 
> - update provider destroy_stack method to have an interactive mode
> - pass region option into context
> - add persist graph to context
>   - context method to get graph
>   - context method to lock graph
>   - context method to unlock graph
>   - context method to put graph
> - add persistent graph exceptions
> - update ensure_s3_bucket
>   - check for recommended bucket settings
>   - applies recommended settings if creating a bucket
> - update plan
>   - class methods to create Step and Graph
>   - remove build_graph
>   - remove build_plan, all logic is now in __init__
>   - add persistent graph management
>   - add more methods for manipulating the graph
> - update base action
>   - add handling for persistent graph
>   - move plan creation to a method that uses classmethods of Graph and Plan
> - update graph action
>   - uses parent class method to create plan
>   - can include persistent graph
> - update diff action
>   - uses parent class method to create plan
>   - can include persistent graph
> - update build action
>   - custom method to create plan that deletes stacks that are in the persistent graph but are no longer in the local graph
> - update destroy action
>   - uses parent class method to create plan
>   - can include persistent graph
> - add persistent_graph_key to config

![image](https://user-images.githubusercontent.com/23145462/74277469-751b8a80-4ccc-11ea-9972-5f46a0b26dbf.png)
(test name in screenshot was before updating it reflect the test)