### PR TITLE
fix cfngin resolve complex variable types, fix runway config variables def

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
         "cygwin",
         "dockerizepip",
         "forcerm",
+        "kwarg",
         "lambci",
         "nondockerizepip"
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `provider` missing from variable resolution args
 
 ## [1.4.3] - 2020-02-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `provider` missing from variable resolution args
+- explicitly pass `provider` as a kwarg for resolving complex variable types
+- error message raised when `var` lookup query is not in variables now includes the query
+- `variables` is now passed from the config file to the `VariablesDefinition` as intended
 
 ## [1.4.3] - 2020-02-25
 ### Fixed

--- a/runway/config.py
+++ b/runway/config.py
@@ -1124,7 +1124,8 @@ class Config(ConfigComponent):
                             config_file.pop('ignore_git_branch',
                                             config_file.pop(
                                                 'ignore-git-branch',
-                                                False)))
+                                                False)),
+                            config_file.pop('variables', {}))
 
             if config_file:
                 LOGGER.warning(

--- a/runway/lookups/handlers/var.py
+++ b/runway/lookups/handlers/var.py
@@ -71,4 +71,6 @@ class VarLookup(LookupHandler):
             return cls.transform(result, to_type=args.pop('transform', ''),
                                  **args)
 
-        raise ValueError('"{}" does not exist in the variable definition')
+        raise ValueError(
+            '"{}" does not exist in the variable definition'.format(query)
+        )

--- a/runway/variables.py
+++ b/runway/variables.py
@@ -36,7 +36,7 @@ def resolve_variables(variables, context, provider):
 
     """
     for variable in variables:
-        variable.resolve(context, provider)
+        variable.resolve(context=context, provider=provider)
 
 
 class Variable(object):
@@ -340,7 +340,8 @@ class VariableValueList(VariableValue, list):
 
         """
         for item in self:
-            item.resolve(context, variables=variables, **kwargs)
+            item.resolve(context, provider=provider, variables=variables,
+                         **kwargs)
 
     @classmethod
     def parse(cls, input_object, variable_type='cfngin'):
@@ -424,7 +425,8 @@ class VariableValueDict(VariableValue, dict):
 
         """
         for item in self.values():
-            item.resolve(context, variables=variables, **kwargs)
+            item.resolve(context, provider=provider, variables=variables,
+                         **kwargs)
 
     @classmethod
     def parse(cls, input_object, variable_type='cfngin'):
@@ -539,7 +541,8 @@ class VariableValueConcatenation(VariableValue, list):
 
         """
         for value in self:
-            value.resolve(context, variables=variables, **kwargs)
+            value.resolve(context, provider=provider, variables=variables,
+                          **kwargs)
 
     def __iter__(self):
         # type: () -> Iterator[Type[VariableValue]]
@@ -649,7 +652,8 @@ class VariableValueLookup(VariableValue):
             FailedLookup: A lookup failed for any reason.
 
         """
-        self.lookup_data.resolve(context, variables=variables, **kwargs)
+        self.lookup_data.resolve(context, provider=provider,
+                                 variables=variables, **kwargs)
         try:
             if isinstance(self.handler, type):
                 result = self.handler.handle(value=self.lookup_data.value,
@@ -667,8 +671,8 @@ class VariableValueLookup(VariableValue):
                 LOGGER.debug('Encountered %s: %s - trying legacy resolver',
                              type(err), err)
                 try:
-                    return self._resolve(self._resolve_legacy(context,
-                                                              provider))
+                    return self._resolve(self._resolve_legacy(context=context,
+                                                              provider=provider))
                 except Exception as err2:
                     raise FailedLookup(self, err2)
             raise FailedLookup(self, err)


### PR DESCRIPTION
## Why This Is Needed

```
[2020-02-28T09:35:01] Couldn't resolve lookup in variable `AppSubnets`, lookup: ${Lookup<Literal<'rxref'> Concatenation[Literal<'core-vpc::PubSubnet1'>]>}: (<class 'ValueError'>) Provider is required
Traceback (most recent call last):
  File "/Users/user/Library/Python/3.7/lib/python/site-packages/runway/variables.py", line 659, in resolve
    **kwargs)
  File "/Users/user/Library/Python/3.7/lib/python/site-packages/runway/cfngin/lookups/handlers/rxref.py", line 40, in handle
    raise ValueError('Provider is required')
ValueError: Provider is required
```

## What Changed

### Fixed

- explicitly pass `provider` as a kwarg for resolving complex variable types
- error message raised when `var` lookup query is not in variables now includes the query
- `variables` is now passed from the config file to the `VariablesDefinition` as intended
