### PR TITLE
Auth@Edge User Pool Creation

### DIFF
--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -78,8 +78,17 @@ Parameters
 
     staticsite_auth_at_edge: true
 
+**staticsite_create_user_pool (Optional[bool])**
+  Creates a User Pool for the Auth@Edge configuration. Either this or ``staticsite_user_pool_arn`` are required when ``staticsite_auth_at_edge`` is ``true``.
+
+  Example:
+
+  .. code-block:: yaml
+
+    staticsite_create_user_pool: true
+
 **staticsite_user_pool_arn (Optional[str])**
-  Required if ``staticsite_auth_at_edge`` is ``true``. A pre-existing Cognito User Pool is required for user authentication.
+  A pre-existing Cognito User Pool is required for user authentication. Either this or ``staticsite_create_user_pool`` are required when ``staticsite_auth_at_edge`` is ``true``.
 
   Example:
 
@@ -343,7 +352,7 @@ Here is how the solution works:
 6. After passing all of the verification steps, `Lambda@Edge` strips out the Authorization header and allows the request to pass through to designated origin for CloudFront. In this case, the origin is the private content Amazon S3 bucket.
 7. After receiving response from the origin S3 bucket, CloudFront sends the response back to the browser. The browser displays the data from the returned response.
 
-An example of a `Auth@Edge`_ static site configuration is as follows. All listed options are required:
+An example of a `Auth@Edge`_ static site configuration is as follows:
 
 .. code-block:: yaml
 
@@ -362,5 +371,5 @@ An example of a `Auth@Edge`_ static site configuration is as follows. All listed
         - us-east-1
 
 The `Auth@Edge`_ functionality uses your existing Cognito User Pool (optionally configured
-with federated identity providers). A user pool app client will be automatically created
-within the pool for the application's use.
+with federated identity providers) or can create one for you with the ``staticsite_create_user_pool`` option.
+A user pool app client will be automatically created within the pool for the application's use.

--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -22,6 +22,11 @@ class Dependencies(Blueprint):
             'default': False,
             'description': 'Utilizing Authorization @ Edge'
         },
