### PR TITLE
adjust cfngin tests log message check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `stacker.__version__` check when shimmed to CFNgin
 
 ## [1.4.0] - 2020-02-18
 ### Added

--- a/runway/cfngin/__init__.py
+++ b/runway/cfngin/__init__.py
@@ -1,1 +1,4 @@
 """Import modules."""
+# added for stacker shim backward compatability.
+# use of __version__ is deprecated and will be removed in 2.0.0.
+__version__ = '1.7.0'


### PR DESCRIPTION
## Why This Is Needed

```
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/.runway_cache/..../ssm.py", line 8, in <module>
    LEGACY_STACKER = LooseVersion(stacker.__version__) < LooseVersion('1.6.0')
AttributeError: module 'runway.cfngin' has no attribute '__version__'
```

## What Changed

### Added

- `runway.cfngin.__version__`
