### PR TITLE
fix staticsite int tests missing dir

### DIFF
--- a/integration_tests/test_staticsite/policies.yaml
+++ b/integration_tests/test_staticsite/policies.yaml
@@ -1,0 +1,8 @@
+---
+- Version: '2012-10-17'
+  Statement:
+    - Effect: Allow
+      Action:
+        - '*'
+      Resource:
+        - '*'

--- a/integration_tests/test_staticsite/test_staticsite.py
+++ b/integration_tests/test_staticsite/test_staticsite.py
@@ -32,12 +32,13 @@ class StaticSite(IntegrationTest):
     def run(self):
         """Find all tests and run them."""
         import_tests(self.logger, self.tests_dir, 'test_*')
-        tests = [test(self.logger) for test in StaticSite.__subclasses__()]
+        self.set_environment('dev')
+        self.set_env_var('PIPENV_VENV_IN_PROJECT', '1')
+        tests = [test(self.logger, self.environment)
+                 for test in StaticSite.__subclasses__()]
         if not tests:
             raise Exception('No tests were found.')
         self.logger.debug('FOUND TESTS: %s', tests)
-        self.set_environment('dev')
-        self.set_env_var('PIPENV_VENV_IN_PROJECT', '1')
         err_count = execute_tests(tests, self.logger)
         assert err_count == 0  # assert that all subtests were successful
         return err_count
@@ -58,6 +59,9 @@ class StaticSite(IntegrationTest):
             if os.path.isdir(folder_path):
                 self.logger.debug('send2trash: "%s"', folder_path)
                 send2trash(folder_path)
+        if os.path.isdir(folder_path):
+            self.logger.debug('send2trash: "%s"', self.staticsite_test_dir)
+            send2trash(self.staticsite_test_dir)
 
     def delete_venv(self, module_directory):
         """Delete pipenv venv before running destroy."""
@@ -69,5 +73,4 @@ class StaticSite(IntegrationTest):
 
     def teardown(self):
         """Teardown resources create during init."""
-        self.unset_env_var('PIPENV_VENV_IN_PROJECT')
         self.clean()

--- a/integration_tests/test_staticsite/tests/test_basic_site.py
+++ b/integration_tests/test_staticsite/tests/test_basic_site.py
@@ -1,4 +1,6 @@
 """Test deploying a base line static site."""
+import os
+
 from runway.util import change_dir
 
 from integration_tests.test_staticsite.test_staticsite import StaticSite
@@ -13,7 +15,9 @@ class TestBasicSite(StaticSite):
 
     def deploy(self):
         """Deploy provider."""
-        self.copy_fixture(self.module_dir)
+        os.mkdir(self.staticsite_test_dir)
+        os.mkdir(os.path.join(self.staticsite_test_dir, self.module_dir))
+        os.mkdir(os.path.join(self.staticsite_test_dir, self.module_dir, 'build'))
         self.copy_runway('basic-site')
         with change_dir(self.staticsite_test_dir):
             return run_command(['runway', 'deploy'])
@@ -30,4 +34,3 @@ class TestBasicSite(StaticSite):
         with change_dir(self.staticsite_test_dir):
             run_command(['runway', 'destroy'])
         self.clean()
-        self.unset_env_var('CI')


### PR DESCRIPTION
## Why This Is Needed

```
Traceback (most recent call last):
--
65 | File "run_test.py", line 20, in <module>
66 | sys.exit(RUNNER.main())
67 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/runner.py", line 48, in main
68 | errs = self.run_tests()
69 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/runner.py", line 44, in run_tests
70 | self.logger)
71 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/util.py", line 56, in execute_tests
72 | test.run()
73 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/test_staticsite/test_staticsite.py", line 41, in run
74 | err_count = execute_tests(tests, self.logger)
75 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/util.py", line 56, in execute_tests
76 | test.run()
77 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/test_staticsite/tests/test_basic_site.py", line 25, in run
78 | assert self.deploy() == 0, '{}: Basic Site failed'.format(__name__)
79 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/test_staticsite/tests/test_basic_site.py", line 17, in deploy
80 | self.copy_runway('basic-site')
81 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/test_staticsite/test_staticsite.py", line 30, in copy_runway
82 | copy_file(template_file, os.path.join(self.staticsite_test_dir, 'runway.yml'))
83 | File "/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/util.py", line 87, in copy_file
84 | shutil.copy(src, dest)
85 | File "/root/.local/share/virtualenvs/integration_tests-qgHwQGFa/lib/python3.7/shutil.py", line 248, in copy
86 | copyfile(src, dst, follow_symlinks=follow_symlinks)
87 | File "/root/.local/share/virtualenvs/integration_tests-qgHwQGFa/lib/python3.7/shutil.py", line 121, in copyfile
88 | with open(dst, 'wb') as fdst:
89 | FileNotFoundError: [Errno 2] No such file or directory: '/codebuild/output/src997986034/src/github.com/onicagroup/runway/integration_tests/test_staticsite/staticsite_test/runway.yml'
```

## What Changed

### Added

- permissions for staticsite integration tests

### Changed

- test now creates the missing dir

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/74470930-3c0e2200-4e54-11ea-8e65-b6ecab75bfd1.png)

