### PR TITLE
add prompt for deploy env when branch name is unexpected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- prompt to optionally provide an explicit deploy environment when git branch name is unexpected (e.g. feature branch) when run interactively
 
 ## [1.6.1] - 2020-04-14
 ### Fixed

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -322,7 +322,8 @@ class ModulesCommand(RunwayCommand):
         if deployments is None:
             deployments = self.runway_config['deployments']
         context = Context(env_name=get_env(self.env_root,
-                                           self.runway_config.ignore_git_branch),
+                                           self.runway_config.ignore_git_branch,
+                                           prompt_if_unexpected=bool(not os.getenv('CI'))),
                           env_region=None,
                           env_root=self.env_root,
                           env_vars=os.environ.copy(),

--- a/runway/context.py
+++ b/runway/context.py
@@ -24,7 +24,7 @@ def echo_detected_environment(env_name, env_vars):
                     "the current git branch or parent directory).")
     else:
         LOGGER.info("Environment \"%s\" was determined from the current "
-                    "git branch or parent directory.",
+                    "git branch, parent directory, or manual entry.",
                     env_name)
         LOGGER.info("If this is not the environment name, update the branch/folder name or "
                     "set an override value via the %s environment variable",

--- a/tests/commands/test_modules_command.py
+++ b/tests/commands/test_modules_command.py
@@ -1,9 +1,10 @@
 """Tests runway/commands/modules_command.py."""
+# pylint: disable=no-self-use,redefined-outer-name
 import os
-import unittest
 from copy import deepcopy
 from os import path
 
+import pytest
 import yaml
 from mock import patch
 from moto import mock_sts
@@ -12,6 +13,7 @@ from runway.commands.modules_command import (select_modules_to_run,
                                              validate_environment)
 
 
+@pytest.fixture(scope='function')
 def module_tag_config():
     """Return a runway.yml file for testing module tags."""
     fixture_dir = path.join(
@@ -22,103 +24,95 @@ def module_tag_config():
         return yaml.safe_load(stream)
 
 
-class ModulesCommandTestCase(unittest.TestCase):
-    """Test runway/commands/modules_command.py."""
+class TestSelectModulesToRun(object):
+    """Test runway.commands.modules_command.select_modules_to_run."""
 
-    tag_yml = module_tag_config()
-
-    def test_select_modules_to_run_tag_test_app(self):
+    def test_tag_test_app(self, module_tag_config):
         """tag=[app:test-app] should return 2 modules."""
-        config = deepcopy(ModulesCommandTestCase.tag_yml)
         tags = ['app:test-app']
 
         result = [
             select_modules_to_run(deployment, tags)
-            for deployment in config['deployments']
+            for deployment in module_tag_config['deployments']
         ]
-        self.assertEqual(len(result[0]['modules']), 1)
-        self.assertEqual(result[0]['modules'][0]['path'], 'sampleapp1.cfn')
-        self.assertEqual(len(result[1]['modules']), 0)
-        self.assertEqual(len(result[2]['modules']), 1)
-        self.assertEqual(result[2]['modules'][0]['path'], 'sampleapp4.cfn')
+        assert len(result[0]['modules']) == 1
+        assert result[0]['modules'][0]['path'] == 'sampleapp1.cfn'
+        assert not result[1]['modules']
+        assert len(result[2]['modules']) == 1
+        assert result[2]['modules'][0]['path'] == 'sampleapp4.cfn'
 
-    def test_select_modules_to_run_tag_iac(self):
+    def test_tag_iac(self, module_tag_config):
         """tag=[tier:iac] should return 2 modules."""
-        config = deepcopy(ModulesCommandTestCase.tag_yml)
         tags = ['tier:iac']
 
         result = [
             select_modules_to_run(deployment, tags)
-            for deployment in config['deployments']
+            for deployment in module_tag_config['deployments']
         ]
-        self.assertEqual(len(result[0]['modules']), 2)
-        self.assertEqual(result[0]['modules'][0]['path'], 'sampleapp1.cfn')
-        self.assertEqual(result[0]['modules'][1]['path'], 'sampleapp2.cfn')
-        self.assertEqual(len(result[1]['modules']), 0)
-        self.assertEqual(len(result[2]['modules']), 0)
+        assert len(result[0]['modules']) == 2
+        assert result[0]['modules'][0]['path'] == 'sampleapp1.cfn'
+        assert result[0]['modules'][1]['path'] == 'sampleapp2.cfn'
+        assert not result[1]['modules']
+        assert not result[2]['modules']
 
-    def test_select_modules_to_run_two_tags(self):
+    def test_two_tags(self, module_tag_config):
         """tag=[tier:iac, app:test-app] should return 1 module."""
-        config = deepcopy(ModulesCommandTestCase.tag_yml)
         tags = ['tier:iac', 'app:test-app']
         result = [
             select_modules_to_run(deployment, tags)
-            for deployment in config['deployments']
+            for deployment in module_tag_config['deployments']
         ]
-        self.assertEqual(len(result[0]['modules']), 1)
-        self.assertEqual(result[0]['modules'][0]['path'], 'sampleapp1.cfn')
-        self.assertEqual(len(result[1]['modules']), 0)
-        self.assertEqual(len(result[2]['modules']), 0)
+        assert len(result[0]['modules']) == 1
+        assert result[0]['modules'][0]['path'] == 'sampleapp1.cfn'
+        assert not result[1]['modules']
+        assert not result[2]['modules']
 
-    def test_select_modules_to_run_no_tags(self):
+    def test_no_tags(self, module_tag_config):
         """tag=[] should request input."""
-        config = deepcopy(ModulesCommandTestCase.tag_yml)
         user_input = ['1']
         with patch('runway.commands.modules_command.input',
                    side_effect=user_input):
             result = select_modules_to_run(
-                config['deployments'][0], []
+                module_tag_config['deployments'][0], []
             )
-        self.assertEqual(result['modules'][0],
-                         config['deployments'][0]['modules'][0])
+        assert result['modules'][0] == \
+            module_tag_config['deployments'][0]['modules'][0]
 
-    def test_select_modules_to_run_no_tags_ci(self):
+    def test_no_tags_ci(self, module_tag_config):
         """tag=[], ci=true should not request input and return everything."""
-        config = deepcopy(ModulesCommandTestCase.tag_yml)
         result = [
             select_modules_to_run(deployment, [], ci='true')
-            for deployment in config['deployments']
+            for deployment in module_tag_config['deployments']
         ]
-        self.assertEqual(result, config['deployments'])
+        assert result == module_tag_config['deployments']
 
-    def test_select_modules_to_run_destroy(self):
+    def test_destroy(self, module_tag_config):
         """command=destroy should only prompt with no tag of ci if one module."""
-        config = deepcopy(ModulesCommandTestCase.tag_yml)
         user_input = ['y', '1']
         with patch('runway.commands.modules_command.input',
                    side_effect=user_input):
             result_single_no_tag = select_modules_to_run(
-                deepcopy(config['deployments'][1]), [], command='destroy'
+                deepcopy(module_tag_config['deployments'][1]), [], command='destroy'
             )
             result_no_tag = select_modules_to_run(
-                deepcopy(config['deployments'][0]), [], command='destroy'
+                deepcopy(module_tag_config['deployments'][0]), [], command='destroy'
             )
-        self.assertEqual(result_single_no_tag['modules'][0],
-                         config['deployments'][1]['modules'][0])
-        self.assertEqual(result_no_tag['modules'][0],
-                         config['deployments'][0]['modules'][0])
+        assert result_single_no_tag['modules'][0] == \
+            module_tag_config['deployments'][1]['modules'][0]
+        assert result_no_tag['modules'][0] == \
+            module_tag_config['deployments'][0]['modules'][0]
         result_tag = select_modules_to_run(
-            deepcopy(config['deployments'][0]), ['app:test-app'],
+            deepcopy(module_tag_config['deployments'][0]), ['app:test-app'],
             command='destroy'
         )
-        self.assertEqual(result_tag['modules'][0],
-                         config['deployments'][0]['modules'][0])
+        assert result_tag['modules'][0] == \
+            module_tag_config['deployments'][0]['modules'][0]
         result_tag_ci = select_modules_to_run(
-            deepcopy(config['deployments'][0]), [], command='destroy',
+            deepcopy(module_tag_config['deployments'][0]), [], command='destroy',
             ci='true'
         )
-        self.assertEqual(result_tag_ci['modules'],
-                         config['deployments'][0]['modules'])
+        assert result_tag_ci['modules'] == \
+            module_tag_config['deployments'][0]['modules']
 
 
 class TestValidateEnvironment(object):

--- a/tests/commands/test_modules_command.py
+++ b/tests/commands/test_modules_command.py
@@ -42,9 +42,8 @@ class TestModulesCommand(object):
         monkeypatch.setattr(MODULE_PATH + '.select_modules_to_run',
                             lambda a, b, c, d, e: a)
         monkeypatch.setattr(MODULE_PATH + '.get_env', get_env)
-        # python 2 passes 2 args (cls, path) but python 3 only passes 1 (path)
         monkeypatch.setattr(Config, 'find_config_file',
-                            lambda x, y=None: os.getcwd() + 'runway.yml')
+                            MagicMock(return_value=os.getcwd() + 'runway.yml'))
         monkeypatch.setattr(ModulesCommand, 'runway_config', test_config)
         monkeypatch.setattr(ModulesCommand, '_process_deployments',
                             lambda obj, y, x: None)

--- a/tests/commands/test_modules_command.py
+++ b/tests/commands/test_modules_command.py
@@ -42,8 +42,9 @@ class TestModulesCommand(object):
         monkeypatch.setattr(MODULE_PATH + '.select_modules_to_run',
                             lambda a, b, c, d, e: a)
         monkeypatch.setattr(MODULE_PATH + '.get_env', get_env)
+        # python 2 passes 2 args (cls, path) but python 3 only passes 1 (path)
         monkeypatch.setattr(Config, 'find_config_file',
-                            lambda x: x + 'runway.yml')
+                            lambda x, y=None: os.getcwd() + 'runway.yml')
         monkeypatch.setattr(ModulesCommand, 'runway_config', test_config)
         monkeypatch.setattr(ModulesCommand, '_process_deployments',
                             lambda obj, y, x: None)

