### PR TITLE
bump pylint and astroid versions, fix linting errors

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -75,20 +75,22 @@ jobs:
         if: matrix.python-version == '2.7' && matrix.os != 'windows-latest'
         run: |
           rm -rf Pipfile.lock
-          pipenv install "pylint<2.0" --dev
-          pipenv sync --dev
+          make sync_two
       - # &pipenv_sync_27_windows
         name: Setup Python Virtual Environment (2.7) (windows)
         if: matrix.python-version == '2.7' && matrix.os == 'windows-latest'
         run: |
           Remove-Item -Path $Env:GITHUB_WORKSPACE\Pipfile.lock -Force
-          pipenv install "pylint<2.0" --dev
-          pipenv sync --dev
+          make sync_two
       - # &pipenv_sync
         name: Setup Python Virtual Environment (3.x)
         if: matrix.python-version != '2.7'
         run: pipenv sync --dev
-      - name: Run Linters
+      - name: Run Linters (2.7)
+        if: matrix.python-version == '2.7'
+        run: make lint_two
+      - name: Run Linters (3.x)
+        if: matrix.python-version != '2.7'
         run: make lint
       - name: Run Unit Tests
         if: matrix.os != 'windows-latest'

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 sync:
 	PIPENV_VENV_IN_PROJECT=1 pipenv sync -d
 
-# not actually a sync since we need to skip-lock but maintains naming
+# changes that need to be made inorder to sync python two (may also require deletion of the existing lock file)
 sync_two:
-	PIPENV_VENV_IN_PROJECT=1 pipenv install --dev --two --skip-lock
+	pipenv install "astroid<2.0" "pylint<2.0" --dev
+	PIPENV_VENV_IN_PROJECT=1 pipenv install --dev
 
 # sync all virtual environments used by this project with their Pipfile.lock
 sync_all:
@@ -30,6 +31,12 @@ clean:
 lint:
 	pipenv run flake8 --exclude=runway/embedded,runway/templates runway
 	find runway -name '*.py' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run pylint --rcfile=.pylintrc
+	find runway/blueprints -name '*.py' | xargs pipenv run pylint --disable=duplicate-code
+
+# linting for python 2, requires additional disables
+lint_two:
+	pipenv run flake8 --exclude=runway/embedded,runway/templates runway
+	find runway -name '*.py' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run pylint --rcfile=.pylintrc --disable=bad-option-value,relative-import
 	find runway/blueprints -name '*.py' | xargs pipenv run pylint --disable=duplicate-code
 
 test:

--- a/Pipfile
+++ b/Pipfile
@@ -20,8 +20,8 @@ flake8-docstrings = "*"
 flake8 = "*"
 # pylint and astroid pinned to avoid "Instance of '' has no 'Bucket' member"
 # error when using boto3. https://github.com/PyCQA/pylint/issues/3134
-pylint = "<2.3.1"
-astroid = "<2.2.5"
+pylint = ">=2.5.0"
+astroid = ">=2.4.0"
 # stuck at 3.5 till this is resolved https://github.com/pyinstaller/pyinstaller/issues/4674
 pyinstaller = "==3.5"
 pytest = "<5.0"  # last version that supports 2.7 - allows install with 2/3

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "410058a612c498d842756d75802c070d950700bf8eb64487e92c66cc7f5d5f89"
+            "sha256": "ab2311cbb434f78fe76e9d7200bf91f0b4820d5855c334ee9318518cb4db707c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -35,24 +35,24 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:16e6259eedcff6afb8b267faf45eeaa69e9a97414e3f7bc2ee6f738d4ee10cec",
-                "sha256:a96d767e92b165df9104d11b32291a4b3282a07f9774cc329f43606862fa0b0f"
+                "sha256:8f18a02ae1817afd084a20191d14daa9c4ead86cdc7c9e4e6209a034ae61232b",
+                "sha256:e2005b3b8ee78005c29da416922bf2777519e683309ef4c3939ff8826a72e612"
             ],
