### PR TITLE
Callback URL Retriever for Auth@Edge

### DIFF
--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -110,16 +110,14 @@ class Dependencies(Blueprint):
             Value=artifacts.ref()
         ))
 
+        callbacks = self.context.hook_data['aae_callback_url_retriever']['callback_urls']
+
         if variables['AuthAtEdge']:
             client = template.add_resource(
                 cognito.UserPoolClient(
                     "AuthAtEdgeClient",
                     AllowedOAuthFlows=['code'],
-                    # Temporary CallbackURLs as they are required to
-                    # create the resource. These are changed during
-                    # the client_updater hook to the correct
-                    # values.
-                    CallbackURLs=['https://example.temp'],
+                    CallbackURLs=callbacks,
                     UserPoolId=variables['UserPoolId'],
                     AllowedOAuthScopes=variables['OAuthScopes']
                 )

--- a/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
@@ -1,0 +1,63 @@
+"""Callback URL Retriever.
+
+Dependency pre-hook responsible for ensuring correct
+callback urls are retrieved or a temporary one is used in it's place.
+"""
+
+import logging
+
+from typing import Any, Dict, Optional  # pylint: disable=unused-import
+
+from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
+from runway.cfngin.context import Context  # noqa pylint: disable=unused-import
+from runway.cfngin.session_cache import get_session
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get(context,  # pylint: disable=unused-argument
+        provider,
+        **kwargs
+       ):  # noqa: E124
+    # type: (Context, BaseProvider, Optional[Dict[str, Any]]) -> Dict
+    """Retrieve the callback URLs for User Pool Client Creation.
+
+    When the User Pool is created a Callback URL is required. During a post
+    hook entitled ``client_updater`` these Callback URLs are updated to that
+    of the Distribution. Before then we need to ensure that if a Client
+    already exists that the URLs for that client are used to prevent any
+    interuption of service during deploy.
+
+    Args:
+        context (:class:`runway.cfngin.context.Context`): The context
+            instance.
+        provider (:class:`runway.cfngin.providers.base.BaseProvider`):
+            The provider instance
+
+    Keyword Args:
+        user_pool_id (str): The ID of the User Pool to check for a client
+    """
+    session = get_session(provider.region)
+    cognito_client = session.client('cognito-idp')
+    context_dict = {}
+    context_dict['callback_urls'] = ['https://example.tmp']
+
+    try:
+        clients = cognito_client.list_user_pool_clients(
+            UserPoolId=kwargs['user_pool_id']
+        )['UserPoolClients']
+
+        client = next((c for c in clients if c['ClientName'].startswith('AuthAtEdge')), None)
+
+        resp = cognito_client.describe_user_pool_client(
+            UserPoolId=kwargs['user_pool_id'],
+            ClientId=client['ClientId']
+        )
+
+        callbacks = resp['UserPoolClient']['CallbackURLs']
+
+        if callbacks:
+            context_dict['callback_urls'] = callbacks
+        return context_dict
+    except Exception:  # pylint: disable=broad-except
+        return context_dict

--- a/runway/hooks/staticsite/auth_at_edge/client_updater.py
+++ b/runway/hooks/staticsite/auth_at_edge/client_updater.py
@@ -41,7 +41,6 @@ def update(context,  # pylint: disable=unused-argument
     session = get_session(provider.region)
     cognito_client = session.client('cognito-idp')
 
-    LOGGER.info(kwargs['distribution_domain'])
     # Combine alternate domains with main distribution
     redirect_domains = kwargs['alternate_domains'] + ['https://' + kwargs['distribution_domain']]
 
@@ -67,8 +66,7 @@ def update(context,  # pylint: disable=unused-argument
             UserPoolId=kwargs['user_pool_id'],
         )
         return True
-    # pylint: disable=broad-except
-    except Exception as err:
+    except Exception as err:  # pylint: disable=broad-except
         LOGGER.error('Was not able to update the callback urls on '
                      'the user pool client')
         LOGGER.error(err)

--- a/runway/hooks/staticsite/auth_at_edge/lambda_config.py
+++ b/runway/hooks/staticsite/auth_at_edge/lambda_config.py
@@ -69,8 +69,6 @@ def write(context,  # type: context.Context
         'redirect_path_sign_out': kwargs['redirect_path_sign_out'],
         'user_pool_id': kwargs['user_pool_id'],
     }
-    LOGGER.info('LAMBDA_CONFIG')
-    LOGGER.info(config)
 
     # Shared file that contains the method called for configuration data
     path = os.path.join(

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -60,6 +60,20 @@ class StaticSite(RunwayModule):
                        "(e.g. url rewrites) will take quite a while (up to an hour). "
                        "Unless you receive an error your deployment is still running.")
                 LOGGER.info(msg.upper())
+
+                # Auth@Edge warning about subsequent deploys
+                if self.parameters.get('staticsite_auth_at_edge', False) is True:
+                    msg = ("PLEASE NOTE: A hook that is part of the dependencies stack of "
+                           "the Auth@Edge static site deployment is designed to verify that "
+                           "the correct Callback URLs are being used when a User Pool Client "
+                           "already exists for the application. This ensures that there is no "
+                           "interruption of service while the deployment reaches the stage "
+                           "where the Callback URLs are updated to that of the Distribution. "
+                           "Because of this you will receive a change set request on your first "
+                           "subsequent deploy from the first, or any subsequent ones where the "
+                           "alias domains have changed.")
+                    LOGGER.info(msg)
+
             self._setup_website_module(command='deploy')
         else:
             LOGGER.info("Skipping staticsite deploy of %s; no environment "
@@ -97,6 +111,18 @@ class StaticSite(RunwayModule):
         return module_dir
 
     def _create_dependencies_yaml(self, module_dir):
+        pre_build = []
+
+        if self.parameters.get('staticsite_auth_at_edge', False):
+            pre_build = [{
+                'path': 'runway.hooks.staticsite.auth_at_edge.callback_url_retriever.get',
+                'required': True,
+                'data_key': 'aae_callback_url_retriever',
+                'args': {
+                    'user_pool_id': self._extract_user_pool_id()
+                }
+            }]
+
         with open(os.path.join(module_dir, '01-dependencies.yaml'), 'w') as output_stream:  # noqa
             yaml.dump(
                 {'namespace': '${namespace}',
@@ -105,6 +131,7 @@ class StaticSite(RunwayModule):
                      "%s-dependencies" % self.name: {
                          'class_path': 'runway.blueprints.staticsite.dependencies.Dependencies',
                          'variables': self._get_dependencies_variables()}},
+                 'pre_build': pre_build,
                  'pre_destroy': [
                      {'path': 'runway.hooks.cleanup_s3.purge_bucket',
                       'required': True,
@@ -215,7 +242,7 @@ class StaticSite(RunwayModule):
 
     def _get_site_stack_variables(self):
         site_stack_variables = {
-            'Aliases': self.parameters.get('staticsite_aliases', '').split(','),
+            'Aliases': [],
             'DisableCloudFront': self.parameters.get('staticsite_cf_disable', False),
             'RewriteDirectoryIndex': self.parameters.get(
                 'staticsite_rewrite_directory_index',
@@ -228,6 +255,9 @@ class StaticSite(RunwayModule):
             'SignOutUrl': '${default staticsite_sign_out_url::/signout}',
             'WAFWebACL': self.parameters.get('staticsite_web_acl', '')
         }
+
+        if self.parameters.get('staticsite_aliases'):
+            site_stack_variables['Aliases'] = self.parameters.get('staticsite_aliases').split(',')
 
         if self.parameters.get('staticsite_acmcert_arn'):
             site_stack_variables['AcmCertificateArn'] = \
@@ -361,9 +391,9 @@ class StaticSite(RunwayModule):
         }
 
     def _get_client_updater_variables(self, name, site_stack_variables):
-        aliases = list(map(add_url_scheme, site_stack_variables['Aliases']))
+        aliases = [add_url_scheme(x) for x in site_stack_variables['Aliases']]
         return {
-            'alternate_domains': [] if aliases[0] == '' else aliases,
+            'alternate_domains': aliases,
             'client_id': "${rxref %s-dependencies::AuthAtEdgeClient}" % self.name,
             'distribution_domain': '${rxref %s::CFDistributionDomainName}' % name,
             'oauth_scopes': site_stack_variables['OAuthScopes'],

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -32,7 +32,6 @@ class StaticSite(RunwayModule):
     def __init__(self, context, path, options=None):
         """Initialize."""
         super(StaticSite, self).__init__(context, path, options)
-        LOGGER.info(self.context.env_region)
         self.name = self.options.get('name', self.options.get('path'))
         self.user_options = self.options.get('options', {})
         self.parameters = self.options.get('parameters')
@@ -119,7 +118,8 @@ class StaticSite(RunwayModule):
                 'required': True,
                 'data_key': 'aae_callback_url_retriever',
                 'args': {
-                    'user_pool_id': self._extract_user_pool_id()
+                    'user_pool_id': self._extract_user_pool_id(),
+                    'stack_name': "${namespace}-%s-dependencies" % self.name
                 }
             }]
 


### PR DESCRIPTION
## Summary

A potential race condition was found in the Auth@Edge deployment cycle. Because a dummy url has to be used for the Callback URLs on creation of a Client User Pool we have the potential to set this value for a period of time until the `client_updater` hook is run.

## What Changed

### Added

A new hook was added that checks for a client generated by Auth@Edge. If it exists then it will extract the Callback URLs from the client for use. If it is not able to find it, or an error occurs, the temporary one will be supplied in its place.

### Fixed

Couple minor pylint issues carried over from original PR

