### PR TITLE
fix bug introduced in #181

### DIFF
--- a/runway/cfngin/lookups/handlers/default.py
+++ b/runway/cfngin/lookups/handlers/default.py
@@ -41,6 +41,6 @@ class DefaultLookup(LookupHandler):
             raise ValueError("Invalid value for default: %s. Must be in "
                              "<env_var>::<default value> format." % value)
 
-        if env_var_name in context.environment:
+        if context.environment.get(env_var_name):
             return context.environment[env_var_name]
         return default_val

--- a/runway/cfngin/lookups/handlers/default.py
+++ b/runway/cfngin/lookups/handlers/default.py
@@ -41,6 +41,6 @@ class DefaultLookup(LookupHandler):
             raise ValueError("Invalid value for default: %s. Must be in "
                              "<env_var>::<default value> format." % value)
 
-        if context.environment.get(env_var_name):
+        if env_var_name in context.environment:
             return context.environment[env_var_name]
         return default_val

--- a/runway/util.py
+++ b/runway/util.py
@@ -170,6 +170,11 @@ class MutableMap(six.moves.collections_abc.MutableMapping):  # pylint: disable=n
             return True
         return False
 
+    def __contains__(self, value):
+        # type: () -> bool
+        """Implement evaluation of 'in' conditional."""
+        return value in self.data
+
     __nonzero__ = __bool__  # python2 compatability
 
     def __getitem__(self, key):


### PR DESCRIPTION
i'll cover unittests in another branch I'm working off of - I have some other changes coming for the class as well.

## Why This Is Needed

fix a bug introduced in #181 (unreleased)

```
runway.cfngin.exceptions.FailedVariableLookup: Couldn't resolve lookup in variable `TestParam`, lookup: ${Lookup<Literal<'default'> Concatenation[Literal<'some_value::default_value'>]>}: (<class 'AttributeError'>) 'MutableMap' object has no attribute 'some_value'
```

## What Changed

### Fixed

- `AttributeError` when the default lookup was looking for a key in the `MutableMap`