### PR TITLE
manually configure npm incase action config is causing failure

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -330,6 +330,7 @@ jobs:
     needs:
       - build-npm
     env:
+      CI: true
       NODE_VERSION: 12
       NPM_PACKAGE_NAME: '@onica/runway'
       NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
@@ -343,15 +344,19 @@ jobs:
       - name: Install Node ${{ env.NODE_VERSION }} on ${{ matrix.os }}
         uses: actions/setup-node@v1.4.1
         with:
-          always-auth: true
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://registry.npmjs.org
-          scope: '@onica'
+          registry-url: https://registry.npmjs.org/
       - name: Download Artifact
         uses: actions/download-artifact@v1.0.0
         with:
           name: npm-pack
           path: artifacts
+      - name: Configure npm
+        run: |
+          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
+          npm config set scope "@onica"
+          npm config set always-auth true
+          npm config list
       - name: Publish Distribution 📦 to npm (dev)
         if: github.ref == 'refs/heads/master'
         run: |


### PR DESCRIPTION
## Why This Is Needed

- npm publish is failing

## What Changed

### Changed

- npm is now manually configured instead of relying on the action
