### PR TITLE
update action trigger, add --access public to npm publish

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,11 @@
 name: CI/CD
 
-on: push
+on:
+  pull_request:  # any pull request
+  push:
+    branches:
+      - master
+      - release
 
 env:
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -273,7 +273,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Node ${{ env.NODE_VERSION }} on ${{ matrix.os }}
-        uses: actions/setup-node@v1.4.0
+        uses: actions/setup-node@v1.4.1
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
@@ -339,7 +339,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Node ${{ env.NODE_VERSION }} on ${{ matrix.os }}
-        uses: actions/setup-node@v1.4.0
+        uses: actions/setup-node@v1.4.1
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -351,12 +351,12 @@ jobs:
       - name: Publish Distribution 📦 to npm (dev)
         if: github.ref == 'refs/heads/master'
         run: |
-          find ./artifacts -name 'onica-runway-*.*.*-*.tgz' -exec npm publish {} --tag dev \;
+          find ./artifacts -name 'onica-runway-*.*.*-*.tgz' -exec npm publish {} --access public --tag dev \;
       - name: Publish Distribution 📦 to npm
         if: startsWith(github.event.ref, 'refs/tags')
         # TODO support alpha, beta, and rc tags
         run: |
-          find ./artifacts -name 'onica-runway-*.*.*-*.tgz' -exec npm publish {} \;
+          find ./artifacts -name 'onica-runway-*.*.*-*.tgz' -exec npm publish {} --access public \;
 
   build-pypi:
     name: Build PyPi 📦


### PR DESCRIPTION
## Why This Is Needed

- actions are not currently being run on PRs from forks
- npm publish is failing

## What Changed

### Added

- `npm publish` now includes `--access public`

### Changed

- the cicd workflow is now triggered on PR or push to the master or release branch
