### PR TITLE
fix command integration tests

### DIFF
--- a/integration_tests/test_commands/policies.yaml
+++ b/integration_tests/test_commands/policies.yaml
@@ -1,0 +1,8 @@
+---
+- Version: '2012-10-17'
+  Statement:
+    - Effect: Allow
+      Action:
+        - '*'
+      Resource:
+        - '*'

--- a/integration_tests/test_commands/test_commands.py
+++ b/integration_tests/test_commands/test_commands.py
@@ -15,8 +15,10 @@ class Commands(IntegrationTest):
         """Find all tests and run them."""
         suffix = os.getenv('COMMAND_SUFFIX', '*')
         pattern = 'test_{0}'.format(suffix)
+        self.set_env_var('AWS_DEFAULT_REGION', 'us-east-1')
         import_tests(self.logger, self.tests_dir, pattern)
-        tests = [test(self.logger) for test in Commands.__subclasses__()]
+        tests = [test(self.logger, self.environment)
+                 for test in Commands.__subclasses__()]
         if not tests:
             raise Exception('No tests were found.')
         self.logger.debug('FOUND TESTS: %s', tests)

--- a/integration_tests/test_commands/tests/test_stacker.py
+++ b/integration_tests/test_commands/tests/test_stacker.py
@@ -5,7 +5,6 @@ import boto3
 
 from integration_tests.test_commands.test_commands import Commands
 
-CLIENT = boto3.client('ssm')
 KEY = "/runway/integration-test/stacker"
 VALUE = "foo"
 
@@ -36,7 +35,9 @@ class TestRunStacker(Commands):
              'build',
              'stack.yaml'],
             cwd=path).decode()
-        parameter = CLIENT.get_parameter(Name=KEY)
+        client = boto3.client('ssm',
+                              region_name=self.environment['AWS_DEFAULT_REGION'])
+        parameter = client.get_parameter(Name=KEY)
         assert parameter['Parameter']['Value'] == VALUE
 
     def teardown(self):


### PR DESCRIPTION
## Why This Is Needed

- tests were failing locally if `AWS_DEFAULT_REGION` is not `us-east-1`
- tests did not have permissions to run successfully

## What Changed

### Added

- permissions policy to allow tests to succeed

### Fixed

- local test invocation using the correct region for boto3 clients

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/74462366-f72ebf00-4e44-11ea-9c16-395796b23ee7.png)


