### PR TITLE
fix npm publishing

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -254,7 +254,6 @@ jobs:
       - build-pyinstaller-onefolder
     env:
       NODE_VERSION: 12
-      NPM_PACKAGE_NAME: '@onica/runway'
     strategy:
       fail-fast: true
       matrix:
@@ -332,7 +331,6 @@ jobs:
     env:
       CI: true
       NODE_VERSION: 12
-      NPM_PACKAGE_NAME: '@onica/runway'
       NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
     strategy:
       fail-fast: true
@@ -353,10 +351,14 @@ jobs:
           path: artifacts
       - name: Publish Distribution 📦 to npm (dev)
         if: github.ref == 'refs/heads/master'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
         run: |
           find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish {} -access public --tag dev \;
       - name: Publish Distribution 📦 to npm
         if: startsWith(github.event.ref, 'refs/tags')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
         # TODO support alpha, beta, and rc tags
         run: |
           find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish {} --access public \;

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -317,7 +317,7 @@ jobs:
         run: |
           npm pack
           rm -rf artifacts && mkdir -p artifacts
-          find . -name 'onica-runway-*.*.*-*.tgz' -exec mv {} artifacts/ \;
+          find . -name 'onica-runway-*.*.*.tgz' -exec mv {} artifacts/ \;
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1.0.0
         with:
@@ -354,13 +354,13 @@ jobs:
       - name: Configure npm
         run: |
           npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
-          npm config set scope "@onica"
+          npm config set scope "@platcorp"
           npm config set always-auth true
           npm config list
       - name: Publish Distribution 📦 to npm (dev)
         if: github.ref == 'refs/heads/master'
         run: |
-          find ./artifacts -name 'onica-runway-*.*.*-*.tgz' -exec npm publish {} -access public --tag dev \;
+          find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish {} -access public --tag dev \;
       - name: Publish Distribution 📦 to npm
         if: startsWith(github.event.ref, 'refs/tags')
         # TODO support alpha, beta, and rc tags

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -354,14 +354,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
         run: |
-          find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish {} -access public --tag dev \;
+          find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish --access public --tag dev {} +
       - name: Publish Distribution 📦 to npm
         if: startsWith(github.event.ref, 'refs/tags')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
         # TODO support alpha, beta, and rc tags
         run: |
-          find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish {} --access public \;
+          find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish --access public {} +
 
   build-pypi:
     name: Build PyPi 📦

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -351,12 +351,6 @@ jobs:
         with:
           name: npm-pack
           path: artifacts
-      - name: Configure npm
-        run: |
-          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
-          npm config set scope "@platcorp"
-          npm config set always-auth true
-          npm config list
       - name: Publish Distribution 📦 to npm (dev)
         if: github.ref == 'refs/heads/master'
         run: |


### PR DESCRIPTION
## Why This Is Needed

npm publish is failing

## What Changed

### Removed

- manual npm configuration
- unused env var

### Changed

- npm token env var is now explicitly added to the steps that need it

### Fixed

- `find -exec` file name pattern
- `find -exec` will now correctly return a non-zero exit code if it fails
