### PR TITLE
[WIP] Fix a@e staticsite deployment

### DIFF
--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -27,11 +27,6 @@ class Dependencies(Blueprint):
             'default': False,
             'description': 'Whether a User Pool should be created for the project'
         },
-        'UserPoolId': {
-            'type': str,
-            'default': '',
-            'description': 'User Pool ID for Authorization @ Edge'
-        },
         'OAuthScopes': {
             'type': list,
             'default': [
@@ -118,8 +113,6 @@ class Dependencies(Blueprint):
         if variables['AuthAtEdge']:
             callbacks = self.context.hook_data['aae_callback_url_retriever']['callback_urls']
 
-            user_pool_id = variables['UserPoolId']
-
             if variables['CreateUserPool']:
                 user_pool = template.add_resource(
                     cognito.UserPool("AuthAtEdgeUserPool")
@@ -132,6 +125,8 @@ class Dependencies(Blueprint):
                     Description='Cognito User Pool App Client for Auth @ Edge',
                     Value=user_pool_id
                 ))
+            else:
+                user_pool_id = self.context.hook_data['aae_user_pool_id_retriever']['id']
 
             client = template.add_resource(
                 cognito.UserPoolClient(

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -140,7 +140,7 @@ class StaticSite(RunwayModule):
                 }
             }]
 
-            if self.parameters.get('staticsite_create_user_pool', False):
+            if self.parameters.get('staticsite_create_user_pool'):
                 # Retrieve the user pool id
                 pre_destroy.append({
                     'path': 'runway.hooks.staticsite.auth_at_edge.user_pool_id_retriever.get',
@@ -156,6 +156,14 @@ class StaticSite(RunwayModule):
                     'required': True,
                     'data_key': 'aae_domain_updater',
                     'args': self._get_domain_updater_variables(),
+                })
+            else:
+                # Retrieve the user pool id
+                pre_build.append({
+                    'path': 'runway.hooks.staticsite.auth_at_edge.user_pool_id_retriever.get',
+                    'required': True,
+                    'data_key': 'aae_user_pool_id_retriever',
+                    'args': self._get_user_pool_id_retriever_variables(),
                 })
 
         with open(os.path.join(module_dir, '01-dependencies.yaml'), 'w') as output_stream:  # noqa


### PR DESCRIPTION
A@E static sites (with a supplied user pool) have an incorrect CFN
config generated. This change fixes the dependencies template to
properly retrieve the user pool id