### PR TITLE
wrap cfngin run with a ctx manager that temp updates os.environ from ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - `runway plan` for cfngin modules will now properly resolve output lookups when the original stack did not change or the reference stack is `locked: true`
+- `env_var` deployment/module will now work as expected when used with a CFNgin or staticsite module
 
 ## [1.5.1] - 2020-03-25
 ### Changed

--- a/runway/util.py
+++ b/runway/util.py
@@ -303,6 +303,33 @@ def ensure_file_is_executable(path):
         sys.exit(1)
 
 
+@contextmanager
+def environ(env=None, **kwargs):
+    """Context manager for temporarily changing os.environ.
+
+    The original value of os.environ is restored upon exit.
+
+    Args:
+        env (Dict[str, str]): Dictionary to use when updating os.environ.
+
+    """
+    env = env or {}
+    env.update(kwargs)
+
+    original_env = {key: os.getenv(key) for key in env}
+    os.environ.update(env)
+
+    try:
+        yield
+    finally:
+        # always restore original values
+        for key, val in original_env.items():
+            if val is None:
+                del os.environ[key]
+            else:
+                os.environ[key] = val
+
+
 def load_object_from_string(fqcn):
     """Convert "." delimited strings to a python object.
 

--- a/tests/cfngin/test_cfngin.py
+++ b/tests/cfngin/test_cfngin.py
@@ -8,7 +8,6 @@ from mock import MagicMock, patch
 
 from runway.cfngin import CFNgin
 from runway.context import Context
-from runway.util import AWS_ENV_VARS
 
 
 def copy_fixture(src, dest):
@@ -22,11 +21,6 @@ def copy_basic_fixtures(cfngin_fixtures, tmp_path):
                  dest=tmp_path / 'test-us-east-1.env')
     copy_fixture(src=cfngin_fixtures / 'configs' / 'basic.yml',
                  dest=tmp_path / 'basic.yml')
-
-
-def get_env_creds():
-    """Return AWS creds from the environment."""
-    return {name: os.environ.get(name) for name in AWS_ENV_VARS if os.environ.get(name)}
 
 
 class TestCFNgin(object):
@@ -98,8 +92,6 @@ class TestCFNgin(object):
                         sys_path=str(tmp_path))  # support python < 3.6
         cfngin.deploy()
 
-        assert get_env_creds() == cfngin._aws_credential_backup, \
-            'env vars should be reverted upon completion'
         assert cfngin.concurrency == 0
         assert not cfngin.interactive
         assert cfngin.parameters.bucket_name == 'cfngin-bucket'
@@ -129,8 +121,6 @@ class TestCFNgin(object):
         cfngin = CFNgin(ctx=self.get_context(), sys_path=str(tmp_path))
         cfngin.destroy()
 
-        assert get_env_creds() == cfngin._aws_credential_backup, \
-            'env vars should be reverted upon completion'
         mock_action.assert_called_once()
         mock_instance.execute.assert_called_once_with(concurrency=0,
                                                       force=True,
@@ -171,8 +161,6 @@ class TestCFNgin(object):
         cfngin = CFNgin(ctx=self.get_context(), sys_path=str(tmp_path))
         cfngin.plan()
 
-        assert get_env_creds() == cfngin._aws_credential_backup, \
-            'env vars should be reverted upon completion'
         mock_action.assert_called_once()
         mock_instance.execute.assert_called_once_with()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,11 @@
 """Test Runway utils."""
 # pylint: disable=no-self-use
-import os.path
+import os
 import string
 
-from runway.util import MutableMap, load_object_from_string
+from mock import patch
+
+from runway.util import MutableMap, environ, load_object_from_string
 
 VALUE = {
     'bool_val': False,
@@ -82,6 +84,20 @@ class TestMutableMap:
             'default_val', 'default should be used'
         assert mute_map.find('str_val', 'default_val') == \
             VALUE['str_val'], 'default should be ignored'
+
+
+@patch.object(os, 'environ', {'TEST_PARAM': 'initial value'})
+def test_environ():
+    """Test environ."""
+    orig_expected = {'TEST_PARAM': 'initial value'}
+    override = {'TEST_PARAM': 'override', 'new_param': 'value'}
+
+    assert os.environ == orig_expected, 'validate original value'
+
+    with environ(override):
+        assert os.environ == override, 'validate override'
+
+    assert os.environ == orig_expected, 'validate value returned to original'
 
 
 def test_load_object_from_string():


### PR DESCRIPTION
## Why This Is Needed

`env_vars` has no effect when used with CFNgin.

## What Changed

### Added

- `environ` context manager

### Fixed

- `env_var` deployment/module will now work as expected when used with a CFNgin or staticsite module

### Removed

- methods/attributes CFNgin was using to insert credentials into `os.environ`, the new context manager now takes care of this.

