### PR TITLE
[Hotfix] Callback URL Retriever hook call in wrong conditional

### DIFF
--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -110,9 +110,9 @@ class Dependencies(Blueprint):
             Value=artifacts.ref()
         ))
 
-        callbacks = self.context.hook_data['aae_callback_url_retriever']['callback_urls']
-
         if variables['AuthAtEdge']:
+            callbacks = self.context.hook_data['aae_callback_url_retriever']['callback_urls']
+
             client = template.add_resource(
                 cognito.UserPoolClient(
                     "AuthAtEdgeClient",


### PR DESCRIPTION
## Summary

Discovered a bug where the Callback URL Retriever hook request was not located within the `AuthAtEdge` conditional. This will cause standard static sites to fail.

## Why This Is Needed

Standard Static sites will fail on launch as hook data is being retrieved that does not exist.

### Fixed

Moved callback retriever in the `dependencies` to the correct conditional (e.g. Only when using Auth@Edge)

![image](https://user-images.githubusercontent.com/1512028/76763968-0cf41480-6762-11ea-94c7-45907e209feb.png)
