### PR TITLE
add static site IAM role permissions boundary support

### DIFF
--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -25,22 +25,13 @@ Parameters
     staticsite_aliases: example.com,foo.example.com
 
 **staticsite_acmcert_arn (Optional[str])**
-  The certificate arn used for any alias domains supplied. This is a requirement when supplying any custom domain unless ``staticsite_acmcert_ssm_param`` is specified.
+  The certificate arn used for any alias domains supplied. This is a requirement when supplying any custom domain.
 
   Example:
 
   .. code-block:: yaml
 
     staticsite_acmcert_arn: arn:aws:acm:us-east-1:123456789012:certificate/...
-
-**staticsite_acmcert_ssm_param (Optional[str])**
-  The certificate ARN can be looked up dynamically via SSM. This is a requirement when supplying any custom domain unless ``staticsite_acmcert_arn`` is specified.
-
-  Example:
-
-  .. code-block:: yaml
-
-    staticsite_acmcert_arn: us-west-2@MySSMParamName
 
 **staticsite_enable_cf_logging (Optional[bool])**
   Defaults to ``true``, allows the user to specify if they would like logging performed on their CloudFront distribution.
@@ -220,6 +211,17 @@ Parameters
   .. code-block:: yaml
 
     staticsite_non_spa: true
+
+**staticsite_role_boundary_arn (Optional[str])**
+  Defines an IAM Managed Policy that will be set as the permissions boundary
+  for any IAM Roles created to support the site (e.g. when using
+  ``staticsite_auth_at_edge`` or ``staticsite_rewrite_directory_index``).
+
+  Example:
+
+  .. code-block:: yaml
+
+    staticsite_role_boundary_arn: arn:aws:iam::444455556666:policy/MyCustomPolicy
 
 Options
 -------

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -181,11 +181,15 @@ class StaticSite(RunwayModule):
                 'args': lambda_config_variables
             })
             post_build.insert(0, {
-                'path': 'runway.hooks.staticsite.auth_at_edge.client_updater.update', # noqa
+                'path': 'runway.hooks.staticsite.auth_at_edge.client_updater.update',
                 'required': True,
                 'data_key': 'client_updater',
                 'args': client_updater_variables
             })
+
+        if self.parameters.get('staticsite_role_boundary_arn', False):
+            site_stack_variables['RoleBoundaryArn'] = \
+                self.parameters.pop('staticsite_role_boundary_arn')
 
         # If lambda_function_associations or custom_error_responses defined,
         # add to stack config


### PR DESCRIPTION
## Summary

Add static site IAM role permissions boundary support

## Why This Is Needed

Deployment scenarios that dictate more limited IAM permissions in an account.