### PR TITLE
fix terraform integration tests

### DIFF
--- a/integration_test_infrastructure/codebuild/common/codebuild_blueprints/codebuild.py
+++ b/integration_test_infrastructure/codebuild/common/codebuild_blueprints/codebuild.py
@@ -78,6 +78,24 @@ class CodeBuild(Blueprint):
                             Name='TEST_TO_RUN',
                             Type='PLAINTEXT',
                             Value=test_name.lower()
+                        ),
+                        codebuild.EnvironmentVariable(
+                            # Disable emojis in output.
+                            Name='PIPENV_HIDE_EMOJIS',
+                            Type='PLAINTEXT',
+                            Value='1'
+                        ),
+                        codebuild.EnvironmentVariable(
+                            # disable terminal spinner.
+                            Name='PIPENV_NOSPIN',
+                            Type='PLAINTEXT',
+                            Value='1'
+                        ),
+                        codebuild.EnvironmentVariable(
+                            # Pipenv automatically assumes “yes” at all prompts.
+                            Name='PIPENV_YES',
+                            Type='PLAINTEXT',
+                            Value='1'
                         )
                     ],
                     Image='aws/codebuild/standard:2.0',

--- a/integration_tests/Pipfile
+++ b/integration_tests/Pipfile
@@ -8,7 +8,6 @@ runway = {editable = true, path = "./.."}
 prettytable = "*"
 colorama = "<=0.3.9,>=0.2.5"
 pexpect = "*"
-stacker = "==1.7.0"
 
 [dev-packages]
 

--- a/integration_tests/Pipfile
+++ b/integration_tests/Pipfile
@@ -8,6 +8,7 @@ runway = {editable = true, path = "./.."}
 prettytable = "*"
 colorama = "<=0.3.9,>=0.2.5"
 pexpect = "*"
+stacker = "==1.7.0"
 
 [dev-packages]
 

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e5145f9561c7434d4360785e38ee48def64a534a7104b099aae2273c30158009"
+            "sha256": "9ea97eb3b96a119de6f7c28fe9b7524a030c44e5929cdbfb687dc376ab5d7277"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,24 +37,24 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:4c49f085fb827ca1aeba5e6e5e39f6005110a0059b5c772aeb1d51c4f33c4028",
-                "sha256:9459ac705c2a5d8724057492800c52084df714b624853eb3331087ecf8726a22"
+                "sha256:75b58f3b0c3fbbf84a465903bc0414f53860aa0e588b7f77f376ba89fd6662fa",
+                "sha256:baaa1a6f920f533cfed2742fc1bc5c060ba4c7c2fd089b45484e1679d50c8628"
             ],
