### PR TITLE
fixed terraform array parameters serialization

### DIFF
--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -1,5 +1,6 @@
 """Terraform module."""
 import copy
+import json
 import logging
 import os
 import re
@@ -189,7 +190,7 @@ def update_env_vars_with_tf_var_values(os_env_vars, tf_vars):
                            for (nestedkey, nestedval) in val.items()])
             )
         elif isinstance(val, list):
-            os_env_vars["TF_VAR_%s" % key] = '[' + ','.join(val) + ']'
+            os_env_vars["TF_VAR_%s" % key] = json.dumps(val)
         else:
             os_env_vars["TF_VAR_%s" % key] = val
     return os_env_vars

--- a/tests/module/test_terraform.py
+++ b/tests/module/test_terraform.py
@@ -12,7 +12,7 @@ class TerraformFunctionTester(unittest.TestCase):
         env_vars = update_env_vars_with_tf_var_values(
             {},
             {'foo': 'bar',
-             'list': ['test1', 'test2', 'test3'],
+             'list': ['foo', 1, True],
              'map': {'one': 'two',
                      'three': 'four'}}
         )
@@ -25,6 +25,6 @@ class TerraformFunctionTester(unittest.TestCase):
         #      'TF_VAR_map': '{ one = "two", three = "four" }'}
         # )
         self.assertTrue(env_vars['TF_VAR_foo'] == 'bar')
-        self.assertTrue(env_vars['TF_VAR_list'] == '[test1,test2,test3]')
+        self.assertTrue(env_vars['TF_VAR_list'] == '["foo", 1, true]')
         self.assertRegexpMatches(env_vars['TF_VAR_map'], r'one = "two"')  # noqa pylint: disable=deprecated-method
         self.assertRegexpMatches(env_vars['TF_VAR_map'], r'three = "four"')  # noqa pylint: disable=deprecated-method


### PR DESCRIPTION
Fixed Runway array parameter serialization for terraform

## Summary

Runway is serializing arrays as invalid json strings using single quotes. As a result parameters are not properly recognized by terraform

## Why This Is Needed

To avoid errors when passing array parameters to terraform.

## What Changed

json array parameters serialization

### Fixed

json array parameters serialization

## How to reproduce

runway.yml
```
deployments:
  - modules:
      - name: module1.tf
        path: module1.tf
        parameters:
          region: us-east-1
          array:
            - foo-01
            - bar-0243
    regions:
      - us-east-1
```

main.tf
```
# Variable definitions
variable "region" {}

variable "array" {
  type = list(string)
}

# Provider and access setup
provider "aws" {
  version = "~> 2.0"
  region = var.region
}

# Data and resources
resource "aws_ssm_parameter" "foo" {
  name  = "/test/tf/array"
  type  = "StringList"
  value = join(",", var.array)
}
```

error
```
Error: Variables not allowed

  on <value for var.array> line 1:
  (source code not available)
```