### PR TITLE
add shim for stacker.variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `stacker.variables` import error by adding a shim to `runway.variables`
 
 ## [1.4.1] - 2020-02-20
 ### Fixed

--- a/runway/__init__.py
+++ b/runway/__init__.py
@@ -1,7 +1,7 @@
 """Set package version."""
 import sys
-from . import cfngin
-from . import variables
+
+from . import cfngin, variables
 
 sys.modules['stacker'] = cfngin  # shim to remove stacker dependency
 sys.modules['stacker.variables'] = variables  # shim to support standard variables

--- a/runway/__init__.py
+++ b/runway/__init__.py
@@ -1,7 +1,9 @@
 """Set package version."""
 import sys
 from . import cfngin
+from . import variables
 
 sys.modules['stacker'] = cfngin  # shim to remove stacker dependency
+sys.modules['stacker.variables'] = variables  # shim to support standard variables
 
 __version__ = '1.4.1'

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,53 @@
 """Packaging settings."""
+import re
 from codecs import open as codecs_open
 from os.path import abspath, dirname, join
 
 from setuptools import find_packages, setup
 
-from runway import __version__
-
-
 THIS_DIR = abspath(dirname(__file__))
+
+
+def read(rel_path):
+    """Read a file.
+
+    Intentionally *not* adding an encoding option to open, See:
+    https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
+
+    Args:
+        rel_path (str): Relative path to a file from this file.
+
+    Returns:
+        str: Contents of the file.
+
+    """
+    with codecs_open(join(THIS_DIR, rel_path), 'r') as file_:
+        return file_.read()
+
+
+def get_version(rel_path):
+    """Get version string without needing to import the module.
+
+    Args:
+        rel_path (str): Relative path to a file from this file.
+
+    Returns:
+        str: Version string.
+
+    Raises:
+        RuntimeError: If a version string can't be found in the provided file.
+
+    """
+    version_file = read(rel_path)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+
+    if version_match:
+        return version_match.group(1)
+
+    raise RuntimeError("Unable to find version string.")
+
+
 with codecs_open(join(THIS_DIR, 'README.md'), encoding='utf-8') as readfile:
     LONG_DESCRIPTION = readfile.read()
 
@@ -50,7 +90,7 @@ INSTALL_REQUIRES = [
 
 setup(
     name='runway',
-    version=__version__,
+    version=get_version('./runway/__init__.py'),
     description='Simplify infrastructure/app testing/deployment',
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Why This Is Needed

Some very old blueprints (before the `.to_json()` method was added) would use a function to convert them to json for output which requires being able to import `stacker.variables` which was moved to `runway.variables` for standard variable handling.

```
  File "./blueprints/example.py", line 4, in <module>
    from some_lib.utils import standalone_output
  File "./some_lib/utils/standalone_output.py", line 4, in <module>
    from stacker.variables import Variable
ModuleNotFoundError: No module named 'stacker.variables'
```

## What Changed

### Added

- shim for `stacker.variables`

## Screenshots

pre-change vs post-change

![image](https://user-images.githubusercontent.com/23145462/75074927-8b39ff80-54b1-11ea-9f32-fe67cd6fe1e1.png)

