### PR TITLE
change cfngin.commands.__init__ import of __version__ to absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- `runway.cfngin.commands.__init__` import of `__version__` through the stacker shim
 
 ## [1.4.1] - 2020-02-20
 ### Fixed

--- a/runway/cfngin/commands/stacker/__init__.py
+++ b/runway/cfngin/commands/stacker/__init__.py
@@ -1,7 +1,8 @@
 """CFNgin commands."""
 import logging
 
-from .... import __version__
+from runway.cfngin import __version__
+
 from ... import session_cache
 from ...config import render_parse_load as load_config
 from ...context import Context


### PR DESCRIPTION
## Why This Is Needed

```
"/Users//.local/share/virtualenvs/xpzysQjY/lib/python2.7/site-packages/runway/cfngin/commands/stacker/__init__.py", line 4, in <module>
    from .... import __version__
ValueError: Attempted relative import beyond toplevel package
```

## What Changed

### Changed

- import from relative to absolute

### Fixed

 - Attempted relative import beyond toplevel package


