### PR TITLE
fix cfngin int test varying message suffix

### DIFF
--- a/integration_tests/test_cfngin/tests/12_rollback_dependent.py
+++ b/integration_tests/test_cfngin/tests/12_rollback_dependent.py
@@ -28,7 +28,9 @@ class TestRollbackWithDependent(Cfngin):
         assert code != 0, 'exit code should be non-zero'
         expected_lines = [
             'dependent-rollback-parent: submitted (creating new stack)',
-            'dependent-rollback-parent: failed (creating new stack)',
+            # the suffix of the below log message can very based on when
+            # CFN is polled b/c of how fast the test stack is
+            'dependent-rollback-parent: failed',
             'dependent-rollback-child: failed (dependency has failed)',
             'The following steps failed: dependent-rollback-parent, dependent-rollback-child'
         ]


### PR DESCRIPTION
## Why This Is Needed

![image](https://user-images.githubusercontent.com/23145462/74549738-fd847000-4f04-11ea-9f06-43321b4e57d8.png)

The suffix of the log message can vary based on when CFN is polled. Because the test stack is so quick, it can transition between states faster than the poll rate.

## What Changed

### Fixed

- log message validation

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/74551620-61f4fe80-4f08-11ea-92d6-e4bcb659dcff.png)


