### PR TITLE
Feature183

### DIFF
--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -64,6 +64,7 @@ class CFNgin(object):
         self.region = ctx.env_region
         self.sys_path = sys_path or os.getcwd()
         self.tail = ctx.debug
+        self.config_dir = ctx.config_dir
 
         self.parameters.update(self.env_file)
 
@@ -86,6 +87,11 @@ class CFNgin(object):
         supported_names = ['{}.env'.format(self.__ctx.env_name),
                            '{}-{}.env'.format(self.__ctx.env_name,
                                               self.region)]
+        if self.config_dir:
+            LOGGER.info('appening config_dir: %s', self.config_dir)
+            for index, name in enumerate(supported_names):
+                supported_names[index] = "{}/{}".format(self.config_dir, name)
+
         for _, file_name in enumerate(supported_names):
             file_path = os.path.join(self.sys_path, file_name)
             if os.path.isfile(file_path):

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -88,7 +88,7 @@ class CFNgin(object):
                            '{}-{}.env'.format(self.__ctx.env_name,
                                               self.region)]
         if self.config_dir:
-            LOGGER.info('appening config_dir: %s', self.config_dir)
+            LOGGER.info('Appening config_dir: %s', self.config_dir)
             for index, name in enumerate(supported_names):
                 supported_names[index] = "{}/{}".format(self.config_dir, name)
 

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -563,6 +563,11 @@ class ModulesCommand(RunwayCommand):
                     context.env_name,
                     context.env_region)
         LOGGER.info("Module options: %s", module_opts)
+
+        if deployment.config_dir:
+            context.set_config_dir(deployment.config_dir)
+            LOGGER.debug("Setting config dir %s in context", context.config_dir)
+
         if module_opts.get('env_vars'):
             module_env_vars = merge_nested_environment_dicts(
                 module_opts.get('env_vars'), env_name=context.env_name,
@@ -574,6 +579,7 @@ class ModulesCommand(RunwayCommand):
                             "applied to this module: %s",
                             str(module_env_vars))
                 context.env_vars = merge_dicts(context.env_vars, module_env_vars)
+
 
         with change_dir(path.module_root):
 
@@ -590,7 +596,10 @@ class ModulesCommand(RunwayCommand):
             )
             if hasattr(module_instance, context.command):
                 command_method = getattr(module_instance, context.command)
+                LOGGER.info("before call")
                 command_method()
+                LOGGER.info("after call")
+
             else:
                 LOGGER.error("'%s' is missing method '%s'",
                              module_instance, context.command)

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -580,7 +580,6 @@ class ModulesCommand(RunwayCommand):
                             str(module_env_vars))
                 context.env_vars = merge_dicts(context.env_vars, module_env_vars)
 
-
         with change_dir(path.module_root):
 
             runway_module_type = RunwayModuleType(path.module_root,

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -596,10 +596,7 @@ class ModulesCommand(RunwayCommand):
             )
             if hasattr(module_instance, context.command):
                 command_method = getattr(module_instance, context.command)
-                LOGGER.info("before call")
                 command_method()
-                LOGGER.info("after call")
-
             else:
                 LOGGER.error("'%s' is missing method '%s'",
                              module_instance, context.command)

--- a/runway/config.py
+++ b/runway/config.py
@@ -459,6 +459,7 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
               lab: true
             account_id: ${var account_ids}  # optional
             assume_role: ${var assume_role}  # optional
+            config_dir: .. # optional used for CFNgin configs directory
             parameters:  # optional
                 region: ${env AWS_REGION}
                 image_id: ${var image_id.${env DEPLOY_ENVIRONMENT}}
@@ -492,6 +493,8 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
                 be used to apply the same role to all environment.
                 ``post_deploy_env_revert: true`` can also be provided to
                 revert credentials after processing.
+            config_dir (Optional[str]): Options directory for CFNgin env files
+                relitive to relitive to the module directory level. default is .
             environments (Optional[Dict[str, Dict[str, Any]]]): Optional
                 mapping of environment names to a booleon value used to
                 explicitly enable or disable in an environment. This

