### PR TITLE
make regex more inclusive

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: deepakputhraya/action-branch-name@v1.0.0
         with:
           # Regex the branch should match. This example enforces grouping
-          regex: '([a-z])+\/([a-z])+'
+          regex: '([a-z])+\/([a-zA-Z0-9\-\_])+'
           # All branches should start with the given prefix
           allowed_prefixes: 'bugfix,chore,docs,enhancement,feat,feature,fix,hotfix,maint,maintain,maintenance,release'
           # Ignore exactly matching branch names from convention


### PR DESCRIPTION
## Summary

Make the branch name check's regex more inclusive to allow for Jira style ticket inclusion.

## What Changed

### Changed

- `branch-name` action now allows Jira style ticket numbers in the branch name
