### PR TITLE
StaticSite Cleanup State Machine

### DIFF
--- a/runway/blueprints/staticsite/cleanup.py
+++ b/runway/blueprints/staticsite/cleanup.py
@@ -142,7 +142,6 @@ class Cleanup(Blueprint):
 
         return res
 
-    # TODO: Swap this with paramterized_codec
     def _get_self_destruct(self, replicated_lambda_remover):
         # type: (Dict[str, Union[awslambda.Function, Any]]) -> Dict[str, Any]
         res = {}

--- a/runway/blueprints/staticsite/cleanup.py
+++ b/runway/blueprints/staticsite/cleanup.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python
+"""Cleanup Stack.
+
+Responsible for cleaning up the remaining orphaned resources created
+by the primary stack.
+"""
+from __future__ import print_function
+
+import json
+import os
+import logging
+from typing import Any, Dict, Union  # pylint: disable=unused-import
+
+import awacs.awslambda
+import awacs.cloudformation
+import awacs.iam
+import awacs.logs
+
+from awacs.aws import Allow, PolicyDocument, Statement
+from awacs.helpers.trust import make_simple_assume_policy
+from troposphere import (AccountId, Join, Output, Partition, Region, StackName, Sub,
+                         awslambda, iam, stepfunctions)
+
+from runway.cfngin.blueprints.base import Blueprint
+from runway.cfngin.util import read_value_from_path
+
+LOGGER = logging.getLogger('runway')
+
+
+class Cleanup(Blueprint):
+    """Cleanup Stack."""
+
+    VARIABLES = {
+        'DisableCloudFront': {'type': bool,
+                              'default': False,
+                              'description': 'Whether to disable CF'},
+        'function_arns': {'type': list,
+                          'default': [],
+                          'description': 'List of function ARNs that need to '
+                                         'be removed.'},
+        'stack_name': {'type': str,
+                       'default': '',
+                       'description': 'The name of the current stack'}
+    }
+
+    @property
+    def cf_enabled(self):
+        # type: () -> bool
+        """CloudFront enabled conditional."""
+        return not self.get_variables().get('DisableCloudFront', False)
+
+    def create_template(self):
+        # type: () -> None
+        """Create template (main function called by Stacker)."""
+        self.template.set_version('2010-09-09')
+        self.template.set_description('Static Website Cleanup - StateMachine')
+        if not self.cf_enabled:
+            return
+
+        self._get_replicated_lambda_state_machine()
+
+    def _get_replicated_lambda_remover_lambda(self):
+        # type: () -> Dict[str, Any]
+        res = {}
+        res['role'] = self.template.add_resource(
+            iam.Role(
+                'ReplicatedLambdaRemoverRole',
+                AssumeRolePolicyDocument=make_simple_assume_policy('lambda.amazonaws.com'),
+                Policies=[
+                    iam.Policy(
+                        PolicyName="LambdaLogCreation",
+                        PolicyDocument=PolicyDocument(
+                            Version='2012-10-17',
+                            Statement=[
+                                Statement(
+                                    Action=[awacs.logs.CreateLogGroup,
+                                            awacs.logs.CreateLogStream,
+                                            awacs.logs.PutLogEvents],
+                                    Effect=Allow,
+                                    Resource=[
+                                        Join('', [
+                                            'arn:',
+                                            Partition,
+                                            ':logs:*:',
+                                            AccountId,
+                                            ':log-group:/aws/lambda/',
+                                            StackName,
+                                            '-ReplicatedLambdaRemover-*'
+                                        ])
+                                    ]
+                                )
+                            ]
+                        )
+                    ),
+                    iam.Policy(
+                        PolicyName="DeleteLambda",
+                        PolicyDocument=PolicyDocument(
+                            Version="2012-10-17",
+                            Statement=[
+                                Statement(
+                                    Action=[awacs.awslambda.DeleteFunction],
+                                    Effect=Allow,
+                                    Resource=self.get_variables()['function_arns']
+                                )
+                            ]
+                        )
+                    )
+                ],
+            )
+        )
+
+        self.template.add_output(Output(
+            'ReplicatedLambdaRemoverRole',
+            Description='The name of the Replicated Lambda Remover Role',
+            Value=res['role'].ref()
+        ))
+
+        res['function'] = self.template.add_resource(
+            awslambda.Function(
+                'ReplicatedLambdaRemover',
+                Code=awslambda.Code(
+                    ZipFile=read_value_from_path(
+                        'file://' + os.path.join(
+                            os.path.dirname(__file__),
+                            'templates/replicated_lambda_remover.template.py'
+                        )
+                    )
+                ),
+                Description="Checks for Replicated Lambdas created during the main stack and "
+                            "deletes them when they are ready.",
+                Handler='index.handler',
+                Role=res['role'].get_att('Arn'),
+                Runtime='python3.7'
+            )
+        )
+
+        self.template.add_output(Output(
+            'ReplicatedLambdaRemoverArn',
+            Description='The ARN of the Replicated Function',
+            Value=res['function'].get_att('Arn')
+        ))
+
+        return res
+
+    # TODO: Swap this with paramterized_codec
+    def _get_self_destruct(self, replicated_lambda_remover):
+        # type: (Dict[str, Union[awslambda.Function, Any]]) -> Dict[str, Any]
+        res = {}
+        variables = self.get_variables()
+
+        res['role'] = self.template.add_resource(
+            iam.Role(
+                'SelfDestructRole',
+                AssumeRolePolicyDocument=make_simple_assume_policy('lambda.amazonaws.com'),
+                Policies=[
+                    iam.Policy(
+                        PolicyName="LambdaLogCreation",
+                        PolicyDocument=PolicyDocument(
+                            Version='2012-10-17',
+                            Statement=[
+                                Statement(
+                                    Action=[awacs.logs.CreateLogGroup,
+                                            awacs.logs.CreateLogStream,
+                                            awacs.logs.PutLogEvents],
+                                    Effect=Allow,
+                                    Resource=[
+                                        Join('', [
+                                            'arn:',
+                                            Partition,
+                                            ':logs:*:',
+                                            AccountId,
+                                            ':log-group:/aws/lambda/',
+                                            StackName,
+                                            '-SelfDestruct-*'
+                                        ])
+                                    ]
+                                )
+                            ]
+                        )
+                    ),
+                    iam.Policy(
+                        PolicyName="DeleteStateMachine",
+                        PolicyDocument=PolicyDocument(
+                            Version="2012-10-17",
+                            Statement=[
+                                Statement(
+                                    Action=[awacs.states.DeleteStateMachine],
+                                    Effect=Allow,
+                                    Resource=[
+                                        # StateMachine
+                                        Join('', [
+                                            'arn:',
+                                            Partition,
+                                            ':states:',
+                                            Region,
+                                            ':',
+                                            AccountId,
+                                            ':stateMachine:StaticSiteCleanup-',
+                                            variables['stack_name']
+                                        ])
+                                    ]
+                                )
+                            ]
+                        )
+                    ),
+                    iam.Policy(
+                        PolicyName="DeleteRolesAndPolicies",
+                        PolicyDocument=PolicyDocument(
+                            Version="2012-10-17",
+                            Statement=[
+                                Statement(
+                                    Action=[
+                                        awacs.iam.DeleteRolePolicy,
+                                        awacs.iam.DeleteRole
+                                    ],
+                                    Effect=Allow,
+                                    Resource=[
+                                        Join('', [
+                                            'arn:',
+                                            Partition,
+                                            ':iam::',
+                                            AccountId,
+                                            ':role/',
+                                            StackName,
+                                            '-*'
+                                        ]),
+                                    ]
+                                )
+                            ]
+                        )
+                    ),
+                    iam.Policy(
+                        PolicyName="DeleteLambdas",
+                        PolicyDocument=PolicyDocument(
+                            Version="2012-10-17",
+                            Statement=[
+                                Statement(
+                                    Action=[awacs.awslambda.DeleteFunction],
+                                    Effect=Allow,
+                                    Resource=[
+                                        Join('', [
+                                            'arn:',
+                                            Partition,
+                                            ':lambda:',
+                                            Region,
+                                            ':',
+                                            AccountId,
+                                            ':function:%s-SelfDestruct-*' % (
+                                                variables['stack_name']
+                                            )
+                                        ]),
+                                        replicated_lambda_remover['function'].get_att('Arn')
+                                    ]
+                                )
+                            ]
+                        )
+                    ),
+                    iam.Policy(
+                        PolicyName="DeleteStack",
+                        PolicyDocument=PolicyDocument(
+                            Version="2012-10-17",
+                            Statement=[
+                                Statement(
+                                    Action=[awacs.cloudformation.DeleteStack],
+                                    Effect=Allow,
+                                    Resource=[
+                                        Join('', [
+                                            'arn:',
+                                            Partition,
+                                            ':cloudformation:',
+                                            Region,
+                                            ':',
+                                            AccountId,
+                                            ':stack/%s/*' % (
+                                                variables['stack_name']
+                                            )
+                                        ])
+                                    ]
+                                )
+                            ]
+                        )
+                    )
+                ],
+            )
+        )
+
+        self.template.add_output(Output(
+            'SelfDestructLambdaRole',
+            Description='The name of the Self Destruct Role',
+            Value=res['role'].ref()
+        ))
+
+        res['function'] = self.template.add_resource(
+            awslambda.Function(
+                'SelfDestruct',
+                Code=awslambda.Code(
+                    ZipFile=read_value_from_path(
+                        'file://' + os.path.join(
+                            os.path.dirname(__file__),
+                            'templates/self_destruct.template.py'
+                        )
+                    )
+                ),
+                Description="Issues a Delete Stack command to the Cleanup stack",
+                Handler='index.handler',
+                Role=res['role'].get_att('Arn'),
+                Runtime='python3.7'
+            )
+        )
+
+        self.template.add_output(Output(
+            'SelfDestructLambdaArn',
+            Description='The ARN of the Replicated Function',
+            Value=res['function'].get_att('Arn')
+        ))
+
+        return res
+
+    def _get_replicated_lambda_state_machine_role(self,
+                                                  remover_function,  # type: Dict[str, Union[awslambda.Function, iam.Role, Any]] # noqa pylint: disable=line-too-long
+                                                  self_destruct_function # type: Dict[str, Union[awslambda.Function, iam.Role, Any]] # noqa pylint: disable=line-too-long
+                                                 ):
+        # type (...) -> iam.Role
+        entity = Join('.', ['states', Region, 'amazonaws.com'])
+
+        return self.template.add_resource(
+            iam.Role(
+                'StateMachineRole',
+                AssumeRolePolicyDocument=make_simple_assume_policy(entity),
+                Policies=[
+                    iam.Policy(
+                        PolicyName="InvokeLambda",
+                        PolicyDocument=PolicyDocument(
+                            Version="2012-10-17",
+                            Statement=[
+                                Statement(
+                                    Action=[awacs.awslambda.InvokeFunction],
+                                    Effect=Allow,
+                                    Resource=[
+                                        remover_function.get_att('Arn'),
+                                        self_destruct_function.get_att('Arn')
+                                    ]
+                                )
+                            ]
+                        )
+                    )
+                ]
+            )
+        )
+
+    def _get_replicated_lambda_state_machine(self):
+        # type(...) -> stepfunctions.StateMachine
+        replicated_lambda_remover = self._get_replicated_lambda_remover_lambda()
+        self_destruct = self._get_self_destruct(replicated_lambda_remover)
+        role = self._get_replicated_lambda_state_machine_role(
+            replicated_lambda_remover['function'],
+            self_destruct['function']
+        )
+
+        state_machine = self.template.add_resource(
+            stepfunctions.StateMachine(
+                'StaticSiteCleanupStateMachine',
+                StateMachineName='StaticSiteCleanup-%s' % (
+                    self.get_variables()['stack_name']
+                ),
+                RoleArn=role.get_att('Arn'),
+                DefinitionString=Sub(json.dumps({
+                    "Comment": "Clean leftover artifacts from StaticSite build",
+                    "StartAt": "DeleteLambdas",
+                    "States": {
+                        "DeleteLambdas": {
+                            "Type": "Task",
+                            "Resource": '${delete_lambdas_arn}',
+                            'Next': "Deleted"
+                        },
+                        "Deleted": {
+                            "Type": "Choice",
+                            "Choices": [
+                                {
+                                    "Variable": "$.deleted",
+                                    "BooleanEquals": True,
+                                    "Next": "SelfDestruct"
+                                },
+                                {
+                                    "Variable": "$.deleted",
+                                    "BooleanEquals": False,
+                                    "Next": "Halt"
+                                }
+                            ]
+                        },
+                        "Halt": {
+                            "Type": "Wait",
+                            "Seconds": 300,
+                            "Next": "DeleteLambdas"
+                        },
+                        "SelfDestruct": {
+                            "Type": "Task",
+                            "Resource": "${self_destruct_arn}",
+                            "Next": "DeletionComplete"
+                        },
+                        "DeletionComplete": {
+                            "Type": "Succeed",
+                        }
+                    }
+                }), {"delete_lambdas_arn": replicated_lambda_remover['function'].get_att('Arn'),
+                     "self_destruct_arn": self_destruct['function'].get_att('Arn')})
+            )
+        )
+
+        self.template.add_output(Output(
+            'ReplicatedFunctionRemoverStateMachineArn',
+            Description='The ARN of the Replicated Function Remover State Machine',
+            Value=state_machine.ref()
+        ))
+        return state_machine

