### PR TITLE
fix broken links in cfngin docs and spelling

### DIFF
--- a/docs/source/cfngin/blueprints.rst
+++ b/docs/source/cfngin/blueprints.rst
@@ -32,7 +32,7 @@ Variables
 =========
 
 A Blueprint can define a ``VARIABLES`` property that defines the variables
-it accepts from the `Config Variables <config.html#variables>`_.
+it accepts from the `Config Variables <configuration.html#variables>`_.
 
 ``VARIABLES`` should be a dictionary of ``<variable name>: <variable
 definition>``. The variable definition should be a dictionary which

--- a/docs/source/cfngin/hooks.rst
+++ b/docs/source/cfngin/hooks.rst
@@ -1,8 +1,8 @@
-.. _hook definition: config.html#pre-post-hooks
-.. _package_sources: config.html#remote-package
-.. _`Pre & Post Hooks`: config.html#pre-post-hooks
+.. _hook definition: configuration.html#pre-post-hooks
+.. _package_sources: configuration.html#remote-package
+.. _`Pre & Post Hooks`: configuration.html#pre-post-hooks
 .. _staticsite: ../module_configuration/staticsite.html
-.. _sys_path: config.html#module-paths
+.. _sys_path: configuration.html#module-paths
 
 =====
 Hooks

--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -1,8 +1,8 @@
-.. _`hook_data`: config.html#pre-post-hooks
+.. _`hook_data`: configuration.html#pre-post-hooks
 .. _`aws_lambda hook`: ../apidocs/runway.cfngin.hooks.aws_lambda.html#runway.cfngin.hooks.aws_lambda.upload_lambda_functions
 .. _`aws_lambda blueprint`: https://github.com/cloudtools/stacker_blueprints/blob/master/stacker_blueprints/aws_lambda.py
-.. _package_sources: config.html#remote-package
-.. _sys_path: config.html#module-paths
+.. _package_sources: configuration.html#remote-package
+.. _sys_path: configuration.html#module-paths
 
 .. _cfngin-lookups:
 
@@ -522,7 +522,7 @@ dictionary.
 
 .. rubric:: Arguments
 
-This Lookup supports all :ref:`Common Lookup Arguments` but, the folling have
+This Lookup supports all :ref:`Common Lookup Arguments` but, the following have
 limited or no effect:
 
 - region
@@ -552,7 +552,7 @@ Custom Lookup
 --------------
 
 A custom lookup may be registered within the config.
-For more information see `Configuring Lookups <config.html#lookups>`_.
+For more information see `Configuring Lookups <configuration.html#lookups>`_.
 
 
 Writing A Custom Lookup

--- a/docs/source/cfngin/templates.rst
+++ b/docs/source/cfngin/templates.rst
@@ -6,7 +6,7 @@ Templates
 
 CloudFormation templates can be provided via Blueprints_ or JSON/YAML.
 JSON/YAML templates are specified for stacks via the ``template_path`` config
-option (see `Stacks <config.html#stacks>`_).
+option (see `Stacks <configuration.html#stacks>`_).
 
 
 Jinja2 Templating


### PR DESCRIPTION
## Why This Is Needed

Links point to an old file resulting in `404`

## What Changed

### Fixed

- links to `config.html` now go to `configuration.html`
