### PR TITLE
fix runway module git path default location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - supports `load`, `transform`, `get`, and `default` arguments
   - dot notation to get nested data from the dictionary
 
+### Fixed
+- git module path will now default to the root of the repo when no `location` is provided.
+
 ## [1.4.4] - 2020-02-28
 ### Fixed
 - explicitly pass `provider` as a kwarg for resolving complex variable types

--- a/runway/path.py
+++ b/runway/path.py
@@ -228,7 +228,7 @@ class Path(object):  # pylint: disable=too-many-instance-attributes
         will be concatenated together.
         """
         split_uri_location = uri_loc_str.split('//')  # type: List[str, str]
-        location_string = '/'  # type: str
+        location_string = ''  # type: str
 
         if len(split_uri_location) == 3:
             location_string = split_uri_location[2]  # type: str

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -9,10 +9,10 @@ LOGGER = logging.getLogger('runway')
 
 
 class MockGitSource(Source):
-    """Mock a Git Source Object"""
+    """Mock a Git Source Object."""
 
     def fetch(self):
-        """ Fetch """
+        """Fetch."""
         return 'mock/git/folder'
 
 
@@ -28,12 +28,16 @@ class PathTester(unittest.TestCase):
         self.assertEqual(options, {})
 
     def test_parse_git_source_no_location_or_options(self):
-        """Parsing Git source with no location or options. Verify tuple is parsed as anticipated."""
+        """Parsing Git source with no location or options.
+
+        Verify tuple is parsed as anticipated.
+
+        """
         (source, uri, location, options) = Path.parse(
             {'path': 'git::git://github.com/onicagroup/foo/bar.git'}
         )
         self.assertEqual(source, 'git')
-        self.assertEqual(location, '/')
+        self.assertEqual(location, '')
         self.assertEqual(uri, 'git://github.com/onicagroup/foo/bar.git')
         self.assertEqual(options, {})
 
@@ -57,7 +61,7 @@ class PathTester(unittest.TestCase):
             {'path': 'git::git://github.com/onicagroup/foo/bar.git?branch=foo'}
         )
         self.assertEqual(source, 'git')
-        self.assertEqual(location, '/')
+        self.assertEqual(location, '')
         self.assertEqual(uri, 'git://github.com/onicagroup/foo/bar.git')
         self.assertEqual(options, {'branch': 'foo'})
 
@@ -71,15 +75,15 @@ class PathTester(unittest.TestCase):
             {'path': 'git::git://github.com/onicagroup/foo/bar.git?branch=foo&bar=baz'}
         )
         self.assertEqual(source, 'git')
-        self.assertEqual(location, '/')
+        self.assertEqual(location, '')
         self.assertEqual(uri, 'git://github.com/onicagroup/foo/bar.git')
         self.assertEqual(options, {'branch': 'foo', 'bar': 'baz'})
 
     def test_parse_git_source_with_options_and_location(self):
-        """
-        Parsing Git source with options and location
+        """Parsing Git source with options and location.
 
         Verify tuple is parsed as anticipated.
+
         """
         (source, uri, location, options) = Path.parse(
             {'path': 'git::git://github.com/onicagroup/foo/bar.git//src/foo/bar?branch=foo'}
@@ -90,10 +94,10 @@ class PathTester(unittest.TestCase):
         self.assertEqual(options, {'branch': 'foo'})
 
     def test_parse_git_source_with_multiple_options_and_location(self):
-        """
-        Parsing Git source with multiple options and location
+        """Parsing Git source with multiple options and location.
 
         Verify tuple is parsed as anticipated.
+
         """
         path = 'git::git://github.com/onicagroup/foo/bar.git//src/foo/bar?branch=foo&bar=baz'
         (source, uri, location, options) = Path.parse({'path': path})
@@ -125,11 +129,11 @@ class PathTester(unittest.TestCase):
         self.assertEqual(instance2.module_root, 'fake/env/root')
 
     def test_module_root_set_to_contcatenated_path(self):
-        """
-            Test module root set to concatednated path.
+        """Test module root set to concatednated path.
 
-            When the path location is local and not the
-            root combine the location with the env_root.
+        When the path location is local and not the root combine the location
+        with the env_root.
+
         """
         path = 'foo/bar'
         instance = Path({'path': path}, 'fake/env/root', git_source_class=MockGitSource)


### PR DESCRIPTION
## Why This Is Needed

When providing a path to a git repo like in the below example, without a `location` provided, it will default to `/` (root) instead of the root of the cloned git repo (`/path/to/repo/.runway_cache/<calculated-path>`).

```
deployments:
  - modules:
      - path: git::git://github.com/cfngin/cfngin-bucket.git?tag=v0.1.0
```

## What Changed

### Fixed

- git module path will now default to the root of the repo when no `location` is provided.
