### PR TITLE
Fix config error in example snippet for auth@edge

### DIFF
--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -356,15 +356,20 @@ An example of a `Auth@Edge`_ static site configuration is as follows:
 
 .. code-block:: yaml
 
+  variables:
+    dev:
+      namespace: sample-app-dev
+      staticsite_auth_at_edge: true
+      staticsite_user_pool_arn: arn:aws:cognito-idp:us-east-1:240134083525:userpool/us-east-1_cjVgcUyWV
+      
   deployments:
     - modules:
       - path: sample-app
         type: static
         parameters:
-          dev:
-            namespace: sample-app-dev
-            staticsite_auth_at_edge: true
-            staticsite_user_pool_arn: arn:aws:cognito-idp:us-east-1:240134083525:userpool/us-east-1_cjVgcUyWV
+          namespace: ${var ${env DEPLOY_ENVIRONMENT}.namespace}
+          staticsite_auth_at_edge: ${var ${env DEPLOY_ENVIRONMENT}.staticsite_auth_at_edge}
+          staticsite_user_pool_arn: ${var ${env DEPLOY_ENVIRONMENT}.staticsite_user_pool_arn}
       regions:
         # NOTE: Much like ACM certificates used with CloudFront,
         # Auth@Edge sites must be deployed to us-east-1

--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -359,7 +359,6 @@ An example of a `Auth@Edge`_ static site configuration is as follows:
   variables:
     dev:
       namespace: sample-app-dev
-      staticsite_auth_at_edge: true
       staticsite_user_pool_arn: arn:aws:cognito-idp:us-east-1:240134083525:userpool/us-east-1_cjVgcUyWV
       
   deployments:
@@ -368,7 +367,7 @@ An example of a `Auth@Edge`_ static site configuration is as follows:
         type: static
         parameters:
           namespace: ${var ${env DEPLOY_ENVIRONMENT}.namespace}
-          staticsite_auth_at_edge: ${var ${env DEPLOY_ENVIRONMENT}.staticsite_auth_at_edge}
+          staticsite_auth_at_edge: true
           staticsite_user_pool_arn: ${var ${env DEPLOY_ENVIRONMENT}.staticsite_user_pool_arn}
       regions:
         # NOTE: Much like ACM certificates used with CloudFront,


### PR DESCRIPTION
## Summary

Fixed an error in the example snippet shown in the documentation for Auth@Edge. The example was using environment subsections under the parameters key, which does not work. The updated example uses a variables section in the runway file, and look ups in the parameters section.


