### PR TITLE
add cfngin stack termination protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ssm` lookup usable in Runway and CFNgin config files
 - `troposphere` transform option for lookups
 - Private (authorized AKA Auth@Edge) static sites
+- `termination_protection` CFNgin stack option
 
 ### Changed
 - `get_session` can now accept AWS credentials when creating a thread-safe session

--- a/docs/source/cfngin/config.rst
+++ b/docs/source/cfngin/config.rst
@@ -519,9 +519,9 @@ A stack has the following keys:
   http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html
 
 **enabled (Optional[bool])**
-  If set to false, the stack is disabled, and will not be
+  If set to ``false``, the stack is disabled, and will not be
   built or updated. This can allow you to disable stacks in different
-  environments.
+  environments. (*default:* ``true``)
 
 **in_progress_behavior (Optional[str])**
   If provided, specifies the behavior for when a stack is in
@@ -531,17 +531,19 @@ A stack has the following keys:
   before attempting to update the stack.
 
 **locked (Optional[bool])**
-  If set to true, the stack is locked and will not be
+  If set to ``true``, the stack is locked and will not be
   updated unless the stack is passed to CFNgin via the ``--force`` flag.
   This is useful for **risky** stacks that you don't want to take the
   risk of allowing CloudFormation to update, but still want to make
   sure get launched when the environment is first created. When ``locked``,
   it's not necessary to specify a ``class_path`` or ``template_path``.
+  (*default:* ``false``)
 
 **protected (Optional[bool])**
   When running an update in non-interactive mode, if a stack has
-  ``protected`` set to ``true`` and would get changed, CFNgin will switch to
+  ``protected: true`` and would get changed, CFNgin will switch to
   interactive mode for that stack, allowing you to approve/skip the change.
+  (*default:* ``false``)
 
 **required_by (Optional[List[str]])**
   A list of other stacks or targets that require this stack. It's an
@@ -575,6 +577,12 @@ A stack has the following keys:
   working directory (e.g. templates stored alongside the Config), or relative
   to a directory in the python ``sys.path`` (i.e. for loading templates
   retrieved via ``packages_sources``).
+
+**termination_protection (Optional[bool])**
+  If ``true``, the stack will be protected from termination by CloudFormation.
+  Any attempts to destroy the stack (using Runway, the AWS Console, AWS API, etc) will be prevented unless manually disabled.
+  When updating a stack and the value has been changed to ``false``, termination protection will be disabled.
+  (*default:* ``false``)
 
 **variables (Optional[Dict[str, str]])**
   A dictionary of Variables_ to pass into the Blueprint_ when rendering the

--- a/docs/source/cfngin/config.rst
+++ b/docs/source/cfngin/config.rst
@@ -509,28 +509,28 @@ If no ``stack_name`` is provided, the value here will be used for the name of th
 
 A stack has the following keys:
 
-**class_path:**
+**class_path (str)**
   The python class path to the Blueprint_ to be used. Specify this or
   ``template_path`` for the stack.
 
-**description:**
+**description (str)**
   A short description to apply to the stack. This overwrites any description
   provided in the Blueprint_. See:
   http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html
 
-**enabled:**
+**enabled (bool)**
   (optional) If set to false, the stack is disabled, and will not be
   built or updated. This can allow you to disable stacks in different
   environments.
 
-**in_progress_behavior**:
+**in_progress_behavior (str)**
   (optional): If provided, specifies the behavior for when a stack is in
   ``CREATE_IN_PROGRESS`` or ``UPDATE_IN_PROGRESS``. By default, CFNgin will raise
   an exception if the stack is in an ``IN_PROGRESS`` state. You can set this
   option to ``wait`` and CFNgin will wait for the previous update to complete
   before attempting to update the stack.
 
-**locked:**
+**locked (bool)**
   (optional) If set to true, the stack is locked and will not be
   updated unless the stack is passed to CFNgin via the ``--force`` flag.
   This is useful for **risky** stacks that you don't want to take the
@@ -538,45 +538,45 @@ A stack has the following keys:
   sure get launched when the environment is first created. When ``locked``,
   it's not necessary to specify a ``class_path`` or ``template_path``.
 
-**protected:**
+**protected (bool)**
   (optional) When running an update in non-interactive mode, if a stack has
   ``protected`` set to ``true`` and would get changed, CFNgin will switch to
   interactive mode for that stack, allowing you to approve/skip the change.
 
-**required_by:**
+**required_by (List[str])**
   (optional) a list of other stacks or targets that require this stack. It's an
   inverse to ``requires``.
 
-**requires:**
+**requires (List[str])**
   (optional) a list of other stacks this stack requires. This is for explicit
   dependencies - you do not need to set this if you refer to another stack in
   a Parameter, so this is rarely necessary.
 
-**stack_name:**
+**stack_name (str)**
   (optional) If provided, this will be used as the name of the CloudFormation
   stack. Unlike ``name``, the value doesn't need to be unique within the config,
   since you could have multiple stacks with the same name, but in different
   regions or accounts. (note: the namespace from the environment will be
   prepended to this)
 
-**stack_policy_path**:
+**stack_policy_path (str)**
   (optional): If provided, specifies the path to a JSON formatted stack policy
   that will be applied when the CloudFormation stack is created and updated.
   You can use stack policies to prevent CloudFormation from making updates to
   protected resources (e.g. databases). See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
 
-**tags:**
+**tags (Dict[str, str])**
   (optional) a dictionary of CloudFormation tags to apply to this stack. This
   will be combined with the global tags, but these tags will take precedence.
 
-**template_path:**
+**template_path (str)**
   Path to raw CloudFormation template (JSON or YAML). Specify this or
   ``class_path`` for the stack. Path can be specified relative to the current
   working directory (e.g. templates stored alongside the Config), or relative
   to a directory in the python ``sys.path`` (i.e. for loading templates
   retrieved via ``packages_sources``).
 
-**variables:**
+**variables (Dict[str, str])**
   A dictionary of Variables_ to pass into the Blueprint_ when rendering the
   CloudFormation template. Variables_ can be any valid YAML data
   structure.

--- a/docs/source/cfngin/config.rst
+++ b/docs/source/cfngin/config.rst
@@ -513,22 +513,22 @@ A stack has the following keys:
   The python class path to the Blueprint_ to be used. Specify this or
   ``template_path`` for the stack.
 
-**template_path:**
-  Path to raw CloudFormation template (JSON or YAML). Specify this or
-  ``class_path`` for the stack. Path can be specified relative to the current
-  working directory (e.g. templates stored alongside the Config), or relative
-  to a directory in the python ``sys.path`` (i.e. for loading templates
-  retrieved via ``packages_sources``).
-
 **description:**
   A short description to apply to the stack. This overwrites any description
   provided in the Blueprint_. See:
   http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html
 
-**variables:**
-  A dictionary of Variables_ to pass into the Blueprint_ when rendering the
-  CloudFormation template. Variables_ can be any valid YAML data
-  structure.
+**enabled:**
+  (optional) If set to false, the stack is disabled, and will not be
+  built or updated. This can allow you to disable stacks in different
+  environments.
+
+**in_progress_behavior**:
+  (optional): If provided, specifies the behavior for when a stack is in
+  ``CREATE_IN_PROGRESS`` or ``UPDATE_IN_PROGRESS``. By default, CFNgin will raise
+  an exception if the stack is in an ``IN_PROGRESS`` state. You can set this
+  option to ``wait`` and CFNgin will wait for the previous update to complete
+  before attempting to update the stack.
 
 **locked:**
   (optional) If set to true, the stack is locked and will not be
@@ -538,28 +538,19 @@ A stack has the following keys:
   sure get launched when the environment is first created. When ``locked``,
   it's not necessary to specify a ``class_path`` or ``template_path``.
 
-**enabled:**
-  (optional) If set to false, the stack is disabled, and will not be
-  built or updated. This can allow you to disable stacks in different
-  environments.
-
 **protected:**
   (optional) When running an update in non-interactive mode, if a stack has
   ``protected`` set to ``true`` and would get changed, CFNgin will switch to
   interactive mode for that stack, allowing you to approve/skip the change.
 
-**requires:**
-  (optional) a list of other stacks this stack requires. This is for explicit
-  dependencies - you do not need to set this if you refer to another stack in
-  a Parameter, so this is rarely necessary.
-
 **required_by:**
   (optional) a list of other stacks or targets that require this stack. It's an
   inverse to ``requires``.
 
-**tags:**
-  (optional) a dictionary of CloudFormation tags to apply to this stack. This
-  will be combined with the global tags, but these tags will take precedence.
+**requires:**
+  (optional) a list of other stacks this stack requires. This is for explicit
+  dependencies - you do not need to set this if you refer to another stack in
+  a Parameter, so this is rarely necessary.
 
 **stack_name:**
   (optional) If provided, this will be used as the name of the CloudFormation
@@ -574,12 +565,21 @@ A stack has the following keys:
   You can use stack policies to prevent CloudFormation from making updates to
   protected resources (e.g. databases). See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
 
-**in_progress_behavior**:
-  (optional): If provided, specifies the behavior for when a stack is in
-  ``CREATE_IN_PROGRESS`` or ``UPDATE_IN_PROGRESS``. By default, CFNgin will raise
-  an exception if the stack is in an ``IN_PROGRESS`` state. You can set this
-  option to ``wait`` and CFNgin will wait for the previous update to complete
-  before attempting to update the stack.
+**tags:**
+  (optional) a dictionary of CloudFormation tags to apply to this stack. This
+  will be combined with the global tags, but these tags will take precedence.
+
+**template_path:**
+  Path to raw CloudFormation template (JSON or YAML). Specify this or
+  ``class_path`` for the stack. Path can be specified relative to the current
+  working directory (e.g. templates stored alongside the Config), or relative
+  to a directory in the python ``sys.path`` (i.e. for loading templates
+  retrieved via ``packages_sources``).
+
+**variables:**
+  A dictionary of Variables_ to pass into the Blueprint_ when rendering the
+  CloudFormation template. Variables_ can be any valid YAML data
+  structure.
 
 
 Stacks Example

--- a/docs/source/cfngin/config.rst
+++ b/docs/source/cfngin/config.rst
@@ -509,74 +509,74 @@ If no ``stack_name`` is provided, the value here will be used for the name of th
 
 A stack has the following keys:
 
-**class_path (str)**
+**class_path (Optional[str])**
   The python class path to the Blueprint_ to be used. Specify this or
   ``template_path`` for the stack.
 
-**description (str)**
+**description (Optional[str])**
   A short description to apply to the stack. This overwrites any description
   provided in the Blueprint_. See:
   http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html
 
-**enabled (bool)**
-  (optional) If set to false, the stack is disabled, and will not be
+**enabled (Optional[bool])**
+  If set to false, the stack is disabled, and will not be
   built or updated. This can allow you to disable stacks in different
   environments.
 
-**in_progress_behavior (str)**
-  (optional): If provided, specifies the behavior for when a stack is in
+**in_progress_behavior (Optional[str])**
+  If provided, specifies the behavior for when a stack is in
   ``CREATE_IN_PROGRESS`` or ``UPDATE_IN_PROGRESS``. By default, CFNgin will raise
   an exception if the stack is in an ``IN_PROGRESS`` state. You can set this
   option to ``wait`` and CFNgin will wait for the previous update to complete
   before attempting to update the stack.
 
-**locked (bool)**
-  (optional) If set to true, the stack is locked and will not be
+**locked (Optional[bool])**
+  If set to true, the stack is locked and will not be
   updated unless the stack is passed to CFNgin via the ``--force`` flag.
   This is useful for **risky** stacks that you don't want to take the
   risk of allowing CloudFormation to update, but still want to make
   sure get launched when the environment is first created. When ``locked``,
   it's not necessary to specify a ``class_path`` or ``template_path``.
 
-**protected (bool)**
-  (optional) When running an update in non-interactive mode, if a stack has
+**protected (Optional[bool])**
+  When running an update in non-interactive mode, if a stack has
   ``protected`` set to ``true`` and would get changed, CFNgin will switch to
   interactive mode for that stack, allowing you to approve/skip the change.
 
-**required_by (List[str])**
-  (optional) a list of other stacks or targets that require this stack. It's an
+**required_by (Optional[List[str]])**
+  A list of other stacks or targets that require this stack. It's an
   inverse to ``requires``.
 
-**requires (List[str])**
-  (optional) a list of other stacks this stack requires. This is for explicit
+**requires (Optional[List[str]])**
+  A list of other stacks this stack requires. This is for explicit
   dependencies - you do not need to set this if you refer to another stack in
   a Parameter, so this is rarely necessary.
 
-**stack_name (str)**
-  (optional) If provided, this will be used as the name of the CloudFormation
+**stack_name (Optional[str])**
+  If provided, this will be used as the name of the CloudFormation
   stack. Unlike ``name``, the value doesn't need to be unique within the config,
   since you could have multiple stacks with the same name, but in different
   regions or accounts. (note: the namespace from the environment will be
   prepended to this)
 
-**stack_policy_path (str)**
-  (optional): If provided, specifies the path to a JSON formatted stack policy
+**stack_policy_path (Optional[str])**
+  If provided, specifies the path to a JSON formatted stack policy
   that will be applied when the CloudFormation stack is created and updated.
   You can use stack policies to prevent CloudFormation from making updates to
   protected resources (e.g. databases). See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
 
-**tags (Dict[str, str])**
-  (optional) a dictionary of CloudFormation tags to apply to this stack. This
+**tags (Optional[Dict[str, str]])**
+  A dictionary of CloudFormation tags to apply to this stack. This
   will be combined with the global tags, but these tags will take precedence.
 
-**template_path (str)**
+**template_path (Optional[str])**
   Path to raw CloudFormation template (JSON or YAML). Specify this or
   ``class_path`` for the stack. Path can be specified relative to the current
   working directory (e.g. templates stored alongside the Config), or relative
   to a directory in the python ``sys.path`` (i.e. for loading templates
   retrieved via ``packages_sources``).
 
-**variables (Dict[str, str])**
+**variables (Optional[Dict[str, str]])**
   A dictionary of Variables_ to pass into the Blueprint_ when rendering the
   CloudFormation template. Variables_ can be any valid YAML data
   structure.

--- a/runway/cfngin/actions/build.py
+++ b/runway/cfngin/actions/build.py
@@ -366,13 +366,15 @@ class Action(BaseAction):
         if recreate:
             LOGGER.debug("Re-creating stack: %s", stack.fqn)
             provider.create_stack(stack.fqn, template, parameters,
-                                  tags, stack_policy=stack_policy)
+                                  tags, stack_policy=stack_policy,
+                                  termination_protection=stack.termination_protection)
             return SubmittedStatus("re-creating stack")
         if not provider_stack:
             LOGGER.debug("Creating new stack: %s", stack.fqn)
             provider.create_stack(stack.fqn, template, parameters, tags,
                                   force_change_set,
-                                  stack_policy=stack_policy)
+                                  stack_policy=stack_policy,
+                                  termination_protection=stack.termination_protection)
             return SubmittedStatus("creating new stack")
 
         try:
@@ -390,6 +392,7 @@ class Action(BaseAction):
                     force_interactive=stack.protected,
                     force_change_set=force_change_set,
                     stack_policy=stack_policy,
+                    termination_protection=stack.termination_protection
                 )
 
                 LOGGER.debug("Updating existing stack: %s", stack.fqn)

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -341,6 +341,7 @@ class Stack(Model):
         stack_policy_path (StringType)
         tags (DictType)
         template_path (StringType)
+        termination_protection (BooleanType)
         variables (DictType)
 
     """
@@ -361,6 +362,7 @@ class Stack(Model):
     stack_policy_path = StringType(serialize_when_none=False)
     tags = DictType(StringType, serialize_when_none=False)
     template_path = StringType(serialize_when_none=False)
+    termination_protection = BooleanType(default=False)
     variables = DictType(AnyType, serialize_when_none=False)
 
     def validate_class_path(self, data, value):

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -812,6 +812,7 @@ class Provider(BaseProvider):
             self.cloudformation.execute_change_set(
                 ChangeSetName=change_set_id,
             )
+            self.update_termination_protection(fqn, termination_protection)
         else:
             args = generate_cloudformation_args(
                 fqn, parameters, tags, template,

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -1035,7 +1035,7 @@ class Provider(BaseProvider):
             if 'TerminationProtection' in err.response['Error']['Message']:
                 approval = ui.ask('Termination protection is enabled for '
                                   "stack '{}'.\nWould you like to disable it "
-                                  'and try deleting the stack again? '
+                                  'and try destroying the stack again? '
                                   '[{}] '.format(
                                       fqn,
                                       '/'.join(approval_options)

--- a/runway/cfngin/stack.py
+++ b/runway/cfngin/stack.py
@@ -49,6 +49,8 @@ class Stack(object):
         profile (str): Profile name from the stack definition.
         protected (bool): Whether this stack is protected.
         region (str): AWS region name.
+        termination_protection (bool): The state of termination protection
+            to apply to the stack.
         variables (Optional[Dict[str, Any]]): Variables for the stack.
 
     """
@@ -71,23 +73,25 @@ class Stack(object):
             protected (bool): Whether this stack is protected.
 
         """
-        self.logging = True
-        self.name = definition.name
-        self.fqn = context.get_fqn(definition.stack_name or self.name)
-        self.region = definition.region
-        self.profile = definition.profile
-        self.definition = definition
-        self.variables = _initialize_variables(definition, variables)
-        self.mappings = mappings
-        self.locked = locked
-        self.force = force
-        self.enabled = enabled
-        self.protected = protected
-        self.context = context
-        self.outputs = None
-        self.in_progress_behavior = definition.in_progress_behavior
         self._blueprint = None
         self._stack_policy = None
+
+        self.name = definition.name  # dependency of other attrs
+        self.context = context
+        self.definition = definition
+        self.enabled = enabled
+        self.force = force
+        self.fqn = context.get_fqn(definition.stack_name or self.name)
+        self.in_progress_behavior = definition.in_progress_behavior
+        self.locked = locked
+        self.logging = True
+        self.mappings = mappings
+        self.outputs = None
+        self.profile = definition.profile
+        self.protected = protected
+        self.region = definition.region
+        self.termination_protection = definition.termination_protection
+        self.variables = _initialize_variables(definition, variables)
 
     @property
     def required_by(self):

--- a/tests/cfngin/providers/aws/test_default.py
+++ b/tests/cfngin/providers/aws/test_default.py
@@ -47,7 +47,8 @@ def random_string(length=12):
 def generate_describe_stacks_stack(stack_name,
                                    creation_time=None,
                                    stack_status="CREATE_COMPLETE",
-                                   tags=None):
+                                   tags=None,
+                                   termination_protection=False):
     """Generate describe stacks stack."""
     tags = tags or []
     return {
@@ -55,7 +56,8 @@ def generate_describe_stacks_stack(stack_name,
         "StackId": stack_name,
         "CreationTime": creation_time or datetime(2015, 1, 1),
         "StackStatus": stack_status,
-        "Tags": tags
+        "Tags": tags,
+        "EnableTerminationProtection": termination_protection
     }
 
 
@@ -911,11 +913,14 @@ class TestProviderInteractiveMode(unittest.TestCase):
         stack_name = "my-fake-stack"
 
         self.stubber.add_response(
+            'describe_stacks',
+            {'Stacks': [generate_describe_stacks_stack(stack_name)]}
+        )
+        self.stubber.add_response(
             "create_change_set",
             {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
         )
-        changes = []
-        changes.append(generate_change())
+        changes = [generate_change()]
 
         self.stubber.add_response(
             "describe_change_set",
@@ -949,11 +954,14 @@ class TestProviderInteractiveMode(unittest.TestCase):
         stack_name = "my-fake-stack"
 
         self.stubber.add_response(
+            'describe_stacks',
+            {'Stacks': [generate_describe_stacks_stack(stack_name)]}
+        )
+        self.stubber.add_response(
             "create_change_set",
             {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
         )
-        changes = []
-        changes.append(generate_change())
+        changes = [generate_change()]
 
         self.stubber.add_response(
             "describe_change_set",

--- a/tests/cfngin/providers/aws/test_default.py
+++ b/tests/cfngin/providers/aws/test_default.py
@@ -4,6 +4,7 @@ import copy
 import os.path
 import random
 import string
+import sys
 import threading
 import unittest
 from datetime import datetime
@@ -28,6 +29,12 @@ from runway.cfngin.providers.aws.default import (DEFAULT_CAPABILITIES,
 from runway.cfngin.providers.base import Template
 from runway.cfngin.session_cache import get_session
 from runway.cfngin.stack import Stack
+from runway.util import MutableMap
+
+if sys.version_info.major < 3:
+    from pathlib2 import Path  # pylint: disable=E
+else:
+    from pathlib import Path  # pylint: disable=E
 
 
 def random_string(length=12):
@@ -462,6 +469,62 @@ class TestProviderDefaultMode(unittest.TestCase):
             self.session, region=region, recreate_failed=False)
         self.stubber = Stubber(self.provider.cloudformation)
 
+    def test_create_stack_no_changeset(self):
+        """Test create_stack, no changeset, template url."""
+        stack_name = 'fake_stack'
+        template = Template(url="http://fake.template.url.com/")
+        parameters = []
+        tags = []
+
+        expected_args = generate_cloudformation_args(stack_name,
+                                                     parameters,
+                                                     tags,
+                                                     template)
+        expected_args['EnableTerminationProtection'] = False
+
+        self.stubber.add_response(
+            'create_stack',
+            {'StackId': stack_name},
+            expected_args
+        )
+
+        with self.stubber:
+            self.provider.create_stack(stack_name, template, parameters, tags)
+        self.stubber.assert_no_pending_responses()
+
+    @patch('runway.cfngin.providers.aws.default.Provider.update_termination_protection')
+    @patch('runway.cfngin.providers.aws.default.create_change_set')
+    def test_create_stack_with_changeset(self, patched_create_change_set,
+                                         patched_update_term):
+        """Test create_stack, force changeset, termination protection."""
+        stack_name = 'fake_stack'
+        template_path = Path('./tests/cfngin/fixtures/cfn_template.yaml')
+        template = Template(body=template_path.read_text())
+        parameters = []
+        tags = []
+
+        changeset_id = 'CHANGESETID'
+
+        patched_create_change_set.return_value = ([], changeset_id)
+
+        self.stubber.add_response(
+            'execute_change_set',
+            {},
+            {'ChangeSetName': changeset_id}
+        )
+
+        with self.stubber:
+            self.provider.create_stack(stack_name, template, parameters, tags,
+                                       force_change_set=True,
+                                       termination_protection=True)
+        self.stubber.assert_no_pending_responses()
+
+        patched_create_change_set.assert_called_once_with(
+            self.provider.cloudformation, stack_name, template, parameters,
+            tags, 'CREATE', service_role=self.provider.service_role
+        )
+        patched_update_term.assert_called_once_with(stack_name, True)
+
     def test_destroy_stack(self):
         """Test destroy stack."""
         stack = {'StackName': 'MockStack'}
@@ -673,6 +736,14 @@ class TestProviderDefaultMode(unittest.TestCase):
                 parameters=[], stack_policy=Template(body="{}"), tags=[],
             )
 
+    def test_noninteractive_destroy_stack_termination_protected(self):
+        """Test noninteractive_destroy_stack with termination protection."""
+        self.stubber.add_client_error('delete_stack')
+
+        with self.stubber, self.assertRaises(ClientError):
+            self.provider.noninteractive_destroy_stack('fake-stack')
+        self.stubber.assert_no_pending_responses()
+
     @patch('runway.cfngin.providers.aws.default.output_full_changeset')
     def test_get_stack_changes_update(self, mock_output_full_cs):
         """Test get stack changes update."""
@@ -866,6 +937,38 @@ class TestProviderDefaultMode(unittest.TestCase):
 
         self.assertEqual(received_events[0]["EventId"], "Event1")
 
+    def test_update_termination_protection(self):
+        """Test update_termination_protection."""
+        stack_name = 'fake-stack'
+        test_cases = [
+            MutableMap(aws=False, defined=True, expected=True),
+            MutableMap(aws=True, defined=False, expected=False),
+            MutableMap(aws=True, defined=True, expected=None),
+            MutableMap(aws=False, defined=False, expected=None)
+        ]
+
+        for test in test_cases:
+            self.stubber.add_response(
+                'describe_stacks',
+                {'Stacks': [
+                    generate_describe_stacks_stack(
+                        stack_name, termination_protection=test.aws
+                    )
+                ]},
+                {'StackName': stack_name}
+            )
+            if isinstance(test.expected, bool):
+                self.stubber.add_response(
+                    'update_termination_protection',
+                    {'StackId': stack_name},
+                    {'EnableTerminationProtection': test.expected,
+                     'StackName': stack_name}
+                )
+            with self.stubber:
+                self.provider.update_termination_protection(stack_name,
+                                                            test.defined)
+            self.stubber.assert_no_pending_responses()
+
 
 class TestProviderInteractiveMode(unittest.TestCase):
     """Tests for runway.cfngin.providers.aws.default interactive mode."""
@@ -879,16 +982,37 @@ class TestProviderInteractiveMode(unittest.TestCase):
         self.stubber = Stubber(self.provider.cloudformation)
 
     @patch('runway.cfngin.ui.get_raw_input')
-    def test_destroy_stack(self, patched_input):
-        """Test destroy stack."""
-        stack = {'StackName': 'MockStack'}
+    def test_interactive_destroy_stack(self, patched_input):
+        """Test interactive_destroy_stack."""
+        stack_name = 'fake-stack'
+        stack = {'StackName': stack_name}
         patched_input.return_value = 'y'
 
         self.stubber.add_response('delete_stack', {}, stack)
 
         with self.stubber:
-            self.assertIsNone(self.provider.destroy_stack(stack))
+            self.assertIsNone(self.provider.interactive_destroy_stack(stack_name))
             self.stubber.assert_no_pending_responses()
+
+    @patch('runway.cfngin.providers.aws.default.Provider.update_termination_protection')
+    @patch('runway.cfngin.ui.get_raw_input')
+    def test_interactive_destroy_stack_termination_protected(self,
+                                                             patched_input,
+                                                             patched_update_term):
+        """Test interactive_destroy_stack with termination protection."""
+        stack_name = 'fake-stack'
+        stack = {'StackName': stack_name}
+        patched_input.return_value = 'y'
+
+        self.stubber.add_client_error('delete_stack',
+                                      service_message='TerminationProtection')
+        self.stubber.add_response('delete_stack', {}, stack)
+
+        with self.stubber:
+            self.provider.interactive_destroy_stack(stack_name, approval='y')
+        self.stubber.assert_no_pending_responses()
+        patched_input.assert_called_once()
+        patched_update_term.assert_called_once_with(stack_name, False)
 
     @patch('runway.cfngin.ui.get_raw_input')
     def test_destroy_stack_canceled(self, patched_input):
@@ -906,16 +1030,14 @@ class TestProviderInteractiveMode(unittest.TestCase):
                             replacements_only=replacements)
         self.assertEqual(provider.replacements_only, replacements)
 
+    @patch('runway.cfngin.providers.aws.default.Provider.update_termination_protection')
     @patch("runway.cfngin.providers.aws.default.ask_for_approval")
     def test_update_stack_execute_success_no_stack_policy(self,
-                                                          patched_approval):
+                                                          patched_approval,
+                                                          patched_update_term):
         """Test update stack execute success no stack policy."""
         stack_name = "my-fake-stack"
 
-        self.stubber.add_response(
-            'describe_stacks',
-            {'Stacks': [generate_describe_stacks_stack(stack_name)]}
-        )
         self.stubber.add_response(
             "create_change_set",
             {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
@@ -940,23 +1062,20 @@ class TestProviderInteractiveMode(unittest.TestCase):
                 parameters=[], tags=[]
             )
 
-        patched_approval.assert_called_with(full_changeset=changes,
-                                            params_diff=[],
-                                            include_verbose=True,
-                                            fqn=stack_name)
+        patched_approval.assert_called_once_with(full_changeset=changes,
+                                                 params_diff=[],
+                                                 include_verbose=True,
+                                                 fqn=stack_name)
+        patched_update_term.assert_called_once_with(stack_name, False)
 
-        self.assertEqual(patched_approval.call_count, 1)
-
+    @patch('runway.cfngin.providers.aws.default.Provider.update_termination_protection')
     @patch("runway.cfngin.providers.aws.default.ask_for_approval")
     def test_update_stack_execute_success_with_stack_policy(self,
-                                                            patched_approval):
+                                                            patched_approval,
+                                                            patched_update_term):
         """Test update stack execute success with stack policy."""
         stack_name = "my-fake-stack"
 
-        self.stubber.add_response(
-            'describe_stacks',
-            {'Stacks': [generate_describe_stacks_stack(stack_name)]}
-        )
         self.stubber.add_response(
             "create_change_set",
             {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
@@ -984,12 +1103,11 @@ class TestProviderInteractiveMode(unittest.TestCase):
                 stack_policy=Template(body="{}"),
             )
 
-        patched_approval.assert_called_with(full_changeset=changes,
-                                            params_diff=[],
-                                            include_verbose=True,
-                                            fqn=stack_name)
-
-        self.assertEqual(patched_approval.call_count, 1)
+        patched_approval.assert_called_once_with(full_changeset=changes,
+                                                 params_diff=[],
+                                                 include_verbose=True,
+                                                 fqn=stack_name)
+        patched_update_term.assert_called_once_with(stack_name, False)
 
     def test_select_destroy_method(self):
         """Test select destroy method."""

--- a/tests/cfngin/test_config.py
+++ b/tests/cfngin/test_config.py
@@ -419,6 +419,7 @@ stacks:
   locked: false
   name: vpc
   protected: false
+  termination_protection: false
 - class_path: blueprints.Bastion
   enabled: true
   locked: false
@@ -426,6 +427,7 @@ stacks:
   protected: false
   requires:
   - vpc
+  termination_protection: false
 """)
 
     def test_load_register_custom_lookups(self):


### PR DESCRIPTION
## Summary

Enable setting and updating termination protection on CloudFormation stacks from a CFNgin config file.

## Why This Is Needed

Protect stacks from accidental deletion either manually or through the API.

## What Changed

### Added

- `termination_protection` option to stack definitions
  - it's value is the end state of `EnableTerminationProtection` for a stack
  - defaults to `false`
- default AWS provider method for updating termination protection when the deployed value does not match the defined value
  - executed before any other stack update methods
- prompt when interactively destroying a stack with termination protection enabled to disable it and try destroying again

## Screenshots

Interactive deletion of a stack with termination protection enabled

![image](https://user-images.githubusercontent.com/23145462/76905723-bec53b00-685f-11ea-9a58-804a544c07fd.png)

Non-interactive raises the `botocore` exception

```
INFO:runway.cfngin.ui:runway-test-stack: failed (An error occurred (ValidationError) when calling the DeleteStack operation: Stack [finley-runway-testing-runway-test-stack] cannot be deleted while TerminationProtection is enabled)
```