--- a/runway/blueprints/staticsite/staticsite.py
+++ b/runway/blueprints/staticsite/staticsite.py
@@ -10,11 +10,14 @@ from typing import Any, Dict, List, Union  # pylint: disable=unused-import
 import awacs.s3
 import awacs.sts
 import awacs.logs
+import awacs.iam
+import awacs.awslambda
+import awacs.states
 from awacs.aws import (Action, Allow, Policy, PolicyDocument, Principal,
                        Statement)
 from awacs.helpers.trust import make_simple_assume_policy
 from troposphere import (AccountId, Join, NoValue, Output, Partition, Region, StackName, Sub, # noqa pylint: disable=unused-import
-                         awslambda, cloudfront, iam, s3)
+                         awslambda, cloudfront, iam, logs, s3, stepfunctions)
 
 from runway.cfngin.blueprints.base import Blueprint
 from runway.cfngin.context import Context
@@ -167,10 +170,10 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             ]
         return []
 
-    def get_directory_index_lambda_association(  # pylint: disable=no-self-use
-            self,
-            lambda_associations,  # List[cloudfront.LambdaFunctionAssociation]
-            directory_index_rewrite_version):  # awslambda.Version
+    def get_directory_index_lambda_association(self,  # pylint: disable=no-self-use
+                                               lambda_associations,  # type: List[cloudfront.LambdaFunctionAssociation] # noqa pylint: disable=line-too-long
+                                               directory_index_rewrite_version   # type: awslambda.Version # noqa pylint: disable=line-too-long
+                                              ):  # noqa E124
         # type: (...) ->  List[cloudfront.LambdaFunctionAssociation]
         """Retrieve the directory index lambda associations with the added rewriter.
 
@@ -186,11 +189,11 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
         return lambda_associations
 
-    def get_cloudfront_distribution_options(
-            self,
-            bucket,  # type: s3.Bucket
-            oai,  # type: cloudfront.CloudFrontOriginAccessIdentity
-            lambda_function_associations):  # List[cloudfront.LambdaFunctionAssociation]
+    def get_cloudfront_distribution_options(self,  # type: StaticSite
+                                            bucket,  # type: s3.Bucket
+                                            oai,  # type: cloudfront.CloudFrontOriginAccessIdentity # noqa pylint: disable=line-too-long
+                                            lambda_function_associations # type: List[cloudfront.LambdaFunctionAssociation] # noqa pylint: disable=line-too-long
+                                           ):
         # type: (...) -> Dict[str, Any]
         """Retrieve the options for our CloudFront distribution.
 