+        'CreateUserPool': {
+            'type': bool,
+            'default': False,
+            'description': 'Whether a User Pool should be created for the project'
+        },
         'UserPoolId': {
             'type': str,
             'default': '',
@@ -113,12 +118,27 @@ class Dependencies(Blueprint):
         if variables['AuthAtEdge']:
             callbacks = self.context.hook_data['aae_callback_url_retriever']['callback_urls']
 
+            user_pool_id = variables['UserPoolId']
+
+            if variables['CreateUserPool']:
+                user_pool = template.add_resource(
+                    cognito.UserPool("AuthAtEdgeUserPool")
+                )
+
+                user_pool_id = user_pool.ref()
+
+                template.add_output(Output(
+                    'AuthAtEdgeUserPoolId',
+                    Description='Cognito User Pool App Client for Auth @ Edge',
+                    Value=user_pool_id
+                ))
+
             client = template.add_resource(
                 cognito.UserPoolClient(
                     "AuthAtEdgeClient",
                     AllowedOAuthFlows=['code'],
                     CallbackURLs=callbacks,
-                    UserPoolId=variables['UserPoolId'],
+                    UserPoolId=user_pool_id,
                     AllowedOAuthScopes=variables['OAuthScopes']
                 )
             )

--- a/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
@@ -52,11 +52,19 @@ def get(context,  # pylint: disable=unused-argument
         )
         # Get the client_id from the outputs
         outputs = stack_desc['Stacks'][0]['Outputs']
+
+        if kwargs['user_pool_arn']:
+            user_pool_id = kwargs['user_pool_arn'].split('/')[-1:][0]
+        else:
+            user_pool_id = [
+                o['OutputValue'] for o in outputs if o['OutputKey'] == 'AuthAtEdgeUserPoolId'
+            ][0]
+
         client_id = [o['OutputValue'] for o in outputs if o['OutputKey'] == 'AuthAtEdgeClient'][0]
 
         # Poll the user pool client information
         resp = cognito_client.describe_user_pool_client(
-            UserPoolId=kwargs['user_pool_id'],
+            UserPoolId=user_pool_id,
             ClientId=client_id
         )
 

--- a/runway/hooks/staticsite/auth_at_edge/client_updater.py
+++ b/runway/hooks/staticsite/auth_at_edge/client_updater.py
@@ -63,7 +63,7 @@ def update(context,  # pylint: disable=unused-argument
             ClientId=kwargs['client_id'],
             CallbackURLs=redirect_uris_sign_in,
             LogoutURLs=redirect_uris_sign_out,
-            UserPoolId=kwargs['user_pool_id'],
+            UserPoolId=context.hook_data['aae_user_pool_id_retriever']['id'],
         )
         return True
     except Exception as err:  # pylint: disable=broad-except

--- a/runway/hooks/staticsite/auth_at_edge/lambda_config.py
+++ b/runway/hooks/staticsite/auth_at_edge/lambda_config.py
@@ -67,7 +67,7 @@ def write(context,  # type: context.Context
         'redirect_path_auth_refresh': kwargs['redirect_path_refresh'],
         'redirect_path_sign_in': kwargs['redirect_path_sign_in'],
         'redirect_path_sign_out': kwargs['redirect_path_sign_out'],
-        'user_pool_id': kwargs['user_pool_id'],
+        'user_pool_id': context.hook_data['aae_user_pool_id_retriever']['id']
     }
 
     # Shared file that contains the method called for configuration data

--- a/runway/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
@@ -1,0 +1,41 @@
+"""Retrieve the ID of the Cognito User Pool."""
+import logging
+
+from typing import Any, Dict, Optional  # pylint: disable=unused-import
+
+from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
+from runway.cfngin.context import Context  # noqa pylint: disable=unused-import
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get(context,  # pylint: disable=unused-argument
+        provider,  # pylint: disable=unused-argument
+        **kwargs
+       ):  # noqa: E124
+    # type: (Context, BaseProvider, Optional[Dict[str, Any]]) -> Dict
+    """Retrieve the ID of the Cognito User Pool.
+
+    The User Pool can either be supplied via an ARN or by being generated.
+    If the user has supplied an ARN that utilize that, otherwise retrieve
+    the generated id. Used in multiple pre_hooks for Auth@Edge.
+
+    Args:
+        context (:class:`runway.cfngin.context.Context`): The context
+            instance.
+        provider (:class:`runway.cfngin.providers.base.BaseProvider`):
+            The provider instance
+
+    Keyword Args:
+        user_pool_arn (str): The ARN of the supplied User pool
+        created_user_pool_id (str): The ID of the created Cognito User Pool
+    """
+    context_dict = {'id': ''}
+
+    # Favor a specific arn over a created one
+    if kwargs['user_pool_arn']:
+        context_dict['id'] = kwargs['user_pool_arn'].split('/')[-1:][0]
+    elif kwargs['created_user_pool_id']:
+        context_dict['id'] = kwargs['created_user_pool_id']
+
+    return context_dict


### PR DESCRIPTION
## Summary

**Note: This PR is dependent on two others being implemented that are in review state: https://github.com/onicagroup/runway/pull/190 && https://github.com/onicagroup/runway/pull/193**

This introduces the ability for the user to generate a basic User Pool with their Auth@Edge build.

## Why This Is Needed

Gives more flexibility to the User, allowing them to spin up an entire Auth@Edge suite without the need to supply manually created elements.

## What Changed

Made references in all pre_hooks from the data being supplied by `aae_create_user_pool_id` pre_hook.

### Added

- Ability to create a User Pool
- Domain Updater check to remove the generated domain prior to User Pool Deletion