### PR TITLE
configurable max concurrent parallel modules & regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `RUNWAY_MAX_CONCURRENT_MODULES` configuration via environment variable
+- `RUNWAY_MAX_CONCURRENT_REGIONS` configuration via environment variable
 
 ## [1.4.2] - 2020-02-21
 ### Fixed

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -122,6 +122,50 @@ Process
 The output of these commands can be found in ``../artifacts``
 
 
+Advanced Configuration
+----------------------
+
+This section has been placed in the **Developer Guide** because it details advanced configuration that should only be used by those with intimate knowledge of how Runway works.
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+
+Environment variables can be used to alter the functionality of Runway.
+
+**CI (Any)**
+    If not ``undefined``, Runway will operate in non-iterative mode,
+
+**DEBUG (Any)**
+    If not ``undefined``, debug logs will be shown.
+
+**DEPLOY_ENVIRONMENT (str)**
+    Explicitly define the deploy environment.
+
+**CFNGIN_STACK_POLL_TIME (int)**
+    Number of seconds between CloudFormation API calls. Adjusting this will
+    impact API throttling. (`default:` ``30``)
+
+**RUNWAY_MAX_CONCURRENT_MODULES (int)**
+    Max number of modules that can be deployed to concurrently.
+    (`default:` ``min(61, os.cpu_count())``)
+
+    On Windows, this must be equal to or lower than ``61``.
+
+    **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
+    together, please consider the nature of their relationship when
+    manually setting this value. (``parallel_regions * child_modules``)
+
+**RUNWAY_MAX_CONCURRENT_REGIONS (int)**
+    Max number of regions that can be deployed to concurrently.
+    (`default:` ``min(61, os.cpu_count())``)
+
+    On Windows, this must be equal to or lower than ``61``.
+
+    **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
+    together, please consider the nature of their relationship when
+    manually setting this value. (``parallel_regions * child_modules``)
+
+
 Travis CI
 ---------
 

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -417,9 +417,8 @@ class ModulesCommand(RunwayCommand):
                     LOGGER.info("Processing parallel regions %s",
                                 deployment.parallel_regions)
                     LOGGER.info('(output will be interwoven)')
