### PR TITLE
only publish to test pypi on commits to master

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -423,12 +423,13 @@ jobs:
           name: pypi-dist
           path: dist
       - name: Publish Distribution 📦 to Test PyPI
+        if: github.ref == 'refs/heads/master'
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/
       - name: Publish Distribution 📦 to PyPI
-        if: success() && startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Fixes prod publishing by eliminating the duplicate push to test pypi after a release is tagged