### PR TITLE
fix reverse_deployments to work with variable attributes

### DIFF
--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -654,14 +654,11 @@ class ModulesCommand(RunwayCommand):
         if deployments is None:
             deployments = []
 
-        reversed_deployments = []
-        for i in deployments[::-1]:
-            deployment = copy.deepcopy(i)
-            for config in ['modules', 'regions']:
-                if deployment.get(config):
-                    deployment[config] = deployment[config][::-1]
-            reversed_deployments.append(deployment)
-        return reversed_deployments
+        for deployment in deployments:
+            deployment.reverse()
+
+        deployments.reverse()
+        return deployments
 
     @staticmethod
     def select_deployment_to_run(deployments=None, command='build'):

--- a/runway/config.py
+++ b/runway/config.py
@@ -714,7 +714,7 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
         value = self._regions.value
         if isinstance(value, list):
             if self._reverse:
-                value.reverse()
+                return value[::-1]
             return value
         raise ValueError('{}.regions is of type {}; expected type '
                          'of list'.format(self.name, type(value)))

--- a/runway/config.py
+++ b/runway/config.py
@@ -585,6 +585,7 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
             - :ref:`command-plan`
 
         """
+        self._reverse = False
         self.name = deployment.pop('name')  # type: str
         self._account_alias = Variable(
             self.name + '.account_alias', deployment.pop(
@@ -712,6 +713,8 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
         """Access the value of an attribute that supports variables."""
         value = self._regions.value
         if isinstance(value, list):
+            if self._reverse:
+                value.reverse()
             return value
         raise ValueError('{}.regions is of type {}; expected type '
                          'of list'.format(self.name, type(value)))
@@ -725,6 +728,14 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
             return value
         raise ValueError('{}.parallel_regions is of type {}; expected type '
                          'of list'.format(self.name, type(value)))
+
+    def reverse(self):
+        """Reverse the order of modules and regions."""
+        if self._reverse:
+            self._reverse = False
+        else:
+            self._reverse = True
+        self.modules.reverse()
 
     @classmethod
     def from_list(cls, deployments):


### PR DESCRIPTION
failing checks pending #145

#116 broke `runway destroy` because of how the deployments were being reversed. each deployment was having `modules` and `regions` attributes rewritten in reverse. `regions` is now a property without a setter so it can no longer be done this way. adding a setter to a variable value did not make sense so i added a `reversed` method to `DeploymentDefinition` that acts like the `reversed` method of a list but for `modules` and `regions`.

