### PR TITLE
fix get_config_directory when used within cfngin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,12 +32,13 @@
         "forcerm",
         "kwarg",
         "lambci",
+        "mybucket",
         "mycdkmodule",
         "myothercdkmodule",
-        "mybucket",
         "mytable",
         "nondockerizepip",
         "rxref",
+        "stacker's",
         "stubbers"
     ],
     "pythonTestExplorer.testFramework": "pytest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - lookups are now resolved when using the `runway envvars` command
 - Terraform list parameters from runway.yml will now properly formatted
+- stacker's cli components can once again be used within CFNgin sessions by the inherited utility functions that require it
 
 ## Added
 - ACM CloudFormation hook

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -6,7 +6,7 @@ import sys
 
 from yaml.constructor import ConstructorError
 
-from runway.util import MutableMap, cached_property, environ
+from runway.util import MutableMap, argv, cached_property, environ
 
 from .actions import build, destroy, diff
 from .config import render_parse_load as load_config
@@ -113,14 +113,15 @@ class CFNgin(object):
             for config in config_files:
                 ctx = self.load(config)
                 LOGGER.info('%s: deploying...', os.path.basename(config))
-                action = build.Action(
-                    context=ctx,
-                    provider_builder=self._get_provider_builder(
-                        ctx.config.service_role
+                with argv('stacker', 'build', ctx.config_path):
+                    action = build.Action(
+                        context=ctx,
+                        provider_builder=self._get_provider_builder(
+                            ctx.config.service_role
+                        )
                     )
-                )
-                action.execute(concurrency=self.concurrency,
-                               tail=self.tail)
+                    action.execute(concurrency=self.concurrency,
+                                   tail=self.tail)
 
     def destroy(self, force=False, sys_path=None):
         """Run the CFNgin destroy action.
@@ -144,15 +145,16 @@ class CFNgin(object):
             for config in config_files:
                 ctx = self.load(config)
                 LOGGER.info('%s: destroying...', os.path.basename(config))
-                action = destroy.Action(
-                    context=ctx,
-                    provider_builder=self._get_provider_builder(
-                        ctx.config.service_role
+                with argv('stacker', 'destroy', ctx.config_path):
+                    action = destroy.Action(
+                        context=ctx,
+                        provider_builder=self._get_provider_builder(
+                            ctx.config.service_role
+                        )
                     )
-                )
-                action.execute(concurrency=self.concurrency,
-                               force=True,
-                               tail=self.tail)
+                    action.execute(concurrency=self.concurrency,
+                                   force=True,
+                                   tail=self.tail)
 
     def load(self, config_path):
         """Load a CFNgin config into a context object.
@@ -201,13 +203,14 @@ class CFNgin(object):
                 ctx = self.load(config)
                 LOGGER.info('%s: generating change sets...',
                             os.path.basename(config))
-                action = diff.Action(
-                    context=ctx,
-                    provider_builder=self._get_provider_builder(
-                        ctx.config.service_role
+                with argv('stacker', 'diff', ctx.config_path):
+                    action = diff.Action(
+                        context=ctx,
+                        provider_builder=self._get_provider_builder(
+                            ctx.config.service_role
+                        )
                     )
-                )
-                action.execute()
+                    action.execute()
 
     def should_skip(self, force=False):
         """Determine if action should be taken or not.

--- a/runway/util.py
+++ b/runway/util.py
@@ -287,7 +287,7 @@ def argv(*args):
     """Context manager for temporarily changing sys.argv."""
     original_argv = sys.argv.copy()
     try:
-        sys.argv = args
+        sys.argv = list(args)  # convert tuple to list
         yield
     finally:
         # always restore original value

--- a/runway/util.py
+++ b/runway/util.py
@@ -282,6 +282,19 @@ class MutableMap(six.moves.collections_abc.MutableMapping):  # pylint: disable=n
 
 
 @contextmanager
+def argv(*args):
+    # type: (str) -> None
+    """Context manager for temporarily changing sys.argv."""
+    original_argv = sys.argv.copy()
+    try:
+        sys.argv = args
+        yield
+    finally:
+        # always restore original value
+        sys.argv = original_argv
+
+
+@contextmanager
 def change_dir(newdir):
     """Change directory.
 

--- a/runway/util.py
+++ b/runway/util.py
@@ -285,7 +285,8 @@ class MutableMap(six.moves.collections_abc.MutableMapping):  # pylint: disable=n
 def argv(*args):
     # type: (str) -> None
     """Context manager for temporarily changing sys.argv."""
-    original_argv = sys.argv.copy()
+    # passing to list() creates a new instance
+    original_argv = list(sys.argv)  # TODO use .copy() after dropping python 2
     try:
         sys.argv = list(args)  # convert tuple to list
         yield

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,10 +2,11 @@
 # pylint: disable=no-self-use
 import os
 import string
+import sys
 
 from mock import patch
 
-from runway.util import MutableMap, environ, load_object_from_string
+from runway.util import MutableMap, argv, environ, load_object_from_string
 
 VALUE = {
     'bool_val': False,
@@ -84,6 +85,20 @@ class TestMutableMap:
             'default_val', 'default should be used'
         assert mute_map.find('str_val', 'default_val') == \
             VALUE['str_val'], 'default should be ignored'
+
+
+@patch.object(sys, 'argv', ['runway', 'deploy'])
+def test_argv():
+    """Test argv."""
+    orig_expected = ['runway', 'deploy']
+    override = ['stacker', 'build', 'test.yml']
+
+    assert sys.argv == orig_expected, 'validate original value'
+
+    with argv(*override):
+        assert sys.argv == override, 'validate override'
+
+    assert sys.argv == orig_expected, 'validate value returned to original'
 
 
 @patch.object(os, 'environ', {'TEST_PARAM': 'initial value'})


### PR DESCRIPTION
## Why This Is Needed

Since runway no longer interacts with stacker using `subprocess`, the CLI components CFNgin inherited from it are not functional since they rely on using `argparse` which would not find the correct values in `sys.argv` resulting in `runway.cfngin.util.get_config_directory` being unusable. When used, it logs its deprecation warning then exits with an unhelpful message from argparse.

## What Changed

### Added

- `argv` context manager, similar to the `environ` context manager to temporarily override the value of `sys.argv`

### Fixed

- stacker's cli components can once again be used within CFNgin sessions by the inherited utility functions that require it
