### PR TITLE
fix parallel_regions skipping subsequent deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - pinned `zipp` sub dependency to `~=1.0.0` to retain support for python 3.5
 - `PyYAML` dependency is now `>=4.1,<5.3` to match the top-end of newer versions of `awscli`
 - `NoSuchBucket` during `PutBucketEncryption` when sls tries to create a `promotezip` bucket
+- `parallel_regions` causing subsequent deployments to be skipped
 
 ## [1.3.7] - 2020-01-07
 ### Fixed

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -431,7 +431,7 @@ class ModulesCommand(RunwayCommand):
                     concurrent.futures.wait(futures)
                     for job in futures:
                         job.result()  # Raise exceptions / exit as needed
-                    return
+                    continue
 
                 # single var to reduce comparisons
                 regions = deployment.parallel_regions or deployment.regions


### PR DESCRIPTION
## Why This Is Needed

Resolves a bug reported in #154 that causes deployments after a deployment using parallel regions to be skipped because it is using `return` instead of `continue`.

## What Changed

### Fixed

- `parallel_regions` causing subsequent deployments to be skipped
