### PR TITLE
fix npm build artifact, pypi publish artifact download, setup-node

### DIFF
--- a/.github/scripts/cicd/build_pyinstaller.sh
+++ b/.github/scripts/cicd/build_pyinstaller.sh
@@ -24,7 +24,17 @@ RUNWAY_VERSION=`pipenv run python ./setup.py --version`
 
 pipenv run python setup.py sdist
 pipenv run pip install .
-mkdir -p artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
 rm -rf dist/runway-$RUNWAY_VERSION.tar.gz
 pipenv run pyinstaller --noconfirm --clean runway.$1.spec
-mv dist/* artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
+
+if [ "$1" == 'file' ]; then
+    mkdir -p artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
+    mv dist/* artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
+else
+    mkdir -p artifacts/$LOCAL_OS_NAME
+    if [ "$OS_NAME" == "windows-latest" ]; then
+        7z a -ttar -so ./runway.tar ./dist/runway/* | 7z a -si ./artifacts/$LOCAL_OS_NAME/runway.tar.gz
+    else
+        tar -C dist/runway/ -czvf ./artifacts/$LOCAL_OS_NAME/runway.tar.gz .
+    fi
+fi

--- a/.github/scripts/cicd/build_pyinstaller.sh
+++ b/.github/scripts/cicd/build_pyinstaller.sh
@@ -25,16 +25,15 @@ RUNWAY_VERSION=`pipenv run python ./setup.py --version`
 pipenv run python setup.py sdist
 pipenv run pip install .
 rm -rf dist/runway-$RUNWAY_VERSION.tar.gz
+mkdir -p artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
 pipenv run pyinstaller --noconfirm --clean runway.$1.spec
 
 if [ "$1" == 'file' ]; then
-    mkdir -p artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
     mv dist/* artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
 else
-    mkdir -p artifacts/$LOCAL_OS_NAME
     if [ "$OS_NAME" == "windows-latest" ]; then
-        7z a -ttar -so ./runway.tar ./dist/runway/* | 7z a -si ./artifacts/$LOCAL_OS_NAME/runway.tar.gz
+        7z a -ttar -so ./runway.tar ./dist/runway/* | 7z a -si ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway.tar.gz
     else
-        tar -C dist/runway/ -czvf ./artifacts/$LOCAL_OS_NAME/runway.tar.gz .
+        tar -C dist/runway/ -czvf ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway.tar.gz .
     fi
 fi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -243,8 +243,7 @@ jobs:
 
   build-npm:
     name: Build npm 📦
-    # TODO uncomment if block
-    # if: github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags')
+    if: github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags')
     needs:
       - test-python
       - build-pyinstaller-onefolder

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -414,6 +414,7 @@ jobs:
         uses: actions/download-artifact@v1.0.0
         with:
           name: pypi-dist
+          path: dist
       - name: Publish Distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -243,7 +243,8 @@ jobs:
 
   build-npm:
     name: Build npm 📦
-    if: github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags')
+    # TODO uncomment if block
+    # if: github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags')
     needs:
       - test-python
       - build-pyinstaller-onefolder

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -272,7 +272,7 @@ jobs:
         uses: actions/setup-node@v1.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://registry.npmjs.org/
+          registry-url: https://registry.npmjs.org
       - name: Install Dependencies (ubuntu)
         run: sudo apt-get update && sudo apt-get install sed tree -y
       # - *cache_pip_ubuntu
@@ -338,7 +338,7 @@ jobs:
         uses: actions/setup-node@v1.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://registry.npmjs.org/
+          registry-url: https://registry.npmjs.org
       - name: Download Artifact
         uses: actions/download-artifact@v1.0.0
         with:


### PR DESCRIPTION
## Why This Is Needed

- pypi publish failed due to missing directory
- npm package did not have the correct contents
- npm publish is failing

## What Changed

### Added

- path to artifact download when publishing to pypi

### Changed

- pyinstaller build script will now zip `onefolder` builds

### Removed

- trailing slash from the npm repository url when setting up node to mimic github docs in an attempt to resolve _"You must be logged in to publish packages."_ error