--- a/runway/config.py
+++ b/runway/config.py
@@ -470,7 +470,7 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
 
     SUPPORTS_VARIABLES = ['account_alias', 'account_id', 'assume_role',
                           'env_vars', 'environments', 'module_options',
-                          'regions', 'parallel_regions', 'parameters']
+                          'regions', 'parallel_regions', 'parameters', 'config_dir']
     PRE_PROCESS_VARIABLES = ['account_alias', 'account_id', 'assume_role',
                              'env_vars', 'regions']
 
@@ -628,6 +628,11 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
         self._env_vars = Variable(self.name + '.env_vars', deployment.pop(
             'env_vars', deployment.pop('env-vars', {})
         ), 'runway')  # type: Variable
+        self._config_dir = Variable(
+            self.name + '.config_dir', deployment.pop(
+                'config_dir', deployment.pop('config-dir', '.')
+            ), 'runway'
+        )
         if deployment.pop('current_dir', False):
             # Deprecated in 1.0 (late 2019). Retain for at least a major version.
             LOGGER.warning('DEPRECATION WARNING: The "current_dir" option has '
@@ -681,6 +686,18 @@ class DeploymentDefinition(ConfigComponent):  # pylint: disable=too-many-instanc
                 'Invalid keys found in deployment %s have been ignored: %s',
                 self.name, ', '.join(deployment.keys())
             )
+
+    @property
+    def config_dir(self):
+        # type: () -> str
+        """Access the value of an attribute that supports variables."""
+        value = self._config_dir.value
+        if isinstance(value, (str, string_types)):
+            return value
+        if isinstance(value, int):
+            return str(value)
+        raise ValueError('{}.config_dir is of type {}; expected type '
+                         'of int, or str'.format(self.name, type(value)))
 
     @property
     def account_alias(self):

--- a/runway/context.py
+++ b/runway/context.py
@@ -209,6 +209,7 @@ class Context(object):
             LOGGER.info("If this is not the environment name, update the "
                         "branch/folder name or set an override value via "
                         "the %s environment variable", self.env_override_name)
+        LOGGER.info("")
 
     def save_existing_iam_env_vars(self):
         """Backup IAM environment variables for later restoration."""

--- a/runway/context.py
+++ b/runway/context.py
@@ -224,5 +224,5 @@ class Context(object):
                 self.env_vars.pop(i)
 
     def set_config_dir(self, config_dir):
-        """ this sets the class attribute for the config dir """
+        """Set the class attribute for the config dir."""
         self.config_dir = config_dir

--- a/runway/context.py
+++ b/runway/context.py
@@ -47,14 +47,12 @@ class Context(object):
         self.env_vars = env_vars or os.environ.copy()
         self._env_name_from_env = bool(self.env_vars.get(self.env_override_name))
         self.debug = bool(self.env_vars.get('DEBUG'))
-        self.echo_detected_environment()
         self.config_dir = None
+
+        self.echo_detected_environment()
+
         if not self._env_name_from_env:
             self.env_vars.update({'DEPLOY_ENVIRONMENT': self.env_name})
-
-    def set_config_dir(self, config_dir):
-        """ this sets the class attribute for the config dir """
-        self.config_dir = config_dir
 
     @property
     def boto3_credentials(self):
@@ -224,3 +222,7 @@ class Context(object):
                 self.env_vars[i] = self.env_vars['OLD_' + i]
             elif i in self.env_vars:
                 self.env_vars.pop(i)
+
+    def set_config_dir(self, config_dir):
+        """ this sets the class attribute for the config dir """
+        self.config_dir = config_dir

--- a/runway/context.py
+++ b/runway/context.py
@@ -47,11 +47,14 @@ class Context(object):
         self.env_vars = env_vars or os.environ.copy()
         self._env_name_from_env = bool(self.env_vars.get(self.env_override_name))
         self.debug = bool(self.env_vars.get('DEBUG'))
-
         self.echo_detected_environment()
-
+        self.config_dir = None
         if not self._env_name_from_env:
             self.env_vars.update({'DEPLOY_ENVIRONMENT': self.env_name})
