### PR TITLE
nest "Type" under "Module" section

### DIFF
--- a/docs/source/runway_config.rst
+++ b/docs/source/runway_config.rst
@@ -74,7 +74,7 @@ accepts three different types of options: `commit`, `tag`, or `branch`. These
 respectively point the repository at the reference id specified.
 
 Type
-^^^^
+----
 
 .. automodule:: runway.runway_module_type.RunwayModuleType
 


### PR DESCRIPTION
## Why This Is Needed

Module **Type** is being shown at the same level as **Module** in the docs

![image](https://user-images.githubusercontent.com/23145462/74758687-83b5f480-522c-11ea-92ce-cc002f925053.png)

## What Changed

### Changed

- header level of **Type** in Runway config docs to place it under **Module**

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/74758821-b9f37400-522c-11ea-8f14-8002a676fce4.png)