@@ -402,7 +405,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
 
     def add_lambda_execution_role(self,
                                   name='LambdaExecutionRole',  # type: str
-                                  function_name=''
+                                  function_name=''  # type: str
                                  ):  # noqa: E124
         # type: (...) -> iam.Role
         """Create the Lambda@Edge execution role."""
@@ -480,18 +483,25 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
                 variables["RewriteDirectoryIndex"]
             )
 
-        return self.template.add_resource(
+        function = self.template.add_resource(
             awslambda.Function(
                 'CFDirectoryIndexRewrite',
-                Code=awslambda.Code(
-                    ZipFile=code_str
-                ),
+                Code=awslambda.Code(ZipFile=code_str),
+                DeletionPolicy='Retain',
                 Description='Rewrites CF directory HTTP requests to default page',  # noqa
                 Handler='index.handler',
                 Role=role.get_att('Arn'),
                 Runtime='nodejs10.x'
             )
         )
+
+        self.template.add_output(Output(
+            'LambdaCFDirectoryIndexRewriteArn',
+            Description='Directory Index Rewrite Function Arn',
+            Value=function.get_att('Arn')
+        ))
+
+        return function
 
     def add_cloudfront_directory_index_rewrite_version(self, directory_index_rewrite):
         # type: (awslambda.Function) -> awslambda.Version

--- a/runway/blueprints/staticsite/templates/replicated_lambda_remover.template.py
+++ b/runway/blueprints/staticsite/templates/replicated_lambda_remover.template.py
@@ -1,0 +1,66 @@
+"""Replicated Lambda Remover State Machine."""
+from typing import Any, Dict  # pylint: disable=unused-import
+
+import boto3
+
+
+def handler(event,  # type: Dict
+            _context  # type: Dict
+           ):  # noqa: E124
+    # type: (...) -> Dict[str, Any]
+    """State Machine step to attempt deletion of replicated Lambdas.
+
+    Given a list of Arns will go through each attempting to
+    delete. If the resource is not found it will move to the
+    next arn, assuming that it has already been deleted. All
+    other errors will move the step function to a halt step
+    where it will then re-request the deletion process.
+
+    Args:
+        event (dict): The AWS Step Function execution event
+    """
+    arns = event.get('FunctionArns')
+    self_destruct = event.get('SelfDestruct')
+    lambda_client = boto3.client('lambda')
+
+    # End early if we don't have any arns
+    if not arns:
+        return {
+            'SelfDestruct': self_destruct,
+            'FunctionArns': arns,
+            'deleted': True,
+            'status': 'No Arns To Delete'
+        }
+
+    deletions = []
+
+    try:
+        # Loop through all arns passed in
+        for arn in arns:
+            try:
+                deletions.append(
+                    lambda_client.delete_function(FunctionName=arn)
+                )
+            # If we can't find the resource then move to the next
+            except lambda_client.ResourceNotFoundException:
+                continue
+
+        return {
+            'SelfDestruct': self_destruct,
+            'FunctionArns': arns,
+            'deleted': True,
+            'deletions': deletions,
+            'status': 'Delete Successful'
+        }
+    # Something went wrong, more than likely the Replicated Function is
+    # not currently able to be deleted.
+    # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-delete-replicas.html
+    # Try again
+    except Exception:  # pylint: disable=broad-except
+        return {
+            'SelfDestruct': self_destruct,
+            'FunctionArns': arns,
+            'deleted': False,
+            'deletions': deletions,
+            'status': 'Delete Failed'
+        }

--- a/runway/blueprints/staticsite/templates/self_destruct.template.py
+++ b/runway/blueprints/staticsite/templates/self_destruct.template.py
@@ -1,0 +1,26 @@
+"""Self Destruction Lambda."""
+from typing import Any, Dict, Union  # pylint: disable=unused-import
+
+import boto3
+
+
+def handler(event,  # type: Dict
+            _context  # type: Dict
+           ):  # noqa: E124
+    # type: (...) -> Union[Dict[str, Any], bool]
+    """Self destruct the stack.
+
+    Execute self destruction of the stack this lambda is a part of.
+
+    Args:
+        event (dict): The AWS Step Function execution event
+    """
+    data = event.get('SelfDestruct')
+    cfn_client = boto3.client('cloudformation')
+
+    if not data:
+        return False
+
+    deleted_stack = cfn_client.delete_stack(StackName=data.get('StackName'))
+
+    return {'deleted_stack': deleted_stack}

--- a/runway/cfngin/util.py
+++ b/runway/cfngin/util.py
@@ -358,9 +358,12 @@ def read_value_from_path(value):
     """
     if value.startswith('file://'):
         path = value.split('file://', 1)[1]
-        config_directory = get_config_directory()
-        relative_path = os.path.join(config_directory, path)
-        with open(relative_path) as read_file:
+        if os.path.isabs(path):
+            read_path = path
+        else:
+            config_directory = get_config_directory()
+            read_path = os.path.join(config_directory, path)
+        with open(read_path) as read_file:
             value = read_file.read()
     return value
 

--- a/runway/hooks/staticsite/auth_at_edge/domain_updater.py
+++ b/runway/hooks/staticsite/auth_at_edge/domain_updater.py
@@ -9,7 +9,7 @@ from runway.cfngin.session_cache import get_session
 LOGGER = logging.getLogger(__name__)
 
 
-def update(context,  # type: Context # pylint: disable=unused-import
+def update(context,  # type: Context
            provider,  # type: BaseProvider
            **kwargs  # type: Optional[Dict[str, Any]]
           ):  # noqa: E124

--- a/runway/hooks/staticsite/cleanup.py
+++ b/runway/hooks/staticsite/cleanup.py
@@ -1,0 +1,56 @@
+"""Replicated Function Remover."""
+import logging
+import json
+from typing import Any, Dict, Optional, Union  # pylint: disable=unused-import
+
+from runway.cfngin.context import Context  # pylint: disable=unused-import
+from runway.cfngin.providers.base import BaseProvider  # pylint: disable=unused-import
+from runway.cfngin.session_cache import get_session
+
+LOGGER = logging.getLogger(__name__)
+
+
+def execute(context,  # type: Context # pylint: disable=unused-argument
+            provider,  # type: BaseProvider
+            **kwargs  # type: Optional[Dict[str, Any]]
+           ):  # noqa: E124
+    # type: (...) -> Union[Dict[str, Any], bool]
+    """Execute the cleanup process.
+
+    A StateMachine will be executed that stays active after the main and
+    dependency stacks have been deleted. This will keep attempting to
+    delete the Replicated functions that were created as part of the main
+    stack. Once it has deleted all the Lambdas supplied it will self
+    destruct its own stack.
+
+    Args:
+        context (:class:`runway.cfngin.context.Context`): The context
+            instance.
+        provider (:class:`runway.cfngin.providers.base.BaseProvider`):
+            The provider instance
+
+    Keyword Args:
+        function_arns (List[str]): The arns of all the Replicated functions to
+            delete
+        state_machine_arn (str): The ARN of the State Machine to execute
+        stack_name (str): The name of the Cleanup stack to delete
+    """
+    session = get_session(provider.region)
+    step_functions_client = session.client('stepfunctions')
+
+    try:
+        step_functions_client.start_execution(
+            stateMachineArn=kwargs['state_machine_arn'],
+            input=json.dumps({
+                "SelfDestruct": {
+                    "StateMachineArn": kwargs['state_machine_arn'],
+                    "StackName": kwargs['stack_name'],
+                },
+                "FunctionArns": kwargs['function_arns']
+            })
+        )
+        return True
+    except Exception as err:  # pylint: disable=broad-except
+        LOGGER.error('Could not execute cleanup process.')
+        LOGGER.error(err)
+        return False


### PR DESCRIPTION
## Summary

In the process of creating a Static Site with a Lambda@Edge function and then subsequently attempting to delete it a "Replicated Function" will be left behind https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-delete-replicas.html. As the article outlines these cannot be deleted until CloudFront has propagated its deletion. 

Runway will attempt to delete the function for about an hour and finally "give up" leaving these functions orphaned whilst making the user experience less than desirable.

This PR launches a StateMachine designed to keep attempting deletion of these functions until successful. Once they have been deleted the State Machine will then delete the Stack it's a part of to "self-destruct"

## Why This Is Needed
1) Better User Experience
2) No orphaned resources

## What Changed

### Added

1) Replicated Function Remover State Machine
2) Corresponding Lambdas/Roles
3) Logic to ensure cleanup is only run when necessary and doesn't get deleted during a normal stack destroy
