### PR TITLE
reload hooks between uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- global variables in hooks are now reloaded between uses to mimic functionality present in `>1.5.0`
 
 ## [1.6.0] - 2020-04-07
 ### Fixed

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -64,7 +64,7 @@ def handle_hooks(stage, hooks, provider, context):  # pylint: disable=too-many-s
             continue
 
         try:
-            method = load_object_from_string(hook.path)
+            method = load_object_from_string(hook.path, try_reload=True)
         except (AttributeError, ImportError):
             LOGGER.exception("Unable to load method at %s:", hook.path)
             if required:

--- a/runway/util.py
+++ b/runway/util.py
@@ -344,11 +344,18 @@ def environ(env=None, **kwargs):
                 os.environ[key] = val
 
 
-def load_object_from_string(fqcn):
+def load_object_from_string(fqcn, try_reload=False):
     """Convert "." delimited strings to a python object.
 
-    Given a "." delimited string representing the full path to an object
-    (function, class, variable) inside a module, return that object.
+    Args:
+        fqcn (str): A "." delimited string representing the full path to an
+            object (function, class, variable) inside a module
+        try_reload (bool): Try to reload the module so any global variables
+            set within the file during import are reloaded. This should only
+            apply to modules that are already imported and are not builtin.
+
+    Returns:
+        Any: Object being imported from the provided path.
 
     Example::
 
@@ -359,9 +366,23 @@ def load_object_from_string(fqcn):
     """
     module_path = "__main__"
     object_name = fqcn
-    if "." in fqcn:
-        module_path, object_name = fqcn.rsplit(".", 1)
-        importlib.import_module(module_path)
+    if '.' in object_name:
+        module_path, object_name = fqcn.rsplit('.', 1)
+        if (
+                try_reload and
+                sys.modules.get(module_path) and
+                module_path.split('.')[0] not in sys.builtin_module_names  # skip builtins
+        ):
+            # This will reload imports such as hooks to allow global
+            # definitions dependent on env vars to be redefined with their
+            # expected values when using a context manager to alter values
+            # of os.environ during execution.
+            #
+            # pylint<2.3.1 incorrectly identifies this
+            # pylint: disable=too-many-function-args
+            six.moves.reload_module(sys.modules[module_path])
+        else:
+            importlib.import_module(module_path)
     return getattr(sys.modules[module_path], object_name)
 
 

--- a/runway/util.py
+++ b/runway/util.py
@@ -351,8 +351,8 @@ def load_object_from_string(fqcn, try_reload=False):
         fqcn (str): A "." delimited string representing the full path to an
             object (function, class, variable) inside a module
         try_reload (bool): Try to reload the module so any global variables
-            set within the file during import are reloaded. This should only
-            apply to modules that are already imported and are not builtin.
+            set within the file during import are reloaded. This only applies
+            to modules that are already imported and are not builtin.
 
     Returns:
         Any: Object being imported from the provided path.
@@ -373,10 +373,7 @@ def load_object_from_string(fqcn, try_reload=False):
                 sys.modules.get(module_path) and
                 module_path.split('.')[0] not in sys.builtin_module_names  # skip builtins
         ):
-            # This will reload imports such as hooks to allow global
-            # definitions dependent on env vars to be redefined with their
-            # expected values when using a context manager to alter values
-            # of os.environ during execution.
+            # TODO remove is next major release; backport circumvents expected functionality
             #
             # pylint<2.3.1 incorrectly identifies this
             # pylint: disable=too-many-function-args

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/fixtures/mock_hooks.py
+++ b/tests/fixtures/mock_hooks.py
@@ -1,0 +1,4 @@
+"""Mock hooks."""
+import os
+
+GLOBAL_VALUE = os.getenv('AWS_DEFAULT_REGION')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -141,6 +141,11 @@ def test_load_object_from_string_reload_conditions(mock_six):
     builtin_test = 'sys.version_info'
     mock_hook = 'tests.fixtures.mock_hooks.GLOBAL_VALUE'
 
+    try:
+        del sys.modules['tests.fixtures.mock_hooks']
+    except:  # noqa pylint: disable=bare-except
+        pass
+
     load_object_from_string(builtin_test, try_reload=False)
     mock_six.moves.reload_module.assert_not_called()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,7 @@ import os
 import string
 import sys
 
-from mock import patch
+from mock import MagicMock, patch
 
 from runway.util import MutableMap, argv, environ, load_object_from_string
 
@@ -124,3 +124,31 @@ def test_load_object_from_string():
     )
     for test in tests:
         assert load_object_from_string(test[0]) is test[1]
+
+    obj_path = 'tests.fixtures.mock_hooks.GLOBAL_VALUE'
+    # check value from os.environ
+    assert load_object_from_string(obj_path, try_reload=True) == 'us-east-1'
+
+    with environ({'AWS_DEFAULT_REGION': 'us-west-2'}):
+        # check value from os.environ after changing it to ensure reload
+        assert load_object_from_string(obj_path, try_reload=True) == 'us-west-2'
+
+
+@patch('runway.util.six')
+def test_load_object_from_string_reload_conditions(mock_six):
+    """Test load_object_from_string reload conditions."""
+    mock_six.moves.reload_module.return_value = MagicMock()
+    builtin_test = 'sys.version_info'
+    mock_hook = 'tests.fixtures.mock_hooks.GLOBAL_VALUE'
+
+    load_object_from_string(builtin_test, try_reload=False)
+    mock_six.moves.reload_module.assert_not_called()
+
+    load_object_from_string(builtin_test, try_reload=True)
+    mock_six.moves.reload_module.assert_not_called()
+
+    load_object_from_string(mock_hook, try_reload=True)
+    mock_six.moves.reload_module.assert_not_called()
+
+    load_object_from_string(mock_hook, try_reload=True)
+    mock_six.moves.reload_module.assert_called_once()


### PR DESCRIPTION
## Why This Is Needed

Hooks that define a global variable when imported that relies on an environment variable set by Runway (e.g. `AWS_DEFAULT_REGION`) will retain its original value across uses.

While this is the appropriate functionally from a python standpoint and should be expected, historically this functioned differently do to the use of `subprocess.Popen` being used to invoke the stacker cli. This created a different process for each region allowing the global values to change.

If merged, this change should be considered for removal in the next major release so that the global variables function as expected.

## What Changed

### Added

- added `try_reload` option to `runway.util.load_object_from_string` that will use `importlib.reload` to reimport a module if it has already been imported and is not a builtin module

### Fixed

- global variables in hooks are now reloaded between uses to mimic functionality present in `>1.5.0`
