### PR TITLE
fix sls race condition when trying to create & encrypt promotezip bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - pinned `zipp` sub dependency to `~=1.0.0` to retain support for python 3.5
 - `PyYAML` dependency is now `>=4.1,<5.3` to match the top-end of newer versions of `awscli`
+- `NoSuchBucket` during `PutBucketEncryption` when sls tries to create a `promotezip` bucket
 
 ## [1.3.7] - 2020-01-07
 ### Fixed

--- a/runway/s3_util.py
+++ b/runway/s3_util.py
@@ -80,6 +80,11 @@ def ensure_bucket_exists(bucket_name, region='us-east-1', session=None):
             }
         s3_client.create_bucket(Bucket=bucket_name, **create_bucket_opts)
 
+        # sometimes when creating the bucket it can take a few moments before
+        # it is ready to add the encryption settings.
+        bucket_waiter = s3_client.get_waiter('bucket_exists')
+        bucket_waiter.wait(Bucket=bucket_name)
+
         # enable default encryption
         s3_client.put_bucket_encryption(Bucket=bucket_name,
                                         ServerSideEncryptionConfiguration={


### PR DESCRIPTION
## Why This Is Needed

This error presents itself in our integration tests causing every other invocation to fail.

```
Traceback (most recent call last):
--
94 | File "/root/.local/share/virtualenvs/integration_tests-4Kxyk61_/bin/runway", line 11, in <module>
95 | load_entry_point('runway', 'console_scripts', 'runway')()
96 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/cli.py", line 84, in main
97 | command_class(cli_arguments).execute()
98 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/commands/modules/deploy.py", line 55, in execute
99 | self.run(deployments=None, command='deploy')
100 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/commands/modules_command.py", line 370, in run
101 | self._process_deployments(deployments_to_run, context)
102 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/commands/modules_command.py", line 455, in _process_deployments
103 | self._execute_deployment(deployment, context, region)
104 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/commands/modules_command.py", line 477, in _execute_deployment
105 | self._process_modules(deployment, context)
106 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/commands/modules_command.py", line 515, in _process_modules
107 | self._deploy_module(module, deployment, context)
108 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/commands/modules_command.py", line 597, in _deploy_module
109 | command_method()
110 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/module/serverless.py", line 229, in deploy
111 | self.run_serverless(command='deploy')
112 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/module/serverless.py", line 191, in run_serverless
113 | self.path)
114 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/module/serverless.py", line 105, in deploy_package
115 | ensure_bucket_exists(bucketname, context.env_region)
116 | File "/codebuild/output/src234671408/src/github.com/onicagroup/runway/runway/s3_util.py", line 88, in ensure_bucket_exists
117 | 'SSEAlgorithm': 'AES256'
118 | File "/root/.local/share/virtualenvs/integration_tests-4Kxyk61_/lib/python3.7/site-packages/botocore/client.py", line 276, in _api_call
119 | return self._make_api_call(operation_name, kwargs)
120 | File "/root/.local/share/virtualenvs/integration_tests-4Kxyk61_/lib/python3.7/site-packages/botocore/client.py", line 586, in _make_api_call
121 | raise error_class(parsed_response, operation_name)
122 | botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the PutBucketEncryption operation: The specified bucket does not exist
123 | ERROR:testsuite:AssertionError: "promotezip-singlesrc-singlezip.sls: Failed to deploy in dev environment"
```

## What Changed

### Fixed

- `NoSuchBucket` during `PutBucketEncryption` when sls tries to create a `promotezip` bucket