### PR TITLE
fix region selection when parallel_regions but not CI

### DIFF
--- a/integration_tests/test_parallelism/test_parallelism.py
+++ b/integration_tests/test_parallelism/test_parallelism.py
@@ -33,11 +33,12 @@ class Parallelism(IntegrationTest):
     def run(self):
         """Find all tests and run them."""
         import_tests(self.logger, self.tests_dir, 'test_*')
-        tests = [test(self.logger) for test in Parallelism.__subclasses__()]
+        self.set_environment('dev')
+        tests = [test(self.logger, self.environment)
+                 for test in Parallelism.__subclasses__()]
         if not tests:
             raise Exception('No tests were found.')
         self.logger.debug('FOUND TESTS: %s', tests)
-        self.set_environment('dev')
         err_count = execute_tests(tests, self.logger)
         assert err_count == 0
         return err_count

--- a/integration_tests/test_parallelism/tests/test_default_to_series.py
+++ b/integration_tests/test_parallelism/tests/test_default_to_series.py
@@ -20,7 +20,6 @@ class TestDefaultToSeries(Parallelism):
     def run(self):
         """Run tests."""
         self.clean()
-        self.set_environment('dev')
         assert self.deploy() == 0, '{}: Default to series failed'.format(__name__)
 
     def teardown(self):
@@ -30,4 +29,3 @@ class TestDefaultToSeries(Parallelism):
         with change_dir(self.parallelism_test_dir):
             run_command(['runway', 'destroy'])
         self.clean()
-        self.unset_env_var('CI')

--- a/integration_tests/test_parallelism/tests/test_two_regions.py
+++ b/integration_tests/test_parallelism/tests/test_two_regions.py
@@ -20,7 +20,6 @@ class TestTwoRegions(Parallelism):
     def run(self):
         """Run tests."""
         self.clean()
-        self.set_environment('dev')
         self.set_env_var('CI', '1')
         assert self.deploy() == 0, '{}: Two regions deployed in parallel failed'.format(__name__)
 
@@ -30,4 +29,3 @@ class TestTwoRegions(Parallelism):
         with change_dir(self.parallelism_test_dir):
             run_command(['runway', 'destroy'])
         self.clean()
-        self.unset_env_var('CI')

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -487,19 +487,21 @@ class ModulesCommand(RunwayCommand):
                         job.result()  # Raise exceptions / exit as needed
                     return
 
+                # single var to reduce comparisons
+                regions = deployment.parallel_regions or deployment.regions
+
                 if deployment.parallel_regions:
                     LOGGER.info(
                         '%s - processing the regions sequentially...',
                         ('Not running in CI mode' if sys.version_info[0] > 2
                          else 'Parallel execution requires Python 3+')
                     )
-                    deployment.regions += deployment.parallel_regions
 
                 LOGGER.info("Attempting to deploy '%s' to region(s): %s",
                             context.env_name,
-                            ", ".join(deployment.regions))
+                            ", ".join(regions))
 
-                for region in deployment.regions:
+                for region in regions:
                     LOGGER.info("")
                     LOGGER.info("======= Processing region %s ================"
                                 "===========", region)


### PR DESCRIPTION
## Why This Is Needed

```
INFO:runway:Not running in CI mode - processing the regions sequentially...
--
138 | Traceback (most recent call last):
139 | File "/root/.local/share/virtualenvs/integration_tests-iRVvH5_P/bin/runway", line 11, in <module>
140 | load_entry_point('runway', 'console_scripts', 'runway')()
141 | File "/codebuild/output/src430919845/src/github.com/onicagroup/runway/runway/cli.py", line 84, in main
142 | command_class(cli_arguments).execute()
143 | File "/codebuild/output/src430919845/src/github.com/onicagroup/runway/runway/commands/modules/deploy.py", line 55, in execute
144 | self.run(deployments=None, command='deploy')
145 | File "/codebuild/output/src430919845/src/github.com/onicagroup/runway/runway/commands/modules_command.py", line 424, in run
146 | self._process_deployments(deployments_to_run, context)
147 | File "/codebuild/output/src430919845/src/github.com/onicagroup/runway/runway/commands/modules_command.py", line 496, in _process_deployments
148 | deployment.regions += deployment.parallel_regions
149 | AttributeError: can't set attribute
```

## What Changed

### Changed

- parallel integration tests to use improved env var handling

### Fixed

- region selection when `parallel_regions` but not `CI`. this was introduced by #116 

## Screenshots

_Please include screenshots of any new features to show how it works._
![image](https://user-images.githubusercontent.com/23145462/74464643-c05aa800-4e48-11ea-91de-490381b70b45.png)