--- a/tests/commands/test_runway_command.py
+++ b/tests/commands/test_runway_command.py
@@ -1,0 +1,73 @@
+"""Test runway.commands.runway_command."""
+import os
+
+import pytest
+from git import InvalidGitRepositoryError
+from mock import MagicMock, call, patch
+
+from runway.commands.runway_command import (get_env, get_env_from_branch,
+                                            get_env_from_directory,
+                                            get_env_from_user)
+from runway.util import environ
+
+
+@patch('git.Repo')
+@patch('runway.commands.runway_command.get_env_from_branch')
+@patch('runway.commands.runway_command.get_env_from_directory')
+def test_get_env(mock_env_dir, mock_env_branch, mock_git_repo):
+    """Test runway.commands.runway_command.get_env."""
+    mock_repo = MagicMock()
+    mock_repo.active_branch.name = 'git_branch'
+    mock_git_repo.return_value = mock_repo
+    mock_env_dir.return_value = 'dir_value'
+    mock_env_branch.return_value = 'branch_value'
+
+    with environ({}):
+        os.environ.pop('DEPLOY_ENVIRONMENT', None)  # ensure not in env
+        assert get_env('/', prompt_if_unexpected=True) == 'branch_value'
+        mock_env_branch.assert_called_once_with('git_branch', True)
+
+        # cases resulting in get_env_from_directory
+        assert get_env('path', ignore_git_branch=True) == 'dir_value'
+        mock_git_repo.side_effect = InvalidGitRepositoryError
+        assert get_env('path') == 'dir_value'
+        mock_env_dir.assert_has_calls([call('path'),
+                                       call('path')])
+
+        # handle TypeError
+        mock_git_repo.side_effect = TypeError
+        with pytest.raises(SystemExit):
+            assert not get_env('path')
+        mock_git_repo.side_effect = None
+
+    with environ({'DEPLOY_ENVIRONMENT': 'test'}):
+        assert get_env('path') == 'test'
+
+
+@patch('runway.commands.runway_command.get_env_from_user')
+def test_get_env_from_branch(mock_user):
+    """Test runway.commands.runway_command.get_env_from_branch."""
+    mock_user.return_value = 'user_value'
+
+    assert get_env_from_branch('ENV-dev', prompt_if_unexpected=True) == 'dev'
+
+    assert get_env_from_branch('master', prompt_if_unexpected=True) == 'common'
+
+    assert get_env_from_branch('invalid', prompt_if_unexpected=True) == 'user_value'
+
+
+def test_get_env_from_directory():
+    """Test runway.commands.runway_command.get_env_from_directory."""
+    assert get_env_from_directory('ENV-dev') == 'dev'
+    assert get_env_from_directory('expected') == 'expected'
+
+
+def test_get_env_from_user():
+    """Test runway.commands.runway_command.get_env_from_user."""
+    input_path = 'runway.commands.runway_command.input'
+
+    with patch(input_path, MagicMock(return_value='n')):
+        assert get_env_from_user('expected') == 'expected'
+
+    with patch(input_path, MagicMock(side_effect=['y', '', 'expected'])):
+        assert get_env_from_user('test') == 'expected'


### PR DESCRIPTION
## Summary

When run interactively, Runway will prompt the user when an unexpected branch name is found (e.g. _feature/env-prompt_). Expected branch names are `master` those that begin with `ENV-`. The user has the choice to enter a deploy environment name (`y` at the prompt) or continue with the branch name (`n` at the prompt).

The prompt will also only occur during commands that are effected by running as interactive/non-interactive (`CI` environment variable set).

## What Changed

### Added

- prompt to optionally provide an explicit deploy environment when git branch name is unexpected (e.g. feature branch) when run interactively

### Changed

- some `unittest.TestCase` tests are now pytest tests