+
+    def set_config_dir(self, config_dir):
+        """ this sets the class attribute for the config dir """
+        self.config_dir = config_dir
 
     @property
     def boto3_credentials(self):
@@ -206,7 +209,6 @@ class Context(object):
             LOGGER.info("If this is not the environment name, update the "
                         "branch/folder name or set an override value via "
                         "the %s environment variable", self.env_override_name)
-        LOGGER.info("")
 
     def save_existing_iam_env_vars(self):
         """Backup IAM environment variables for later restoration."""

--- a/tests/cfngin/test_cfngin.py
+++ b/tests/cfngin/test_cfngin.py
@@ -140,7 +140,9 @@ class TestCFNgin(object):
         """Test load."""
         copy_basic_fixtures(cfngin_fixtures, tmp_path)
         # support python < 3.6
-        cfngin = CFNgin(ctx=self.get_context(), sys_path=str(tmp_path))
+        ctx=self.get_context()
+        ctx.set_config_dir(".")
+        cfngin = CFNgin(ctx=ctx, sys_path=str(tmp_path))
         result = cfngin.load(str(tmp_path / 'basic.yml'))  # support python < 3.6
 
         assert not result.bucket_name

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -197,3 +197,10 @@ class TestContext(object):
         assert context.env_vars['OLD_AWS_ACCESS_KEY_ID'] == 'foo'
         assert context.env_vars['OLD_AWS_SECRET_ACCESS_KEY'] == 'bar'
         assert context.env_vars['OLD_AWS_SESSION_TOKEN'] == 'foobar'
+
+    def test_set_config_dir(self):
+        context = Context(env_name='dev', env_region='us-east-1',
+                          env_root='./', env_vars=TEST_CREDENTIALS.copy())
+        expected = "foobar"
+        context.set_config_dir(expected)
+        assert expected == context.config_dir


### PR DESCRIPTION
Change cfngin config location as an option
## Summary

Added config_dir for CFNgin env file directories. this was added at the modules level

## Why This Is Needed

need to have a central configs that have to be generated and don't want configurations to live in the runway yaml as that means we are dynamically creating the runway file

## What Changed

context has a new feild (config_dir comment if this should be changed to cfn_gin_config_dir or something more clear).

### Added

_What was added?_

### Changed

no default functionality changed. new functionality added (see above

### Fixed

_Were any bugs fixed?_

### Removed

Nothing

## Screenshots

_Please include screenshots of any new features to show how it works._

```
$ tree
.
├── environments
│   ├── dev.env
│   ├── prod.env
│   ├── qa.env
│   ├── sat.env
│   ├── test.env
│   └── uat.env
├── module1
│   ├── lambdas
│   │   └── test_lambda.py
│   └── stacker.yaml
├── module2
│   ├── lambdas
│   │   └── test_lambda.py
│   └── stacker.yaml
├── runway.variables.yml
├── runway.yml
└── templates
    └── lambda.yml

6 directories, 13 files
$ cat runway.yml 
---
# See full syntax at https://docs.onica.com/projects/runway/en/latest/
deployments:
  - modules:
      - module1
      - module2
    regions:
      - us-east-1
    config_dir: ../environments
```
The above is far more preferable/efficient than the below current state of runway:
```
$ tree
.
├── module1
│   ├── dev.env
│   ├── lambdas
│   │   └── test_lambda.py
│   ├── prod.env
│   ├── qa.env
│   ├── sat.env
│   ├── stacker.yaml
│   ├── test.env
│   └── uat.env
├── module2
│   ├── dev.env
│   ├── lambdas
│   │   └── test_lambda.py
│   ├── prod.env
│   ├── qa.env
│   ├── sat.env
│   ├── stacker.yaml
│   ├── test.env
│   └── uat.env
├── runway.variables.yml
├── runway.yml
└── templates
    └── lambda.yml

5 directories, 19 files

$ cat runway.yml 
---
# See full syntax at https://docs.onica.com/projects/runway/en/latest/
deployments:
  - modules:
      - module1
      - module2
    regions:
      - us-east-1
```
