### PR TITLE
add handling for depedabot PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,9 @@ categories:
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
+  - title: '🧶 Dependencies'
+    labels:
+      - dependencies
   - title: '📖 Doc Updates'
     labels:
       - documentation

--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -15,7 +15,7 @@ jobs:
           # Regex the branch should match. This example enforces grouping
           regex: '([a-z])+\/([a-zA-Z0-9\-\_])+'
           # All branches should start with the given prefix
-          allowed_prefixes: 'bugfix,chore,docs,enhancement,feat,feature,fix,hotfix,maint,maintain,maintenance,release'
+          allowed_prefixes: 'bugfix,chore,dependabot,docs,enhancement,feat,feature,fix,hotfix,maint,maintain,maintenance,release'
           # Ignore exactly matching branch names from convention
           ignore: master,release,develop,v0_47_fixes
           # Min length of the branch name


### PR DESCRIPTION
## Summary

Add handling for depedabot PRs.

## What Changed

### Added

- `dependabot/` is now an accepted branch prefix
- releases will now have a **Dependencies** section if any merged PRs were labeled with `dependencies` (used by dependabot)
