### PR TITLE
fix cfngin diff output lookup resolution when no stack change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `runway plan` for cfngin modules will now properly resolve output lookups when the original stack did not change
 
 ## [1.5.1] - 2020-03-25
 ### Changed

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -182,6 +182,7 @@ class Action(build.Action):
             stack.set_outputs(outputs)
         except exceptions.StackDidNotChange:
             LOGGER.info('No changes: %s', stack.fqn)
+            stack.set_outputs(provider.get_outputs(stack.fqn))
         except exceptions.StackDoesNotExist:
             if self.context.persistent_graph:
                 return SkippedStatus('persistent graph: stack does not '


### PR DESCRIPTION
## Why This Is Needed

Outputs are not being set on the `Stack` object from `Context` if the CFN stack reports no change. This causes any `output` lookups to fail. Output lookups work fine when when the stack being referenced reports changes.

```
ERROR:runway.cfngin.plan:Couldn't resolve lookup in variable `TestParam`, lookup: ${Lookup<Literal<'output'> Concatenation[Literal<'fake-stack::FakeOutput'>]>}: (<class 'TypeError'>) 'NoneType' object is not subscriptable
Traceback (most recent call last):
  File "/Users/kyle/repos/runway/runway/variables.py", line 663, in resolve
    **kwargs)
  File "/Users/kyle/repos/runway/runway/cfngin/lookups/handlers/output.py", line 36, in handle
    return stack.outputs[decon.output_name]
TypeError: 'NoneType' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kyle/repos/runway/runway/variables.py", line 675, in resolve
    provider=provider))
  File "/Users/kyle/repos/runway/runway/variables.py", line 710, in _resolve_legacy
    provider=provider)
  File "/Users/kyle/repos/runway/runway/cfngin/lookups/handlers/output.py", line 36, in handle
    return stack.outputs[decon.output_name]
TypeError: 'NoneType' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kyle/repos/runway/runway/variables.py", line 103, in resolve
    variables=variables, **kwargs)
  File "/Users/kyle/repos/runway/runway/variables.py", line 677, in resolve
    raise FailedLookup(self, err2)
runway.cfngin.exceptions.FailedLookup: Failed lookup

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kyle/repos/runway/runway/cfngin/plan.py", line 142, in _run_once
    status = self.fn(self.stack, status=self.status)
  File "/Users/kyle/repos/runway/runway/cfngin/actions/diff.py", line 177, in _diff_stack
    stack.resolve(self.context, provider)
  File "/Users/kyle/repos/runway/runway/cfngin/stack.py", line 231, in resolve
    resolve_variables(self.variables, context, provider)
  File "/Users/kyle/repos/runway/runway/variables.py", line 39, in resolve_variables
    variable.resolve(context=context, provider=provider)
  File "/Users/kyle/repos/runway/runway/variables.py", line 105, in resolve
    raise FailedVariableLookup(self.name, err.lookup, err.error)
runway.cfngin.exceptions.FailedVariableLookup: Couldn't resolve lookup in variable `TestParam`, lookup: ${Lookup<Literal<'output'> Concatenation[Literal<'fake-stack::FakeOutput'>]>}: (<class 'TypeError'>) 'NoneType' object is not subscriptable
INFO:runway.cfngin.ui:fake-stack-02: failed (Couldn't resolve lookup in variable `TestParam`, lookup: ${Lookup<Literal<'output'> Concatenation[Literal<'fake-stack::FakeOutput'>]>}: (<class 'TypeError'>) 'NoneType' object is not subscriptable)
```

## What Changed

### Fixed

- `runway plan` for cfngin modules will now properly resolve output lookups when the original stack did not change

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/77669494-150e3a00-6f42-11ea-84d6-03ea13c90990.png)

