### PR TITLE
Bugfix/template safe sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - `runway plan` for cfngin modules will now properly resolve output lookups when the original stack did not change or the reference stack is `locked: true`
 - `env_var` deployment/module will now work as expected when used with a CFNgin or staticsite module
-- when rendering a config file, it should no longer raise an error if there is an undefined variable in a comment
+- when rendering a CFNgin config file, it should no longer raise an error if there is an undefined variable in a comment
 
 ## [1.5.1] - 2020-03-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - `runway plan` for cfngin modules will now properly resolve output lookups when the original stack did not change or the reference stack is `locked: true`
 - `env_var` deployment/module will now work as expected when used with a CFNgin or staticsite module
+- when rendering a config file, it should no longer raise an error if there is an undefined variable in a comment
 
 ## [1.5.1] - 2020-03-25
 ### Changed

--- a/runway/cfngin/config/__init__.py
+++ b/runway/cfngin/config/__init__.py
@@ -78,16 +78,13 @@ def render(raw_config, environment=None):
     if not environment:
         environment = {}
     try:
-        substituted = template.substitute(environment)
+        substituted = template.substitute(**environment)
     except KeyError as err:
         raise exceptions.MissingEnvironment(err.args[0])
-    except AttributeError as err:
-        # gets the missing attr from the error message to result in the same
-        # message as a KeyError
-        raise exceptions.MissingEnvironment(err.args[0].split("'")[3])
     except ValueError:
         # Support "invalid" placeholders for lookup placeholders.
-        substituted = template.safe_substitute(environment)
+        # needs to pass a Dict for correct error handling by the built-in
+        substituted = template.safe_substitute(**environment)
 
     if not isinstance(substituted, text_type):
         substituted = substituted.decode('utf-8')


### PR DESCRIPTION
## Why This Is Needed

Error is raised if missing variable definition is commented out. This returns error handling to act the same as v1.4.

## What Changed

### Changed

- `environments` is now passed to `substitute`/`safe_substitute` as a dict instead of `MutableMap` type to enable built-in error handling

### Fixed

- when rendering a CFNgin config file, it should no longer raise an error if there is an undefined variable in a comment
