### PR TITLE
deprecate support for python 3.5

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.6, 3.7]
     runs-on: ${{ matrix.os }}
     env:
       # populating AWS creds with fake values
@@ -87,12 +87,6 @@ jobs:
         name: Setup Python Virtual Environment (3.x)
         if: matrix.python-version != '2.7'
         run: pipenv sync --dev
-      - # &install_pipenv_legacy
-        name: Install Legacy Python Dependencies
-        if: matrix.python-version == '3.5'
-        # install missing dependency for older versions of python
-        # the version of pytest we are using only requires install for <3.4
-        run: pipenv install "pathlib2>=2.2.0" --dev
       - name: Run Linters
         run: make lint
       - name: Run Unit Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - prompt to optionally provide an explicit deploy environment when git branch name is unexpected (e.g. feature branch) when run interactively
 
+### Changed
+- deprecated support for python 3.5
+  - no longer testing for compatibility
+  - not advertised as being supported
+
 ### Fixed
 - cfngin `hook_data` is once again stored as a `dict` rather than `MutableMap` to support stacker hooks/lookups/blueprints that do not handle the `MutableMap` data type when consuming hook_data.
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],


### PR DESCRIPTION
## Summary

Deprecate python 3.5 support.

## What Changed

### Removed

- python 3.5 compatibility testing
- python 3.5 pypi label