### PR TITLE
add stacker config deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `hook_data` lookup now supports the standardized lookup query syntax
   - supports `load`, `transform`, `get`, and `default` arguments
   - dot notation to get nested data from the dictionary
+- deprecate `stacker_bucket` in CFNgin configs
+  - replaced by `cfngin_bucket`
+- deprecate `stacker_bucket_region` in CFNgin configs
+  - replaced by `cfngin_bucket_region`
 
 ## [1.4.4] - 2020-02-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - replaced by `cfngin_bucket`
 - deprecate `stacker_bucket_region` in CFNgin configs
   - replaced by `cfngin_bucket_region`
+- deprecate `stacker_cache_dir` in CFNgin configs
+  - replaced by `cfngin_cache_dir`
 
 ## [1.4.4] - 2020-02-28
 ### Fixed

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -580,6 +580,19 @@ class Config(Model):
         except SchematicsError as err:
             raise exceptions.InvalidConfig(err.errors)
 
+    def validate_stacker_cache_dir(self, _data, value):  # pylint: disable=no-self-use
+        """Validate stacker_cache_dir is not used.
+
+        If in use, show deprecation warning.
+
+        """
+        msg = ('Use of "stacker_cache_dir" has been deprecated and will '
+               'be removed after the next major release. Please use '
+               '"cfngin_cache_dir".')
+        if value:
+            warnings.warn(msg, DeprecationWarning)
+            LOGGER.warning(msg)
+
     def validate_stacker_bucket(self, _data, value):  # pylint: disable=no-self-use
         """Validate stack_bucket is not used.
 
@@ -594,7 +607,7 @@ class Config(Model):
             LOGGER.warning(msg)
 
     def validate_stacker_bucket_region(self, _data, value):  # pylint: disable=no-self-use
-        """Validate stack_bucket is not used.
+        """Validate stacker_bucket_regio is not used.
 
         If in use, show deprecation warning.
 

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from io import StringIO
 from string import Template
+import warnings
 
 import yaml
 from schematics import Model
@@ -578,6 +579,32 @@ class Config(Model):
             raise exceptions.InvalidConfig([str(err)])
         except SchematicsError as err:
             raise exceptions.InvalidConfig(err.errors)
+
+    def validate_stacker_bucket(self, _data, value):  # pylint: disable=no-self-use
+        """Validate stack_bucket is not used.
+
+        If in use, show deprecation warning.
+
+        """
+        msg = ('Use of "stacker_bucket" has been deprecated and will be '
+               'removed after the next major release. Please use '
+               '"cfngin_bucket".')
+        if value or value == '':
+            warnings.warn(msg, DeprecationWarning)
+            LOGGER.warning(msg)
+
+    def validate_stacker_bucket_region(self, _data, value):  # pylint: disable=no-self-use
+        """Validate stack_bucket is not used.
+
+        If in use, show deprecation warning.
+
+        """
+        msg = ('Use of "stacker_bucket_region" has been deprecated and will '
+               'be removed after the next major release. Please use '
+               '"cfngin_bucket_region".')
+        if value:
+            warnings.warn(msg, DeprecationWarning)
+            LOGGER.warning(msg)
 
     def validate_stacks(self, _data, value):  # pylint: disable=no-self-use
         """Validate stacks."""

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -2,9 +2,9 @@
 import copy
 import logging
 import sys
+import warnings
 from io import StringIO
 from string import Template
-import warnings
 
 import yaml
 from schematics import Model
@@ -580,19 +580,6 @@ class Config(Model):
         except SchematicsError as err:
             raise exceptions.InvalidConfig(err.errors)
 
-    def validate_stacker_cache_dir(self, _data, value):  # pylint: disable=no-self-use
-        """Validate stacker_cache_dir is not used.
-
-        If in use, show deprecation warning.
-
-        """
-        msg = ('Use of "stacker_cache_dir" has been deprecated and will '
-               'be removed after the next major release. Please use '
-               '"cfngin_cache_dir".')
-        if value:
-            warnings.warn(msg, DeprecationWarning)
-            LOGGER.warning(msg)
-
     def validate_stacker_bucket(self, _data, value):  # pylint: disable=no-self-use
         """Validate stack_bucket is not used.
 
@@ -615,6 +602,19 @@ class Config(Model):
         msg = ('Use of "stacker_bucket_region" has been deprecated and will '
                'be removed after the next major release. Please use '
                '"cfngin_bucket_region".')
+        if value:
+            warnings.warn(msg, DeprecationWarning)
+            LOGGER.warning(msg)
+
+    def validate_stacker_cache_dir(self, _data, value):  # pylint: disable=no-self-use
+        """Validate stacker_cache_dir is not used.
+
+        If in use, show deprecation warning.
+
+        """
+        msg = ('Use of "stacker_cache_dir" has been deprecated and will '
+               'be removed after the next major release. Please use '
+               '"cfngin_cache_dir".')
         if value:
             warnings.warn(msg, DeprecationWarning)
             LOGGER.warning(msg)


### PR DESCRIPTION
## Why This Is Needed

Log a warning when CFNgin config keys are used that we intend to remove support for in the future. These keys use `stacker` in their name.

## What Changed

### Added

- deprecation warnings when `stacker_bucket`, `stacker_bucket_region`, and `stacker_config_dir` are used.

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/76785888-716b9f80-6773-11ea-91cf-09fe21fc5e36.png)