-            "version": "==1.17.9"
+            "version": "==1.17.15"
         },
         "boto3": {
             "hashes": [
-                "sha256:05f7ae180813fbf11cb7397b43b6bd29463abdc246bee58127836f1a8f6a9a2f",
-                "sha256:3480c87b530e7f41d9264a6725dda68208de2697822cf02cd3a541b001872410"
+                "sha256:0b9dc594e16a96ed7c6f37e1563ab3f113f130b3cc79efe8eea43097bf87fccb",
+                "sha256:e48ff93a3b6424c65675e1cbe08f7f3245b0128d1c27115cdcf51d432e9767d6"
             ],
-            "version": "==1.11.9"
+            "version": "==1.11.15"
         },
         "botocore": {
             "hashes": [
-                "sha256:1909424c9544f92142c8e551888731e32a99f9c99cfe8d21fea3ec0c32981dae",
-                "sha256:e3e3c0f59dc30c86dd2116aece3bd554f8476446cf1c5770bbf5111993d676c8"
+                "sha256:2538065f9f5023eae3607e78fc5d8c595c9173ec02bc92410652078617c44ac1",
+                "sha256:554231b1690c8521e05a41e50184e43d62941fdf9351e658aea894649b879985"
             ],
-            "version": "==1.14.9"
+            "version": "==1.14.15"
         },
         "certifi": {
             "hashes": [
@@ -65,41 +65,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
-                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
-                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
-                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
-                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
-                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
-                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
-                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
-                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
-                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
-                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
-                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
-                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
-                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
-                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
-                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
-                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
-                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
-                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
-                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
-                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
-                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
-                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
-                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
-                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
-                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
-                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
-                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
-                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
-                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
-                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
-                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
-                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
             ],
-            "version": "==1.13.2"
+            "version": "==1.14.0"
         },
         "cfn-flip": {
             "hashes": [
@@ -110,10 +105,10 @@
         },
         "cfn-lint": {
             "hashes": [
-                "sha256:07aa493be259f90a77f590213d26df9e834d003843c4dafc026d730055ba54a9",
-                "sha256:085ded355f11278c14a1c45335e27f81b2a31e6c3eb9ec288a2b39ec813829b4"
+                "sha256:685af38cc0d4f2db1f4efedda56df5bb04fdcf47fdae99a34a481c379cca2082",
+                "sha256:f16cdcbd7603fc81b55b4ad341f3456ec4d9ed05efb5952e243c609a0d5e2f39"
             ],
-            "version": "==0.27.4"
+            "version": "==0.27.5"
         },
         "chardet": {
             "hashes": [
@@ -408,10 +403,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:2525bae2a530195576da53671bae8ca8c55ee8e33bc2225a65e804476611ea5a",
-                "sha256:4924e10451cc37901945806423d16c2c2040a6530645a614ed87e995ccec764c"
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
             ],
-            "version": "==0.3.2"
+            "version": "==0.3.3"
         },
         "schematics": {
             "hashes": [
@@ -441,6 +436,13 @@
             ],
             "version": "==2.0.5"
         },
+        "stacker": {
+            "hashes": [
+                "sha256:fb8d519a88758eae6c236b859fc2aff658c8cfa2df2666c68eece9b09cd36339"
+            ],
+            "index": "pypi",
+            "version": "==1.7.0"
+        },
         "troposphere": {
             "hashes": [
                 "sha256:fbf3592fb0559102e2abf15aa26cadbeced3390565ee294e6df0fb2d421bf759"
@@ -452,6 +454,7 @@
                 "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
                 "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==1.24.3"
         },
         "yamllint": {

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9ea97eb3b96a119de6f7c28fe9b7524a030c44e5929cdbfb687dc376ab5d7277"
+            "sha256": "e5145f9561c7434d4360785e38ee48def64a534a7104b099aae2273c30158009"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,24 +37,24 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:75b58f3b0c3fbbf84a465903bc0414f53860aa0e588b7f77f376ba89fd6662fa",
-                "sha256:baaa1a6f920f533cfed2742fc1bc5c060ba4c7c2fd089b45484e1679d50c8628"
+                "sha256:20967a2001be195ff426b9e308f1b732eaf9eb40444508225af0a6d2413581dd",
+                "sha256:bd0d2f37c38854989ccddd7890153980b3fdd72c8711fb07884450b54723c35c"
             ],
-            "version": "==1.17.15"
+            "version": "==1.17.16"
         },
         "boto3": {
             "hashes": [
-                "sha256:0b9dc594e16a96ed7c6f37e1563ab3f113f130b3cc79efe8eea43097bf87fccb",
-                "sha256:e48ff93a3b6424c65675e1cbe08f7f3245b0128d1c27115cdcf51d432e9767d6"
+                "sha256:2cb3063d347c0d06f96dcd10d69247d3e3d12eda4b1ed9fdec62ac25c7fee8b6",
+                "sha256:5bffdfc7d3465f053db38a64821fbeb1f8044ffafb71c90587f1c293d334305f"
             ],
-            "version": "==1.11.15"
+            "version": "==1.11.16"
         },
         "botocore": {
             "hashes": [
-                "sha256:2538065f9f5023eae3607e78fc5d8c595c9173ec02bc92410652078617c44ac1",
-                "sha256:554231b1690c8521e05a41e50184e43d62941fdf9351e658aea894649b879985"
+                "sha256:63dc203046e47573add16c348f00a8e2fe3bb4975323458787e7b2bebeec5923",
+                "sha256:d31d7e0e12fb64d6bd331c6b853750c71423d560cee01a989f607dd45407ef65"
             ],
-            "version": "==1.14.15"
+            "version": "==1.14.16"
         },
         "certifi": {
             "hashes": [
@@ -435,13 +435,6 @@
                 "sha256:29a9ffa0497e7f2be94ca0ed1ca1aa3cd4cf25a1f6b4f5f87f74b46ed91d609a"
             ],
             "version": "==2.0.5"
-        },
-        "stacker": {
-            "hashes": [
-                "sha256:fb8d519a88758eae6c236b859fc2aff658c8cfa2df2666c68eece9b09cd36339"
-            ],
-            "index": "pypi",
-            "version": "==1.7.0"
         },
         "troposphere": {
             "hashes": [

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -98,9 +98,11 @@ class IntegrationTest(object):
         with change_dir(self.working_dir):
             cmd_process = subprocess.Popen(cmd, env=env_vars or self.environment,
                                            stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE)
+                                           stderr=subprocess.PIPE,
+                                           universal_newlines=True)
             stdout, stderr = cmd_process.communicate(timeout=timeout)
-        return cmd_process.returncode, stdout.decode(), stderr.decode()
+            print(stderr)
+        return cmd_process.returncode, stdout, stderr
 
     def set_environment(self, env):
         """Set deploy environment."""

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -72,7 +72,7 @@ class IntegrationTest(object):
         with open(path) as data_file:
             return yaml.safe_load(data_file)
 
-    def runway_cmd(self, action, env_vars=None, tags=None, timeout=300, *args):
+    def runway_cmd(self, action, env_vars=None, tags=None, timeout=900, *args):
         """Run a deploy command based on tags.
 
         Args:

--- a/integration_tests/test_terraform/policies.yaml
+++ b/integration_tests/test_terraform/policies.yaml
@@ -1,6 +1,13 @@
 ---
 - Version: '2012-10-17'
   Statement:
+    - Sid: DoesNotSupportResourceLevelPermissions
+      Effect: Allow
+      Action:
+        - s3:HeadBucket
+        - sqs:ListQueues
+      Resource:
+        - '*'
     - Effect: Allow
       Action:
         - 'cloudformation:CreateStack'
@@ -10,24 +17,28 @@
         - 'cloudformation:DescribeChangeSet'
         - 'cloudformation:DeleteChangeSet'
       Resource: 'arn:aws:cloudformation:*:*:stack/testsuite-tf-state*'
-    - Effect: Allow
+    - Sid: S3BucketPermissions
+      Effect: Allow
       Action:
-        - 's3:HeadBucket'
-        - 's3:ListBucket'
-        - 's3:ListBucketVersions'
-        - 's3:GetBucketVersioning'
+        - s3:ListBucket
+        - s3:ListBucketVersions
+        - s3:GetBucketVersioning
+        - s3:CreateBucket
+        - s3:PutLifecycleConfiguration
+        - s3:PutBucketVersioning
+        - s3:DeleteBucket
+      Resource:
+        - arn:aws:s3:::testsuite-tf-state*
+    - Sid: S3ObjectPermissions
+      Effect: Allow
+      Action:
         - 's3:GetObject'
         - 's3:GetObjectVersion'
-        - 's3:CreateBucket'
-        - 's3:PutLifecycleConfiguration'
-        - 's3:PutBucketVersioning'
         - 's3:PutObject'
-        - 's3:DeleteBucket'
         - 's3:DeleteObjectVersion'
         - 's3:DeleteObject'
-      Resource: 
-        - 'arn:aws:s3:::testsuite-tf-state'
-        - 'arn:aws:s3:::testsuite-tf-state/*'
+      Resource:
+        - 'arn:aws:s3:::testsuite-tf-state*/*'
     - Effect: Allow
       Action:
         - 'dynamodb:CreateTable'
@@ -36,16 +47,17 @@
         - 'dynamodb:DeleteTable'
         - 'dynamodb:PutItem'
         - 'dynamodb:DeleteItem'
+        - dynamodb:TagResource
+        - dynamodb:UntagResource
       Resource: 'arn:aws:dynamodb:*:*:table/testsuite-tf-state-TerraformLockTable*'
     - Effect: Allow
       Action:
         - 'sqs:CreateQueue'
         - 'sqs:DeleteQueue'
         - 'sqs:SetQueueAttributes'
-        - 'sqs:ListQueues'
         - 'sqs:GetQueueAttributes'
         - 'sqs:GetQueueUrl'
         - 'sqs:ListQueueTags'
         - 'sqs:TagQueue'
-      Resource: 
+      Resource:
         - 'arn:aws:sqs:*:*:terraform*'

--- a/integration_tests/test_terraform/templates/runway-state.yml
+++ b/integration_tests/test_terraform/templates/runway-state.yml
@@ -1,0 +1,7 @@
+deployments:
+  - modules:
+      - tf_state.cfn
+    regions:
+      - us-east-1
+    parameters:
+      namespace: testsuite

--- a/integration_tests/test_terraform/test_terraform.py
+++ b/integration_tests/test_terraform/test_terraform.py
@@ -61,19 +61,10 @@ class Terraform(IntegrationTest):
         if not tests:
             raise Exception('No tests were found.')
         self.logger.debug('FOUND TESTS: %s', tests)
-
-        # deploy tf state bucket
-        self.copy_runway('state')
-        code, _stdout, _stderr = self.runway_cmd('deploy')
-        assert code == 0, 'exit code should be zero'
-
         err_count = execute_tests(tests, self.logger)
         assert err_count == 0  # assert that all subtests were successful
         return err_count
 
     def teardown(self):
         """Teardown resources create during init."""
-        self.copy_runway('state')
-        code, _stdout, _stderr = self.runway_cmd('destroy')
-        assert code == 0, 'exit code should be zero'
         self.clean()

--- a/integration_tests/test_terraform/test_terraform.py
+++ b/integration_tests/test_terraform/test_terraform.py
@@ -1,14 +1,11 @@
 """Tests for Terraform."""
-from __future__ import print_function
-import os
 import glob
-import platform
+import os
+
 from send2trash import send2trash
-from runway.util import change_dir
 
 from integration_tests.integration_test import IntegrationTest
-from integration_tests.util import (copy_file, import_tests,
-                                    execute_tests, run_command)
+from integration_tests.util import copy_file, execute_tests, import_tests
 
 
 class Terraform(IntegrationTest):
@@ -16,7 +13,6 @@ class Terraform(IntegrationTest):
 
     base_dir = os.path.abspath(os.path.dirname(__file__))
     template_dir = os.path.join(base_dir, 'templates')
-    tests_dir = os.path.join(base_dir, 'tests')
 
     tf_test_dir = os.path.join(base_dir, 'terraform_test.tf')
     tf_state_dir = os.path.join(base_dir, 'tf_state.cfn')
@@ -50,45 +46,34 @@ class Terraform(IntegrationTest):
                 self.logger.debug('send2trash: "%s"', folder_path)
                 send2trash(folder_path)
 
-        # destroy stacker tf-state
-        self.run_stacker('destroy')
-
     def set_tf_version(self, version=11):
         """Copy version file to module directory."""
         version_file = 'tf-v{}.version'.format(version)
         self.copy_template(version_file, '.terraform-version')
 
-    def run_stacker(self, command='build'):
-        """Deploys the CFN module to create S3 and DynamoDB resources."""
-        if command not in ('build', 'destroy'):
-            raise ValueError('run_stacker: command must be one of %s' % ['build', 'destroy'])
-
-        self.logger.info('Running "%s" on tf_state.cfn ...', command)
-        self.logger.debug('tf_state_dir: %s', self.tf_state_dir)
-        with change_dir(self.tf_state_dir):
-            stacker_cmd = ['stacker.cmd' if platform.system().lower() == 'windows' else 'stacker',
-                           command, '-i', '-r', 'us-east-1']
-            if command == 'destroy':
-                stacker_cmd = stacker_cmd + ['-f']
-            stacker_cmd = stacker_cmd + ['dev-us-east-1.env', 'tfstate.yaml']
-            self.logger.debug('STACKER_CMD: %s', stacker_cmd)
-            cmd_opts = {'cmd_list': stacker_cmd}
-            return run_command(**cmd_opts) # noqa
-
     def run(self):
         """Find all Terraform tests and run them."""
         import_tests(self.logger, self.tests_dir, 'test_*')
-        tests = [test(self.logger) for test in Terraform.__subclasses__()]
+        self.set_environment('dev')
+        self.set_env_var('CI', '1')
+        tests = [test(self.logger, self.environment)
+                 for test in Terraform.__subclasses__()]
         if not tests:
             raise Exception('No tests were found.')
         self.logger.debug('FOUND TESTS: %s', tests)
-        self.set_environment('dev')
-        self.set_env_var('CI', '1')
+
+        # deploy tf state bucket
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('deploy')
+        assert code == 0, 'exit code should be zero'
+
         err_count = execute_tests(tests, self.logger)
         assert err_count == 0  # assert that all subtests were successful
         return err_count
 
     def teardown(self):
         """Teardown resources create during init."""
-        self.unset_env_var('CI')
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('destroy')
+        assert code == 0, 'exit code should be zero'
         self.clean()

--- a/integration_tests/test_terraform/tests/test_local_to_local_backend.py
+++ b/integration_tests/test_terraform/tests/test_local_to_local_backend.py
@@ -1,7 +1,5 @@
 """Test changing backends between local and local."""
-from runway.util import change_dir
 from integration_tests.test_terraform.test_terraform import Terraform
-from integration_tests.util import run_command
 
 
 class LocalToLocalBackend(Terraform):
@@ -13,15 +11,13 @@ class LocalToLocalBackend(Terraform):
         """Deploy provider."""
         self.copy_template('{}-backend.tf'.format(backend))
         self.copy_runway('nos3')
-
-        with change_dir(self.base_dir):
-            return run_command(['runway', 'deploy'])
+        code, _stdout, _stderr = self.runway_cmd('deploy')
+        return code
 
     def run(self):
         """Run tests."""
         self.clean()
         self.set_tf_version(11)
-        self.set_env_var('CI', '1')
 
         assert self.deploy_backend('no') == 0,\
             '{}: "No local backend" failed'.format(self.TEST_NAME)
@@ -32,7 +28,6 @@ class LocalToLocalBackend(Terraform):
     def teardown(self):
         """Teardown any created resources."""
         self.logger.info('Tearing down: %s', self.TEST_NAME)
-        with change_dir(self.base_dir):
-            run_command(['runway', 'destroy'])
-        self.unset_env_var('CI')
+        code, _stdout, _stderr = self.runway_cmd('destroy')
+        assert code == 0, 'exit code should be zero'
         self.clean()

--- a/integration_tests/test_terraform/tests/test_local_to_s3_backend.py
+++ b/integration_tests/test_terraform/tests/test_local_to_s3_backend.py
@@ -22,6 +22,11 @@ class LocalToS3Backend(Terraform):
         self.clean()
         self.set_tf_version(11)
 
+        # deploy tf state bucket
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('deploy')
+        assert code == 0, 'exit code should be zero'
+
         assert self.deploy_backend('local') == 0, '{}: Local backend failed'.format(__name__)
         assert self.deploy_backend('s3') == 0, '{}: S3 backend failed'.format(__name__)
 
@@ -30,4 +35,10 @@ class LocalToS3Backend(Terraform):
         self.logger.info('Tearing down: %s', self.TEST_NAME)
         code, _stdout, _stderr = self.runway_cmd('destroy')
         assert code == 0, 'exit code should be zero'
+
+        # destroy tf state bucket
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('destroy')
+        assert code == 0, 'exit code should be zero'
+
         self.clean()

--- a/integration_tests/test_terraform/tests/test_provider.py
+++ b/integration_tests/test_terraform/tests/test_provider.py
@@ -1,7 +1,5 @@
 """Test changing provider versions."""
-from runway.util import change_dir
 from integration_tests.test_terraform.test_terraform import Terraform
-from integration_tests.util import run_command
 
 
 class ProviderTest(Terraform):
@@ -13,15 +11,13 @@ class ProviderTest(Terraform):
         """Deploy provider."""
         self.copy_template('provider-version{}.tf'.format(version))
         self.copy_runway('s3')
-        with change_dir(self.base_dir):
-            return run_command(['runway', 'deploy'])
+        code, _stdout, _stderr = self.runway_cmd('deploy')
+        return code
 
     def run(self):
         """Run tests."""
         self.clean()
-        self.run_stacker()
         self.set_tf_version(11)
-        self.set_env_var('CI', '1')
 
         assert self.deploy_provider(1) == 0, '{}: Provider version 1 failed'.format(__name__)
         assert self.deploy_provider(2) == 0, '{}: Provider version 2 failed'.format(__name__)
@@ -29,7 +25,6 @@ class ProviderTest(Terraform):
     def teardown(self):
         """Teardown any created resources."""
         self.logger.info('Tearing down: %s', self.TEST_NAME)
-        with change_dir(self.base_dir):
-            run_command(['runway', 'destroy'])
-        self.unset_env_var('CI')
+        code, _stdout, _stderr = self.runway_cmd('destroy')
+        assert code == 0, 'exit code should be zero'
         self.clean()

--- a/integration_tests/test_terraform/tests/test_provider.py
+++ b/integration_tests/test_terraform/tests/test_provider.py
@@ -19,6 +19,11 @@ class ProviderTest(Terraform):
         self.clean()
         self.set_tf_version(11)
 
+        # deploy tf state bucket
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('deploy')
+        assert code == 0, 'exit code should be zero'
+
         assert self.deploy_provider(1) == 0, '{}: Provider version 1 failed'.format(__name__)
         assert self.deploy_provider(2) == 0, '{}: Provider version 2 failed'.format(__name__)
 
@@ -27,4 +32,10 @@ class ProviderTest(Terraform):
         self.logger.info('Tearing down: %s', self.TEST_NAME)
         code, _stdout, _stderr = self.runway_cmd('destroy')
         assert code == 0, 'exit code should be zero'
+
+        # destroy tf state bucket
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('destroy')
+        assert code == 0, 'exit code should be zero'
+
         self.clean()

--- a/integration_tests/test_terraform/tests/test_version.py
+++ b/integration_tests/test_terraform/tests/test_version.py
@@ -19,6 +19,11 @@ class VersionTest(Terraform):
         """Run tests."""
         self.clean()
 
+        # deploy tf state bucket
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('deploy')
+        assert code == 0, 'exit code should be zero'
+
         assert self.deploy_version(11) == 0, '{}: Terraform version 11 failed'.format(__name__)
         assert self.deploy_version(12) == 0, '{}: Terraform version 12 failed'.format(__name__)
 
@@ -27,4 +32,10 @@ class VersionTest(Terraform):
         self.logger.info('Tearing down: %s', self.TEST_NAME)
         code, _stdout, _stderr = self.runway_cmd('destroy')
         assert code == 0, 'exit code should be zero'
+
+        # destroy tf state bucket
+        self.copy_runway('state')
+        code, _stdout, _stderr = self.runway_cmd('destroy')
+        assert code == 0, 'exit code should be zero'
+
         self.clean()

--- a/integration_tests/test_terraform/tf_state.cfn/dev-us-east-1.env
+++ b/integration_tests/test_terraform/tf_state.cfn/dev-us-east-1.env
@@ -1,2 +1,0 @@
-namespace: testsuite
-region: us-east-1

--- a/integration_tests/test_terraform/tf_state.cfn/tfstate.yaml
+++ b/integration_tests/test_terraform/tf_state.cfn/tfstate.yaml
@@ -6,8 +6,6 @@ sys_path: ./
 stacks:
   tf-state:
     template_path: templates/tf_state.yaml
-    variables:
-      # BucketName: ${namespace}-tf-state
 
 pre_destroy:
   - path: runway.hooks.cleanup_s3.purge_bucket


### PR DESCRIPTION
## Why This Is Needed

```
Traceback (most recent call last):
--
133 | File "run_test.py", line 20, in <module>
134 | sys.exit(RUNNER.main())
135 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/runner.py", line 48, in main
136 | errs = self.run_tests()
137 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/runner.py", line 44, in run_tests
138 | self.logger)
139 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/util.py", line 56, in execute_tests
140 | test.run()
141 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/test_terraform/test_terraform.py", line 87, in run
142 | err_count = execute_tests(tests, self.logger)
143 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/util.py", line 56, in execute_tests
144 | test.run()
145 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/test_terraform/tests/test_version.py", line 22, in run
146 | self.clean()
147 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/test_terraform/test_terraform.py", line 54, in clean
148 | self.run_stacker('destroy')
149 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/test_terraform/test_terraform.py", line 76, in run_stacker
150 | return run_command(**cmd_opts) # noqa
151 | File "/codebuild/output/src581795159/src/github.com/onicagroup/runway/integration_tests/util.py", line 14, in run_command
152 | subprocess.check_call(cmd_list, env=env_vars)
153 | File "/usr/local/lib/python3.7/subprocess.py", line 342, in check_call
154 | retcode = call(*popenargs, **kwargs)
155 | File "/usr/local/lib/python3.7/subprocess.py", line 323, in call
156 | with Popen(*popenargs, **kwargs) as p:
157 | File "/usr/local/lib/python3.7/subprocess.py", line 775, in __init__
158 | restore_signals, start_new_session)
159 | File "/usr/local/lib/python3.7/subprocess.py", line 1522, in _execute_child
160 | raise child_exception_type(errno_num, err_msg, err_filename)
161 | FileNotFoundError: [Errno 2] No such file or directory: 'stacker': 'stacker
```

## What Changed

### Added

- pipenv environment variables to codebuild to reduce spam in the logs

### Changed

- tf tests to use runway instead of stacker
- updated tf tests to use newer parent methods for invoking runway commands
- `runway_cmd` method now prints `stderr` for every invocation. This is not realtime since we need to use a `PIPE` to collect it for assertions.

### Fixed

- test permissions

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/74390363-e125ed80-4db5-11ea-92e8-d6f254338109.png)