-                    executor = concurrent.futures.ThreadPoolExecutor(
-                        max_workers=context.max_concurrent_regions,
-                        thread_name_prefix='runway.parallel_regions'
+                    executor = concurrent.futures.ProcessPoolExecutor(
+                        max_workers=context.max_concurrent_regions
                     )
                     futures = [executor.submit(self._execute_deployment,
                                                *[deployment, context,

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -417,8 +417,9 @@ class ModulesCommand(RunwayCommand):
                     LOGGER.info("Processing parallel regions %s",
                                 deployment.parallel_regions)
                     LOGGER.info('(output will be interwoven)')
-                    executor = concurrent.futures.ProcessPoolExecutor(
-                        context.max_concurrent_regions
+                    executor = concurrent.futures.ThreadPoolExecutor(
+                        max_workers=context.max_concurrent_regions,
+                        thread_name_prefix='runway.parallel_regions'
                     )
                     futures = [executor.submit(self._execute_deployment,
                                                *[deployment, context,
@@ -487,7 +488,7 @@ class ModulesCommand(RunwayCommand):
                     # we need to be able to do things like `cd` which is not
                     # thread safe.
                     executor = concurrent.futures.ProcessPoolExecutor(
-                        context.max_concurrent_modules
+                        max_workers=context.max_concurrent_modules
                     )
                     futures = [executor.submit(self._deploy_module,
                                                *[x, deployment, context])

--- a/runway/context.py
+++ b/runway/context.py
@@ -117,7 +117,7 @@ class Context(object):
         """Max number of regions that can be deployed to concurrently.
 
         This property can be set by exporting ``RUNWAY_MAX_CONCURRENT_REGIONS``.
-        If no value is specified, ``min(32, os.cpu_count() + 4)`` is used.
+        If no value is specified, ``min(61, os.cpu_count())`` is used.
 
         IMPORTANT: When using ``parallel_regions`` and ``child_modules``
         together, please consider the nature of their relationship when
@@ -125,7 +125,7 @@ class Context(object):
 
         Returns:
             int: Value from environment variable or
-            ``min(32, os.cpu_count() + 4)``
+            ``min(61, os.cpu_count())``
 
         """
         value = os.getenv('RUNWAY_MAX_CONCURRENT_REGIONS')
@@ -133,7 +133,7 @@ class Context(object):
         if value:
             return int(value)
         # TODO update to `os.cpu_count()` when dropping python2
-        return min(32, multiprocessing.cpu_count() + 4)
+        return min(61, multiprocessing.cpu_count())
 
     @property
     def use_concurrent(self):

--- a/runway/context.py
+++ b/runway/context.py
@@ -92,14 +92,13 @@ class Context(object):
         """Max number of modules that can be deployed to concurrently.
 
         This property can be set by exporting ``RUNWAY_MAX_CONCURRENT_MODULES``.
-        If no value is specified, the systems core count is used.
+        If no value is specified, ``min(61, os.cpu_count())`` is used.
 
         On Windows, max_workers must be equal or lower than ``61``.
 
-        .. important:: When using ``parallel_regions`` and ``child_modules``
-                       together, please consider the exponential nature of
-                       their relationship when manually setting this value.
-                       (``parallel_regions``^``child_modules``)
+        IMPORTANT: When using ``parallel_regions`` and ``child_modules``
+        together, please consider the nature of their relationship when
+        manually setting this value. (``parallel_regions * child_modules``)
 
         Returns:
             int: Value from environment variable or
@@ -118,18 +117,15 @@ class Context(object):
         """Max number of regions that can be deployed to concurrently.
 
         This property can be set by exporting ``RUNWAY_MAX_CONCURRENT_REGIONS``.
-        If no value is specified, the systems core count is used.
+        If no value is specified, ``min(32, os.cpu_count() + 4)`` is used.
 
-        On Windows, max_workers must be equal or lower than ``61``.
-
-        .. important:: When using ``parallel_regions`` and ``child_modules``
-                       together, please consider the exponential nature of
-                       their relationship when manually setting this value.
-                       (``parallel_regions``^``child_modules``)
+        IMPORTANT: When using ``parallel_regions`` and ``child_modules``
+        together, please consider the nature of their relationship when
+        manually setting this value. (``parallel_regions * child_modules``)
 
         Returns:
             int: Value from environment variable or
-            ``min(61, os.cpu_count())``
+            ``min(32, os.cpu_count() + 4)``
 
         """
         value = os.getenv('RUNWAY_MAX_CONCURRENT_REGIONS')
@@ -137,7 +133,7 @@ class Context(object):
         if value:
             return int(value)
         # TODO update to `os.cpu_count()` when dropping python2
-        return min(61, multiprocessing.cpu_count())
+        return min(32, multiprocessing.cpu_count() + 4)
 
     @property
     def use_concurrent(self):

--- a/runway/context.py
+++ b/runway/context.py
@@ -94,15 +94,14 @@ class Context(object):
         This property can be set by exporting ``RUNWAY_MAX_CONCURRENT_MODULES``.
         If no value is specified, ``min(61, os.cpu_count())`` is used.
 
-        On Windows, max_workers must be equal or lower than ``61``.
+        On Windows, this must be equal to or lower than ``61``.
 
-        IMPORTANT: When using ``parallel_regions`` and ``child_modules``
+        **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
         together, please consider the nature of their relationship when
         manually setting this value. (``parallel_regions * child_modules``)
 
         Returns:
-            int: Value from environment variable or
-            ``min(61, os.cpu_count())``
+            int: Value from environment variable or ``min(61, os.cpu_count())``
 
         """
         value = os.getenv('RUNWAY_MAX_CONCURRENT_MODULES')
@@ -119,13 +118,14 @@ class Context(object):
         This property can be set by exporting ``RUNWAY_MAX_CONCURRENT_REGIONS``.
         If no value is specified, ``min(61, os.cpu_count())`` is used.
 
-        IMPORTANT: When using ``parallel_regions`` and ``child_modules``
+        On Windows, this must be equal to or lower than ``61``.
+
+        **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
         together, please consider the nature of their relationship when
         manually setting this value. (``parallel_regions * child_modules``)
 
         Returns:
-            int: Value from environment variable or
-            ``min(61, os.cpu_count())``
+            int: Value from environment variable or ``min(61, os.cpu_count())``
 
         """
         value = os.getenv('RUNWAY_MAX_CONCURRENT_REGIONS')


### PR DESCRIPTION
## Summary

Allow users to override the default `max_workers` for multiprocessing. This will allow for creating more processes than cores. This can be beneficial in specific situations but also cause degraded performance if improperly configured so it is documented as advanced configuration in the Developer Guide

## What Changed

### Added

- `RUNWAY_MAX_CONCURRENT_MODULES` configuration via environment variable
- `RUNWAY_MAX_CONCURRENT_REGIONS` configuration via environment variable

### Changed

- moved some repetitive conditional logic to context properties for easy reuse 
