### PR TITLE
revert context.hook_data data type to dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - prompt to optionally provide an explicit deploy environment when git branch name is unexpected (e.g. feature branch) when run interactively
 
+### Fixed
+- cfngin `hook_data` is once again stored as a `dict` rather than `MutableMap` to support stacker hooks/lookups/blueprints that do not handle the `MutableMap` data type when consuming hook_data.
+
 ## [1.6.1] - 2020-04-14
 ### Fixed
 - global variables in hooks are now reloaded between uses to mimic functionality present in `>1.5.0`

--- a/runway/cfngin/context.py
+++ b/runway/cfngin/context.py
@@ -3,8 +3,6 @@ import collections
 import json
 import logging
 
-from runway.util import MutableMap  # abs to support import through shim
-
 from .config import Config
 from .exceptions import (PersistentGraphCannotLock,
                          PersistentGraphCannotUnlock,
@@ -89,7 +87,7 @@ class Context(object):
         self.bucket_region = self.config.cfngin_bucket_region or region
         self.environment = environment
         self.force_stacks = force_stacks or []
-        self.hook_data = MutableMap()
+        self.hook_data = {}  # TODO change to MutableMap in next major release
         self.region = region
         self.s3_conn = self.get_session(region=self.bucket_region).client('s3')
         self.stack_names = stack_names or []

--- a/runway/cfngin/lookups/handlers/hook_data.py
+++ b/runway/cfngin/lookups/handlers/hook_data.py
@@ -6,6 +6,7 @@ import warnings
 from troposphere import BaseAWSObject
 
 from runway.lookups.handlers.base import LookupHandler
+from runway.util import MutableMap  # abs to support import through shim
 
 LOGGER = logging.getLogger(__name__)
 TYPE_NAME = "hook_data"
@@ -49,7 +50,10 @@ class HookDataLookup(LookupHandler):
         except ValueError:
             query, args = cls.legacy_parse(value)
 
-        result = context.hook_data.find(query, args.get('default'))
+        hook_data = MutableMap(**context.hook_data)
+
+        # TODO use context.hook_data directly in next major release
+        result = hook_data.find(query, args.get('default'))
 
         if isinstance(result, BaseAWSObject) and \
                 args.get('get') and \

--- a/tests/cfngin/test_context.py
+++ b/tests/cfngin/test_context.py
@@ -1,5 +1,5 @@
 """Tests for runway.cfngin.context."""
-# pylint: disable=protected-access,too-many-public-methods
+# pylint: disable=no-self-use,protected-access,too-many-public-methods
 import io
 import json
 import unittest
@@ -72,6 +72,22 @@ class TestContext(unittest.TestCase):
                 {'name': 'stack1'}, {'name': 'stack2', 'requires': ['stack1']}]
         }
         self.persist_graph_config = Config(self.persist_graph_raw_config)
+
+    def test_attributes(self):
+        """Test class attributes."""
+        context = Context(
+            config=Config({}),
+            region='us-east-1'
+        )
+
+        assert isinstance(context.config, Config)
+        assert context.config_path == './'
+        assert context.bucket_region == 'us-east-1'
+        assert not context.environment  # TODO check value
+        assert isinstance(context.force_stacks, list)
+        assert isinstance(context.hook_data, dict)
+        assert context.s3_conn  # TODO check value
+        assert isinstance(context.stack_names, list)
 
     def test_context_optional_keys_set(self):
         """Test context optional keys set."""


### PR DESCRIPTION
## Why This Is Needed

To support legacy uses that do not handle MutableMap until we can enforce the breaking change in the next major release.

Blueprint use case that was broken:

```
        ...
        template.add_resource(ssm.Document(
            'SsmDocument',
            Content=self.context.hook_data['json']],
            DocumentType='Command'
        ))
```

Which resulted in the following error.

```
ERROR:runway.cfngin.plan:<class 'troposphere.ssm.Document'>: SsmDocument.Content is <class 'runway.util.MutableMap'>, expected <class 'dict'>
```

## What Changed

### Fixed

- cfngin `hook_data` is once again stored as a `dict` rather than `MutableMap` to support stacker hooks/lookups/blueprints that do not handle the `MutableMap` data type when consuming hook_data.
