### PR TITLE
replace sls_configfile with args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - if this is used with a variables file, what is defined in the runway config takes precedence
 - `parameters` directive for modules and deployments
     - predecessor to `environments.$DEPLOY_ENVIRONMENT` map
-- Add `sls_configfile` option in sls modules to support sls `--config` option
+- Add `args` option for serverless module to pass additional arguments/option to the serverless command
 
 ### Changed
 - install now requires `pyhcl~=0.4` which is being used in place of the embedded copy

--- a/docs/source/module_configuration/serverless.rst
+++ b/docs/source/module_configuration/serverless.rst
@@ -135,14 +135,34 @@ directory is pre-compiled) via the ``skip_npm_ci`` module option:
             options:
               skip_npm_ci: true
 
-Specifying serverless config file
----------------------------------
-Name of your configuration file, if other than serverless.yml|.yaml|.js|.json.
-::
+Specifying Serverless CLI Arguments/Options
+-------------------------------------------
 
-    ---
-    deployments:
-        - modules:
-            - path: sampleapp.sls
-              options:
-                sls_configfile: sampleapp.yml
+Runway can pass custom arguments/options to the Serverless CLI by using the ``args`` option. These will always be placed after the default arguments/options
+
+The value of ``args`` must be a list of arguments/options to pass to the CLI.
+Each element of the argument/option should be it's own list item (e.b. ``--config sls.yml`` would be ``['--config', 'sls.yml']``.
+
+.. important:: Do not provide ``--region <region>`` or ``--stage <stage>`` here. These will be provided by Runway.
+
+
+.. rubric:: Runway Example
+.. code-block:: yaml
+
+  ---
+  deployments:
+    - modules:
+        - path: sampleapp.sls
+          options:
+            args:
+              - '--config'
+              - sls.yml
+      regions
+        - us-east-2
+      environments:
+        example: true
+
+.. rubric:: Command Equivalent
+.. code-block::
+
+  serverless deploy -r us-east-1 --stage example --config sls.yml

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -172,8 +172,7 @@ class Serverless(RunwayModule):
         sls_env_file = get_sls_config_file(self.path,
                                            self.context.env_name,
                                            self.context.env_region)
-        if self.options.get('options', {}).get('sls_configfile', {}):
-            sls_opts.extend(['--config', self.options['options']['sls_configfile']])
+        sls_opts.extend(self.options.get('options', {}).get('args', []))
 
         sls_cmd = generate_node_command(command='sls',
                                         command_opts=sls_opts,


### PR DESCRIPTION
## Summary

Ability to provide any additional CLI options to the serverless module.

## Why This Is Needed

resolves #136 and provides support for future cli argument/option needs.

## What Changed

### Changed

- `sls_configfile` to the more general `args` option to support specifying a config file name or any other cli option
