### PR TITLE
fix cfngin lookups missing dependencies method, add shim test script for travis

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -19,3 +19,4 @@ ${PIPENV}pytest
 ${PIPENV}flake8 --exclude=runway/cfngin,runway/embedded,runway/templates runway
 find runway -name '*.py' -not -path 'runway/cfngin*' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run ${PIPENV}pylint --rcfile=.pylintrc
 find runway/blueprints -name '*.py' | xargs ${PIPENV}pylint --disable=duplicate-code
+bash .travis/test_shim.sh

--- a/.travis/test_shim.sh
+++ b/.travis/test_shim.sh
@@ -24,5 +24,6 @@ stacks:
 HERE
 }
 
-${PIPENV}runway run-stacker -- build <(cfngin_config) --dump .travis
+# AWS_SECRET_ACCESS_KEY required to pass in forked travis runs
+AWS_SECRET_ACCESS_KEY=1 ${PIPENV}runway run-stacker -- build <(cfngin_config) --dump .travis
 rm -rf .travis/stack_templates

--- a/.travis/test_shim.sh
+++ b/.travis/test_shim.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# A simple script for testing the stacker => runway.cfngin shim
+
+if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] || [ -z "$TRAVIS_OS_NAME"]; then
+    # these do not nativly run in a venv
+    PIPENV="pipenv run "
+fi
+
+set -ev
+
+cfngin_config() {
+    cat <<'HERE'
+namespace: runway-shim-test
+cfngin_bucket: ''
+
+sys_path: ./integration_tests/test_moduletags/sampleapp
+
+stacks:
+  shim_test:
+    class_path: blueprints.fake_stack.BlueprintClass
+    variables:
+      TestVar: '${default something::something_else}'
+HERE
+}
+
+${PIPENV}runway run-stacker -- build <(cfngin_config) --dump .travis
+rm -rf .travis/stack_templates

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ lint:
 test:
 	pipenv run pytest
 
+test_shim:
+	./.travis/test_shim.sh
+
 travistest: create_readme
 	./.travis/test.sh
 

--- a/runway/lookups/handlers/base.py
+++ b/runway/lookups/handlers/base.py
@@ -68,6 +68,21 @@ class LookupHandler(object):
     """Base class for lookup handlers."""
 
     @classmethod
+    def dependencies(cls, _lookup_data):
+        """Calculate any dependencies required to perform this lookup.
+
+        Note that lookup_data may not be (completely) resolved at this time.
+
+        Args:
+            lookup_data (VariableValue): Parameter(s) given to this lookup.
+
+        Returns:
+            Set
+
+        """
+        return set()
+
+    @classmethod
     def handle(cls, value, context, **kwargs):
         # type: (str, 'Context', Any) -> Any
         """Perform the lookup.


### PR DESCRIPTION
## Summary

CFNgin lookups have a dependency method so they lookups (like output) can emit the stacks they depend on. this adds a class method to the base class that just returns an empty set unless overridden by a subclass.

## Why This Is Needed

```
Traceback (most recent call last):
  File "/Users/kyle/repos/runway/.venv/bin/runway", line 11, in <module>
    load_entry_point('runway', 'console_scripts', 'runway')()
  File "/Users/kyle/repos/runway/runway/cli.py", line 84, in main
    command_class(cli_arguments).execute()
  File "/Users/kyle/repos/runway/runway/commands/runway/run_stacker.py", line 36, in execute
    args.run(args)
  File "/Users/kyle/repos/runway/runway/cfngin/commands/stacker/build.py", line 50, in run
    dump=options.dump)
  File "/Users/kyle/repos/runway/runway/cfngin/actions/base.py", line 163, in execute
    self.run(**kwargs)
  File "/Users/kyle/repos/runway/runway/cfngin/actions/build.py", line 517, in run
    plan = self.__generate_plan(tail=kwargs.get('tail'))
  File "/Users/kyle/repos/runway/runway/cfngin/actions/build.py", line 452, in __generate_plan
    return self._generate_plan(tail)
  File "/Users/kyle/repos/runway/runway/cfngin/actions/base.py", line 258, in _generate_plan
    graph = Graph.from_steps(steps)
  File "/Users/kyle/repos/runway/runway/cfngin/plan.py", line 587, in from_steps
    graph.add_steps(steps)
  File "/Users/kyle/repos/runway/runway/cfngin/plan.py", line 445, in add_steps
    for dep in step.requires:
  File "/Users/kyle/repos/runway/runway/cfngin/plan.py", line 171, in requires
    return self.stack.requires
  File "/Users/kyle/repos/runway/runway/cfngin/stack.py", line 114, in requires
    deps = variable.dependencies
  File "/Users/kyle/repos/runway/runway/variables.py", line 68, in dependencies
    return self._value.dependencies
  File "/Users/kyle/repos/runway/runway/variables.py", line 611, in dependencies
    return self.handler.dependencies(self.lookup_data)
AttributeError: type object 'DefaultLookup' has no attribute 'dependencies'
```

## What Changed


### Added

- `runway.lookups.handlers.base.LookupHandler.dependencies()` classmethod
- script to test the stacker shim using `runway run-stacker` (used during travis testing)
- `make test_shim` to run the shim test outside of travis

### Fixed

- `AttributeError: type object 'DefaultLookup' has no attribute 'dependencies'`

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/74369335-0dc41000-4d8a-11ea-8b9c-ae87fdac6892.png)

