### PR TITLE
Fix a@e staticsite deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Static Site Auth@Edge deployments with pre-existing userpools
+
 ### Added
 - support for AWS SSO profile as the initial credential source
 

--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -27,11 +27,6 @@ class Dependencies(Blueprint):
             'default': False,
             'description': 'Whether a User Pool should be created for the project'
         },
-        'UserPoolId': {
-            'type': str,
-            'default': '',
-            'description': 'User Pool ID for Authorization @ Edge'
-        },
         'OAuthScopes': {
             'type': list,
             'default': [
@@ -118,8 +113,6 @@ class Dependencies(Blueprint):
         if variables['AuthAtEdge']:
             callbacks = self.context.hook_data['aae_callback_url_retriever']['callback_urls']
 
-            user_pool_id = variables['UserPoolId']
-
             if variables['CreateUserPool']:
                 user_pool = template.add_resource(
                     cognito.UserPool("AuthAtEdgeUserPool")
@@ -132,6 +125,8 @@ class Dependencies(Blueprint):
                     Description='Cognito User Pool App Client for Auth @ Edge',
                     Value=user_pool_id
                 ))
+            else:
+                user_pool_id = self.context.hook_data['aae_user_pool_id_retriever']['id']
 
             client = template.add_resource(
                 cognito.UserPoolClient(

--- a/runway/hooks/staticsite/auth_at_edge/templates/check_auth/__init__.py
+++ b/runway/hooks/staticsite/auth_at_edge/templates/check_auth/__init__.py
@@ -3,7 +3,7 @@
 
 When the information is not present or an error occurs due to verification a new
 request to Cognito will be made to authorize the user. The user will be taken
-to the Cognito login page to enter their information, and so long as it is valid,
+to the Cognito login page to enter their information, and as long as it is valid,
 the information will be passed to the parsing agent.
 
 If a refresh token exists and it has expired (after 1 hour) do an automatic refresh

--- a/runway/hooks/staticsite/auth_at_edge/templates/http_headers/__init__.py
+++ b/runway/hooks/staticsite/auth_at_edge/templates/http_headers/__init__.py
@@ -1,4 +1,4 @@
-"""Add all configured headers (CloudFront compatable) to origin response."""
+"""Add all configured (CloudFront compatable) headers to origin response."""
 from shared import as_cloud_front_headers, get_config  # pylint: disable=import-error
 
 CONFIG = get_config()

--- a/runway/hooks/staticsite/auth_at_edge/templates/parse_auth/__init__.py
+++ b/runway/hooks/staticsite/auth_at_edge/templates/parse_auth/__init__.py
@@ -1,7 +1,7 @@
 """Parse the given Cognito/Local authorization information.
 
 Ensure the parsed Cognito and Local authorization information from the retrieved
-query string parameter and cookie headers matches our expectations. If it doesn't
+query string parameter and cookie headers matches expectations. If it doesn't
 then inform the user of a bad request, otherwise retrieve the Cognito tokens to
 add to the cookie headers.
 """

--- a/runway/hooks/staticsite/auth_at_edge/templates/refresh_auth/__init__.py
+++ b/runway/hooks/staticsite/auth_at_edge/templates/refresh_auth/__init__.py
@@ -1,4 +1,4 @@
-"""Refresh the authorization token for new credentials."""
+"""Refresh authorization token for new credentials."""
 
 import logging
 import traceback

--- a/runway/hooks/staticsite/auth_at_edge/templates/sign_out/__init__.py
+++ b/runway/hooks/staticsite/auth_at_edge/templates/sign_out/__init__.py
@@ -1,4 +1,4 @@
-"""Sign the user out of Cognito and remove all Cookie Headers."""
+"""Sign user out of Cognito and remove all Cookie Headers."""
 
 import logging
 from urllib.parse import urlencode  # pylint: disable=no-name-in-module,import-error

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -140,7 +140,7 @@ class StaticSite(RunwayModule):
                 }
             }]
 
-            if self.parameters.get('staticsite_create_user_pool', False):
+            if self.parameters.get('staticsite_create_user_pool'):
                 # Retrieve the user pool id
                 pre_destroy.append({
                     'path': 'runway.hooks.staticsite.auth_at_edge.user_pool_id_retriever.get',
@@ -156,6 +156,14 @@ class StaticSite(RunwayModule):
                     'required': True,
                     'data_key': 'aae_domain_updater',
                     'args': self._get_domain_updater_variables(),
+                })
+            else:
+                # Retrieve the user pool id
+                pre_build.append({
+                    'path': 'runway.hooks.staticsite.auth_at_edge.user_pool_id_retriever.get',
+                    'required': True,
+                    'data_key': 'aae_user_pool_id_retriever',
+                    'args': self._get_user_pool_id_retriever_variables(),
                 })
 
         with open(os.path.join(module_dir, '01-dependencies.yaml'), 'w') as output_stream:  # noqa


### PR DESCRIPTION
A@E static sites (with a supplied user pool) have an incorrect CFN
config generated. This change fixes the dependencies template to
properly retrieve the user pool id.

An additional error is encountered by existing runway staticsite
deployments (example I have tested is from master pre-1.5) which
don't cleanly update the Lambda@Edge functions. The issue appears to be
that the same Lambda function versions are used by L@E while the IAM
role (that was associated with them when they were created) is deleted
by CFN.

I've elected for a simple fix here: non-functional function source code
changes to trigger new versions to be deployed.