-            "version": "==1.18.41"
+            "version": "==1.18.48"
         },
         "boto3": {
             "hashes": [
-                "sha256:c2c1ee703cb0fa03c5df84b7f00eaa462c808be477dc9014c1e8eef269122770",
-                "sha256:ef16d7dc5f357faf1b081411d2faf62a01793f79a9d664c8b6b1b3ff37aa5e44"
+                "sha256:39ef75f1351d9dce9542c71602bbe4dbae001df1aa5c75bdacea933d60cc1e7f",
+                "sha256:d345f2ba820f022ab45627913cb427b1fa56d7c1f8e19312eee20874ba800007"
             ],
-            "version": "==1.12.41"
+            "version": "==1.12.48"
         },
         "botocore": {
             "hashes": [
-                "sha256:a45a65ba036bc980decfc3ce6c2688a2d5fffd76e4b02ea4d59e63ff0f6896d4",
-                "sha256:b12a5b642aa210a72d84204da18618276eeae052fbff58958f57d28ef3193034"
+                "sha256:ef4fa3055421cb95a7bf559e715f8c5f656aca30fafef070eca21b13ca3f0f81",
+                "sha256:f3569216d2f0067a34608e26ae1d0035b84fa29ad68d6c5fd26124a4cc86e8c9"
             ],
-            "version": "==1.15.41"
+            "version": "==1.15.48"
         },
         "certifi": {
             "hashes": [
@@ -116,10 +116,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
         },
         "colorama": {
             "hashes": [
@@ -131,27 +131,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e",
-                "sha256:192ca04a36852a994ef21df13cca4d822adbbdc9d5009c0f96f1d2929e375d4f",
-                "sha256:19ae795137682a9778892fb4390c07811828b173741bce91e30f899424b3934d",
-                "sha256:1b9b535d6b55936a79dbe4990b64bb16048f48747c76c29713fea8c50eca2acf",
-                "sha256:2a2ad24d43398d89f92209289f15265107928f22a8d10385f70def7a698d6a02",
-                "sha256:3be7a5722d5bfe69894d3f7bbed15547b17619f3a88a318aab2e37f457524164",
-                "sha256:49870684da168b90110bbaf86140d4681032c5e6a2461adc7afdd93be5634216",
-                "sha256:587f98ce27ac4547177a0c6fe0986b8736058daffe9160dcf5f1bd411b7fbaa1",
-                "sha256:5aca6f00b2f42546b9bdf11a69f248d1881212ce5b9e2618b04935b87f6f82a1",
-                "sha256:6b744039b55988519cc183149cceb573189b3e46e16ccf6f8c46798bb767c9dc",
-                "sha256:6b91cab3841b4c7cb70e4db1697c69f036c8bc0a253edc0baa6783154f1301e4",
-                "sha256:7598974f6879a338c785c513e7c5a4329fbc58b9f6b9a6305035fca5b1076552",
-                "sha256:7a279f33a081d436e90e91d1a7c338553c04e464de1c9302311a5e7e4b746088",
-                "sha256:95e1296e0157361fe2f5f0ed307fd31f94b0ca13372e3673fa95095a627636a1",
-                "sha256:9fc9da390e98cb6975eadf251b6e5fa088820141061bf041cd5c72deba1dc526",
-                "sha256:cc20316e3f5a6b582fc3b029d8dc03aabeb645acfcb7fc1d9848841a33265748",
-                "sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc",
-                "sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547",
-                "sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585"
+                "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
+                "sha256:18452582a3c85b96014b45686af264563e3e5d99d226589f057ace56196ec78b",
+                "sha256:1dfa985f62b137909496e7fc182dac687206d8d089dd03eaeb28ae16eec8e7d5",
+                "sha256:1e4014639d3d73fbc5ceff206049c5a9a849cefd106a49fa7aaaa25cc0ce35cf",
+                "sha256:22e91636a51170df0ae4dcbd250d318fd28c9f491c4e50b625a49964b24fe46e",
+                "sha256:3b3eba865ea2754738616f87292b7f29448aec342a7c720956f8083d252bf28b",
+                "sha256:651448cd2e3a6bc2bb76c3663785133c40d5e1a8c1a9c5429e4354201c6024ae",
+                "sha256:726086c17f94747cedbee6efa77e99ae170caebeb1116353c6cf0ab67ea6829b",
+                "sha256:844a76bc04472e5135b909da6aed84360f522ff5dfa47f93e3dd2a0b84a89fa0",
+                "sha256:88c881dd5a147e08d1bdcf2315c04972381d026cdb803325c03fe2b4a8ed858b",
+                "sha256:96c080ae7118c10fcbe6229ab43eb8b090fccd31a09ef55f83f690d1ef619a1d",
+                "sha256:a0c30272fb4ddda5f5ffc1089d7405b7a71b0b0f51993cb4e5dbb4590b2fc229",
+                "sha256:bb1f0281887d89617b4c68e8db9a2c42b9efebf2702a3c5bf70599421a8623e3",
+                "sha256:c447cf087cf2dbddc1add6987bbe2f767ed5317adb2d08af940db517dd704365",
+                "sha256:c4fd17d92e9d55b84707f4fd09992081ba872d1a0c610c109c18e062e06a2e55",
+                "sha256:d0d5aeaedd29be304848f1c5059074a740fa9f6f26b84c5b63e8b29e73dfc270",
+                "sha256:daf54a4b07d67ad437ff239c8a4080cfd1cc7213df57d33c97de7b4738048d5e",
+                "sha256:e993468c859d084d5579e2ebee101de8f5a27ce8e2159959b6673b418fd8c785",
+                "sha256:f118a95c7480f5be0df8afeb9a11bd199aa20afab7a96bcf20409b411a3a85f0"
             ],
-            "version": "==2.9"
+            "version": "==2.9.2"
         },
         "decorator": {
             "hashes": [
@@ -226,12 +226,12 @@
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b",
-                "sha256:d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"
+                "sha256:6f87df66833e1942667108628ec48900e02a4ab4ad850e25fbf07cb17cf734ca",
+                "sha256:85dc0b9b325ff78c8bef2e4ff42616094e16b98ebd5e3b50fe7e2f0bbcdcde49"
             ],
             "index": "pypi",
             "markers": "python_version < '3.7'",
-            "version": "==1.0.2"
+            "version": "==1.5.0"
         },
         "jinja2": {
             "hashes": [
@@ -354,9 +354,9 @@
         },
         "pyhcl": {
             "hashes": [
-                "sha256:91892e72e0488e3595e30eeac86e2cf38aa22494000dfa59336fa467bb0da03c"
+                "sha256:2d9b9dcdf1023d812bfed561ba72c99104c5b3f52e558d595130a44ce081b003"
             ],
-            "version": "==0.4.3"
+            "version": "==0.4.4"
         },
         "pyopenssl": {
             "hashes": [
@@ -501,18 +501,18 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:39183aecc01d6f74eb54edc6739992e842f3bf3068bdfaaba30b5a1742f44091",
-                "sha256:62bd1d8d2ace3e812b3a22eb3c4b7856536d8cc0cdb37466f6a53cf881dbad1f"
+                "sha256:29fa5d46a2404d01c834fcb802a3943685f1fc538eb2a02a161349f5505ac196",
+                "sha256:2fecea42b20abb1922ed65c7b5be27edfba97211b04b2b6abc6a43549a024ea6"
             ],
             "index": "pypi",
-            "version": "==2.2.4"
+            "version": "==2.4.0"
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
+                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
             ],
-            "version": "==1.3.0"
+            "version": "==1.4.0"
         },
         "attrs": {
             "hashes": [
@@ -543,17 +543,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c2c1ee703cb0fa03c5df84b7f00eaa462c808be477dc9014c1e8eef269122770",
-                "sha256:ef16d7dc5f357faf1b081411d2faf62a01793f79a9d664c8b6b1b3ff37aa5e44"
+                "sha256:39ef75f1351d9dce9542c71602bbe4dbae001df1aa5c75bdacea933d60cc1e7f",
+                "sha256:d345f2ba820f022ab45627913cb427b1fa56d7c1f8e19312eee20874ba800007"
             ],
-            "version": "==1.12.41"
+            "version": "==1.12.48"
         },
         "botocore": {
             "hashes": [
-                "sha256:a45a65ba036bc980decfc3ce6c2688a2d5fffd76e4b02ea4d59e63ff0f6896d4",
-                "sha256:b12a5b642aa210a72d84204da18618276eeae052fbff58958f57d28ef3193034"
+                "sha256:ef4fa3055421cb95a7bf559e715f8c5f656aca30fafef070eca21b13ca3f0f81",
+                "sha256:f3569216d2f0067a34608e26ae1d0035b84fa29ad68d6c5fd26124a4cc86e8c9"
             ],
-            "version": "==1.15.41"
+            "version": "==1.15.48"
         },
         "certifi": {
             "hashes": [
@@ -647,27 +647,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e",
-                "sha256:192ca04a36852a994ef21df13cca4d822adbbdc9d5009c0f96f1d2929e375d4f",
-                "sha256:19ae795137682a9778892fb4390c07811828b173741bce91e30f899424b3934d",
-                "sha256:1b9b535d6b55936a79dbe4990b64bb16048f48747c76c29713fea8c50eca2acf",
-                "sha256:2a2ad24d43398d89f92209289f15265107928f22a8d10385f70def7a698d6a02",
-                "sha256:3be7a5722d5bfe69894d3f7bbed15547b17619f3a88a318aab2e37f457524164",
-                "sha256:49870684da168b90110bbaf86140d4681032c5e6a2461adc7afdd93be5634216",
-                "sha256:587f98ce27ac4547177a0c6fe0986b8736058daffe9160dcf5f1bd411b7fbaa1",
-                "sha256:5aca6f00b2f42546b9bdf11a69f248d1881212ce5b9e2618b04935b87f6f82a1",
-                "sha256:6b744039b55988519cc183149cceb573189b3e46e16ccf6f8c46798bb767c9dc",
-                "sha256:6b91cab3841b4c7cb70e4db1697c69f036c8bc0a253edc0baa6783154f1301e4",
-                "sha256:7598974f6879a338c785c513e7c5a4329fbc58b9f6b9a6305035fca5b1076552",
-                "sha256:7a279f33a081d436e90e91d1a7c338553c04e464de1c9302311a5e7e4b746088",
-                "sha256:95e1296e0157361fe2f5f0ed307fd31f94b0ca13372e3673fa95095a627636a1",
-                "sha256:9fc9da390e98cb6975eadf251b6e5fa088820141061bf041cd5c72deba1dc526",
-                "sha256:cc20316e3f5a6b582fc3b029d8dc03aabeb645acfcb7fc1d9848841a33265748",
-                "sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc",
-                "sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547",
-                "sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585"
+                "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
+                "sha256:18452582a3c85b96014b45686af264563e3e5d99d226589f057ace56196ec78b",
+                "sha256:1dfa985f62b137909496e7fc182dac687206d8d089dd03eaeb28ae16eec8e7d5",
+                "sha256:1e4014639d3d73fbc5ceff206049c5a9a849cefd106a49fa7aaaa25cc0ce35cf",
+                "sha256:22e91636a51170df0ae4dcbd250d318fd28c9f491c4e50b625a49964b24fe46e",
+                "sha256:3b3eba865ea2754738616f87292b7f29448aec342a7c720956f8083d252bf28b",
+                "sha256:651448cd2e3a6bc2bb76c3663785133c40d5e1a8c1a9c5429e4354201c6024ae",
+                "sha256:726086c17f94747cedbee6efa77e99ae170caebeb1116353c6cf0ab67ea6829b",
+                "sha256:844a76bc04472e5135b909da6aed84360f522ff5dfa47f93e3dd2a0b84a89fa0",
+                "sha256:88c881dd5a147e08d1bdcf2315c04972381d026cdb803325c03fe2b4a8ed858b",
+                "sha256:96c080ae7118c10fcbe6229ab43eb8b090fccd31a09ef55f83f690d1ef619a1d",
+                "sha256:a0c30272fb4ddda5f5ffc1089d7405b7a71b0b0f51993cb4e5dbb4590b2fc229",
+                "sha256:bb1f0281887d89617b4c68e8db9a2c42b9efebf2702a3c5bf70599421a8623e3",
+                "sha256:c447cf087cf2dbddc1add6987bbe2f767ed5317adb2d08af940db517dd704365",
+                "sha256:c4fd17d92e9d55b84707f4fd09992081ba872d1a0c610c109c18e062e06a2e55",
+                "sha256:d0d5aeaedd29be304848f1c5059074a740fa9f6f26b84c5b63e8b29e73dfc270",
+                "sha256:daf54a4b07d67ad437ff239c8a4080cfd1cc7213df57d33c97de7b4738048d5e",
+                "sha256:e993468c859d084d5579e2ebee101de8f5a27ce8e2159959b6673b418fd8c785",
+                "sha256:f118a95c7480f5be0df8afeb9a11bd199aa20afab7a96bcf20409b411a3a85f0"
             ],
-            "version": "==2.9"
+            "version": "==2.9.2"
         },
         "decorator": {
             "hashes": [
@@ -749,15 +749,6 @@
             "markers": "python_version < '3.8'",
             "version": "==1.6.0"
         },
-        "importlib-resources": {
-            "hashes": [
-                "sha256:6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b",
-                "sha256:d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"
-            ],
-            "index": "pypi",
-            "markers": "python_version < '3.7'",
-            "version": "==1.0.2"
-        },
         "isort": {
             "hashes": [
                 "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
@@ -795,10 +786,10 @@
         },
         "jsonpickle": {
             "hashes": [
-                "sha256:3d71018794242f6b1640f779a94a192500f73ceed9ef579b4f01799171ec3fb3",
-                "sha256:e8ca6ec3f379f5eee6e11380d48db220aacc282b480dea46b11cc6f6009d1cdb"
+                "sha256:8919c166bac0574e3d74425c7559434062002d9dfc0ac2afa6dc746ba4a19439",
+                "sha256:e8d4b7cd0bd6826001a74377df1079a76ad8bae0f909282de2554164c837c8ba"
             ],
-            "version": "==1.4"
+            "version": "==1.4.1"
         },
         "jsonpointer": {
             "hashes": [
@@ -940,11 +931,11 @@
         },
         "pep8-naming": {
             "hashes": [
-                "sha256:45f330db8fcfb0fba57458c77385e288e7a3be1d01e8ea4268263ef677ceea5f",
-                "sha256:a33d38177056321a167decd6ba70b890856ba5025f0a8eca6a3eda607da93caf"
+                "sha256:5d9f1056cb9427ce344e98d1a7f5665710e2f20f748438e308995852cfa24164",
+                "sha256:f3b4a5f9dd72b991bf7d8e2a341d2e1aa3a884a769b5aaac4f56825c1763bf3a"
             ],
             "index": "pypi",
-            "version": "==0.9.1"
+            "version": "==0.10.0"
         },
         "pluggy": {
             "hashes": [
@@ -1007,11 +998,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:2bf4bd58d6d5d87174fbc9d1d134a9aeee852d4dc29cbd422a7015772770bc63",
-                "sha256:ee80c7af4f127b2a480d83010c9f0e97beb8eaa652b78c2837d3ed30b12e1182"
+                "sha256:588e114e3f9a1630428c35b7dd1c82c1c93e1b0e78ee312ae4724c5e1a1e0245",
+                "sha256:bd556ba95a4cf55a1fc0004c00cf4560b1e70598a54a74c6904d933c8f3bd5a8"
             ],
             "index": "pypi",
-            "version": "==2.3.0"
+            "version": "==2.5.0"
         },
         "pyparsing": {
             "hashes": [
@@ -1058,10 +1049,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
-                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
-            "version": "==2019.3"
+            "version": "==2020.1"
         },
         "pywin32": {
             "hashes": [
@@ -1173,6 +1164,13 @@
             "index": "pypi",
             "version": "==4.10.1"
         },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
         "typed-ast": {
             "hashes": [
                 "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
@@ -1197,7 +1195,7 @@
                 "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
-            "markers": "implementation_name == 'cpython'",
+            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
             "version": "==1.4.1"
         },
         "urllib3": {

--- a/runway/cfngin/plan.py
+++ b/runway/cfngin/plan.py
@@ -290,6 +290,7 @@ class Step(object):
             :class:`Step`
 
         """
+        # pylint: disable=import-outside-toplevel
         from runway.cfngin.config import Stack as StackConfig
         from runway.cfngin.stack import Stack
 

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -677,8 +677,7 @@ class Provider(BaseProvider):
                     if cancel.wait(TAIL_RETRY_SLEEP):
                         return
                     continue
-                else:
-                    raise
+                raise
 
     @staticmethod
     def _tail_print(event):

--- a/runway/cfngin/util.py
+++ b/runway/cfngin/util.py
@@ -335,7 +335,7 @@ def get_config_directory():
 
     """
     # avoid circular import
-    from .commands.stacker import Stacker
+    from .commands.stacker import Stacker  # pylint: disable=import-outside-toplevel
     deprecation_msg = ('get_config_directory has been deprecated and will be '
                        'removed in the next major release')
     warnings.warn(deprecation_msg, DeprecationWarning)
@@ -715,7 +715,7 @@ class SourceProcessor(object):
         """
         # only loading git here when needed to avoid load errors on systems
         # without git installed
-        from git import Repo
+        from git import Repo  # pylint: disable=import-outside-toplevel
 
         ref = self.determine_git_ref(config)
         dir_name = self.sanitize_git_path(uri=config['uri'], ref=ref)

--- a/runway/commands/runway/gen_sample.py
+++ b/runway/commands/runway/gen_sample.py
@@ -83,6 +83,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 def generate_tfstate_cfn_template():
     """Return rendered CFN template yaml."""
+    # pylint: disable=import-outside-toplevel
     from runway.blueprints.tf_state import TfState
 
     return to_yaml(TfState('test',
@@ -169,6 +170,7 @@ def generate_sample_k8s_cfn_repo(env_root):
                      repo_dir)
         sys.exit(1)
 
+    # pylint: disable=import-outside-toplevel
     from runway.blueprints.k8s.k8s_master import Cluster
     from runway.blueprints.k8s.k8s_iam import Iam
     from runway.blueprints.k8s.k8s_workers import NodeGroup as WorkerNodeGroup

--- a/runway/commands/runway_command.py
+++ b/runway/commands/runway_command.py
@@ -126,8 +126,8 @@ def get_env(path, ignore_git_branch=False, prompt_if_unexpected=False):
     else:
         # These are not located with the top imports because they throw an
         # error if git isn't installed
-        from git import Repo as GitRepo
-        from git.exc import InvalidGitRepositoryError
+        from git import Repo as GitRepo  # pylint: disable=import-outside-toplevel
+        from git.exc import InvalidGitRepositoryError  # pylint: disable=import-outside-toplevel
 
         try:
             b_name = GitRepo(

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -7,8 +7,8 @@ import sys
 import tempfile
 
 # Old pylint on py2.7 incorrectly flags these
-from six.moves.urllib.request import urlretrieve  # noqa pylint: disable=import-error,line-too-long
-from six.moves.urllib.error import URLError  # noqa pylint: disable=import-error,relative-import,line-too-long
+from six.moves.urllib.request import urlretrieve  # pylint: disable=E
+from six.moves.urllib.error import URLError  # pylint: disable=E
 
 from . import EnvManager, ensure_versions_dir_exists, handle_bin_download_error
 from ..util import md5sum

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -14,8 +14,8 @@ import zipfile
 import hcl
 import requests
 # Old pylint on py2.7 incorrectly flags these
-from six.moves.urllib.request import urlretrieve  # noqa pylint: disable=import-error,line-too-long
-from six.moves.urllib.error import URLError  # noqa pylint: disable=import-error,relative-import,line-too-long
+from six.moves.urllib.request import urlretrieve  # pylint: disable=E
+from six.moves.urllib.error import URLError  # pylint: disable=E
 
 from . import EnvManager, ensure_versions_dir_exists, handle_bin_download_error
 from ..util import get_hash_for_filename, sha256sum

--- a/runway/sources/git.py
+++ b/runway/sources/git.py
@@ -53,7 +53,7 @@ class Git(Source):
     def fetch(self):
         # type: () -> str
         """Retrieve the git repository from it's remote location."""
-        from git import Repo
+        from git import Repo  # pylint: disable=import-outside-toplevel
 
         ref = self.__determine_git_ref()  # type: str
         dir_name = '_'.join([self.sanitize_git_path(self.uri), ref])  # type: str

--- a/runway/templates/k8s-tf-repo/eks-base.tf/get_idp_root_cert_thumbprint.py
+++ b/runway/templates/k8s-tf-repo/eks-base.tf/get_idp_root_cert_thumbprint.py
@@ -4,7 +4,7 @@ import json
 import socket
 import sys
 # This false pylint error is only an issue on py2
-from six.moves.urllib.parse import urlparse  # pylint: disable=relative-import
+from six.moves.urllib.parse import urlparse  # pylint: disable=E
 import requests
 from cryptography.hazmat.primitives import serialization
 from OpenSSL import SSL

--- a/runway/variables.py
+++ b/runway/variables.py
@@ -699,7 +699,7 @@ class VariableValueLookup(VariableValue):
 
         """
         if isinstance(self.handler, type):
-            import warnings
+            import warnings  # pylint: disable=import-outside-toplevel
             warn_msg = ('Old style lookup in use. Please upgrade to use '
                         'the new style of Lookups that accepts '
                         '"**kwargs".')


### PR DESCRIPTION
## Why This Is Needed

resolves #256 

## What Changed

### Added

- `make lint_two` as there are some disables that need to be added to the cli command for python 2 liniting
	- it is done this way to avoid cluttering codebase with python 2 specific disables that would need to be cleaned up in the not to distant future

### Changed

- bumped pylint and astroid versions
- `make sync_two` now changes the pinned versions of astroid and pylint so that syncing can succeed.

### Fixed

- linting errors introduced by new version of pylint
