### PR TITLE
catch AttributeError in cfngin diff for stack from persist graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - git module path will now default to the root of the repo when no `location` is provided.
+- cfngin correctly notifies when a stack will be deleted during `runway plan` when using persistent graph
 
 ## [1.4.4] - 2020-02-28
 ### Fixed

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -173,22 +173,21 @@ class Action(build.Action):
         provider = self.build_provider(stack)
         tags = build.build_stack_tags(stack)
 
-        stack.resolve(self.context, provider)
-        parameters = self.build_parameters(stack)
-
         try:
+            stack.resolve(self.context, provider)
+            parameters = self.build_parameters(stack)
             outputs = provider.get_stack_changes(
                 stack, self._template(stack.blueprint), parameters, tags
             )
             stack.set_outputs(outputs)
         except exceptions.StackDidNotChange:
             LOGGER.info('No changes: %s', stack.fqn)
-        except exceptions.StackDoesNotExist:  # TODO make sure this is correct post chageset
+        except exceptions.StackDoesNotExist:
             if self.context.persistent_graph:
                 return SkippedStatus('persistent graph: stack does not '
                                      'exist, will be removed')
             return StackDoesNotExistStatus()
-        except AttributeError as err:  # TODO make sure this is correct post chageset
+        except AttributeError as err:
             if (self.context.persistent_graph and
                     'defined class or template path' in str(err)):
                 return SkippedStatus('persistent graph: will be destroyed')


### PR DESCRIPTION
## Why This Is Needed

When running `runway plan` with a cfngin persistent graph containing a stack that has been removed from the confg, the below error is raised

```
INFO:runway.cfngin.actions.diff:Diffing stacks: runway-test-stack, runway-test-stack-02
ERROR:runway.cfngin.plan:Stack does not have a defined class or template path.
Traceback (most recent call last):
  File "/Users/kyle/repos/runway/runway/cfngin/plan.py", line 142, in _run_once
    status = self.fn(self.stack, status=self.status)
  File "/Users/kyle/repos/runway/runway/cfngin/actions/diff.py", line 176, in _diff_stack
    stack.resolve(self.context, provider)
  File "/Users/kyle/repos/runway/runway/cfngin/stack.py", line 228, in resolve
    self.blueprint.resolve_variables(self.variables)
  File "/Users/kyle/repos/runway/runway/cfngin/stack.py", line 151, in blueprint
    raise AttributeError("Stack does not have a defined class or "
AttributeError: Stack does not have a defined class or template path.
INFO:runway.cfngin.ui:runway-test-stack: failed (Stack does not have a defined class or template path.)
```

## What Changed

### Fixed

- cfngin correctly notifies when a stack will be deleted during `runway plan` when using persistent graph

## New Output

```
INFO:runway.cfngin.actions.diff:Diffing stacks: runway-test-stack, runway-test-stack-02
INFO:runway.cfngin.ui:runway-test-stack: skipped (persistent graph: will be destroyed)
INFO:runway.cfngin.actions.diff:No changes: finley-runway-testing-runway-test-stack-02
```
