### PR TITLE
fix sample for eks tf

### DIFF
--- a/runway/templates/k8s-tf-repo/eks-base.tf/main.tf
+++ b/runway/templates/k8s-tf-repo/eks-base.tf/main.tf
@@ -215,6 +215,8 @@ provider "kubernetes" {
   cluster_ca_certificate = "${base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)}"
   token = "${data.aws_eks_cluster_auth.cluster_auth.token}"
   load_config_file = false
+  # Pinned back from 1.11 pending resolution of:
+  # https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759
   version = "~> 1.10.0"
 }
 

--- a/runway/templates/k8s-tf-repo/eks-base.tf/main.tf
+++ b/runway/templates/k8s-tf-repo/eks-base.tf/main.tf
@@ -215,7 +215,7 @@ provider "kubernetes" {
   cluster_ca_certificate = "${base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)}"
   token = "${data.aws_eks_cluster_auth.cluster_auth.token}"
   load_config_file = false
-  version = "~> 1.10"
+  version = "~> 1.10.0"
 }
 
 resource "kubernetes_config_map" "aws_auth_configmap" {

--- a/runway/templates/k8s-tf-repo/job-s3-echo.tf/main.tf
+++ b/runway/templates/k8s-tf-repo/job-s3-echo.tf/main.tf
@@ -36,7 +36,9 @@ provider "kubernetes" {
   cluster_ca_certificate = "${base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)}"
   token = "${data.aws_eks_cluster_auth.cluster_auth.token}"
   load_config_file = false
-  version = "~> 1.10"
+  # Pinned back from 1.11 pending resolution of:
+  # https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759
+  version = "~> 1.10.0"
 }
 
 data "aws_ssm_parameter" "oidc_iam_provider_cluster_url" {


### PR DESCRIPTION
## Summary
Currently the sample doesn't work OTB because there's an issue with the tf aws eks integration.
see 
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/734
- https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/733#issuecomment-584448774

## Why This Is Needed

This is needed to fix the eks tf sample

## What Changed

I implemented the workaround proposed at https://github.com/terraform-aws-modules/terraform-aws-eks/issues/733#issuecomment-584448774, namely pin the kubernetes provider version to "~> 1.10.0"
