### PR TITLE
fix cfngin diff output lookup resolution when stack is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `runway plan` for cfngin modules will now properly resolve output lookups when the original stack did not change
+- `runway plan` for cfngin modules will now properly resolve output lookups when the original stack did not change or the reference stack is `locked: true`
 
 ## [1.5.1] - 2020-03-25
 ### Changed

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -167,10 +167,12 @@ class Action(build.Action):
         if not build.should_submit(stack):
             return NotSubmittedStatus()
 
+        provider = self.build_provider(stack)
+
         if not build.should_update(stack):
+            stack.set_outputs(provider.get_outputs(stack.fqn))
             return NotUpdatedStatus()
 
-        provider = self.build_provider(stack)
         tags = build.build_stack_tags(stack)
 
         try:


### PR DESCRIPTION
## Why This Is Needed

Similar to #208, if the stack is `locked: true` outputs are not set on the stack object.

## What Changed

### Fixed

- `runway plan` for cfngin modules will now properly resolve output lookups when the reference stack is `locked: true`
