### PR TITLE
add ability to extend a serverless.yml from runway.yml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
         "altgraph",
         "atomicwrites",
         "boto",
+        "bufsize",
         "certifi",
         "cffi",
         "cfngin",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- ability to extend a Serverless configuration file the `extend_serverless_yml` option
+
+### Fixed
+- the value of `environments` is once again used to determine if a serverless module should be skipped
+
 ## [1.7.3] - 2020-04-29
 ### Fixed
 - Static Site Auth@Edge deployments with pre-existing userpools

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint:
 
 # linting for python 2, requires additional disables
 lint_two:
-	pipenv run flake8 --exclude=runway/embedded,runway/templates runway
+	pipenv run flake8 --exclude=runway/embedded,runway/templates --ignore=D101,D403,E124,W504 runway
 	find runway -name '*.py' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run pylint --rcfile=.pylintrc --disable=bad-option-value,relative-import
 	find runway/blueprints -name '*.py' | xargs pipenv run pylint --disable=duplicate-code
 

--- a/docs/source/runway_config.rst
+++ b/docs/source/runway_config.rst
@@ -34,10 +34,14 @@ Module
 
 .. autoclass:: runway.config.ModuleDefinition
 
+.. _runway-module-path:
+
 Path
 ----
 
 .. automodule:: runway.path.Path
+
+.. _runway-module-path-git:
 
 Git
 ~~~

--- a/docs/source/serverless/configuration.rst
+++ b/docs/source/serverless/configuration.rst
@@ -15,6 +15,59 @@ Prerequisites
 We strongly recommend you commit the package-lock.json that is generated after running ``npm install``.
 
 
+*******
+Options
+*******
+
+Options specific to Serverless Framework modules.
+
+**args (Optional[List[str]]**
+  List of CLI arguments/options to pass to the Serverless Framework CLI.
+  See :ref:`Specifying Serverless CLI Arguments/Options <sls-args>` for more details.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    options:
+      args:
+        - '--config'
+        - sls.yml
+
+**extend_serverless_yml (Optional[Dict[str, Any]])**
+  If provided, the value of this option will be recursively merged into the modules *serverless.yml* file.
+  See :ref:`Extending a Serverless Configuration File <sls-extend-yml>` for more details.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    options:
+      extend_serverless_yml:
+        custom:
+          env:
+            memorySize: 512
+
+**promotezip (Optional[Dict[str, str]])**
+  If provided, promote Serverless Framework generated zip files between environments from a *build* AWS account.
+  See :ref:`Promoting Builds Through Environments <sls-promotezip>` for more details.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    options:
+      promotezip:
+        bucketname: my-build-account-bucket-name
+
+**skip_npm_ci (bool)**
+  Skip running ``npm ci`` in the module directory prior to processing the module *(default: false)*.
+  See :ref:`Disabling NPM CI <sls-skip-npm-ci>` for more details.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    options:
+      skip_npm_ci: true
+
+
 **************
 serverless.yml
 **************

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -165,7 +165,7 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
 
         # potential future state of RunwayModule attributes in a future release
         self._raw_path = Path(options.pop('path')) if options.get('path') else None
-        self.environments = options.pop('environments', None)
+        self.environments = options.pop('environments', {})
         self.options = options.pop('options', {})
         self.parameters = options.pop('parameters', {})
         self.path = path if isinstance(self.path, Path) else Path(self.path)

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -147,6 +147,7 @@ class RunwayModule(object):
 class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
     """Base class for Runway modules that use npm."""
 
+    # TODO we need a better name than "options" or pass in as kwargs
     def __init__(self, context, path, options=None):
         """Instantiate class.
 
@@ -164,7 +165,7 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
 
         # potential future state of RunwayModule attributes in a future release
         self._raw_path = Path(options.pop('path')) if options.get('path') else None
-        self.environments = options.pop('environments', {})
+        self.environments = options.pop('environments', None)
         self.options = options.pop('options', {})
         self.parameters = options.pop('parameters', {})
         self.path = Path(self.path)  # convert to path object

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -9,6 +9,11 @@ import six
 
 from ..util import merge_nested_environment_dicts, which
 
+if sys.version_info[0] > 2:  # TODO remove after droping python 2
+    from pathlib import Path  # pylint: disable=E
+else:
+    from pathlib2 import Path  # pylint: disable=E
+
 LOGGER = logging.getLogger('runway')
 NPM_BIN = 'npm.cmd' if platform.system().lower() == 'windows' else 'npm'
 NPX_BIN = 'npx.cmd' if platform.system().lower() == 'windows' else 'npx'
@@ -110,6 +115,7 @@ class RunwayModule(object):
 
     def __init__(self, context, path, options=None):
         """Initialize base class."""
+        self._env_file = None
         self.context = context
 
         self.path = path
@@ -136,6 +142,82 @@ class RunwayModule(object):
         """Implement dummy method (set in consuming classes)."""
         raise NotImplementedError('You must implement the destroy() method '
                                   'yourself!')
+
+
+class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
+    """Base class for Runway modules that use npm."""
+
+    def __init__(self, context, path, options=None):
+        """Instantiate class.
+
+        Args:
+            context (Context): Runway context object.
+            path (str): Path to the module.
+            options (Dict[str, Dict[str, Any]]): Everything in the module
+                definition merged with applicable values from the deployment
+                definition.
+
+        """
+        self.check_for_npm()  # fail fast
+        super(RunwayModuleNpm, self).__init__(context, path, options)
+        del self.options  # remove the attr set by the parent class
+
+        # potential future state of RunwayModule attributes in a future release
+        self._raw_path = Path(options.pop('path')) if options.get('path') else None
+        self.environments = options.pop('environments', {})
+        self.options = options.pop('options', {})
+        self.parameters = options.pop('parameters', {})
+        self.path = Path(self.path)  # convert to path object
+
+        for k, v in options.items():
+            setattr(self, k, v)
+
+        warn_on_boto_env_vars(self.context.env_vars)
+
+    def check_for_npm(self):
+        """Ensure npm is installed and in the current path."""
+        if not which('npm'):
+            LOGGER.error('%s: "npm" not found in path or is not executable; '
+                         'please ensure it is installed correctly.',
+                         self.path.name)
+            sys.exit(1)
+
+    def log_npm_command(self, command):
+        """Log an npm command that is going to be run.
+
+        Args:
+            command (List[str]): List that will be passed into a subprocess.
+
+        """
+        LOGGER.info('%s: Running "%s"', self.path.name,
+                    format_npm_command_for_logging(command))
+
+    def npm_install(self):
+        """Run ``npm install``."""
+        if self.options.get('skip_npm_ci'):
+            LOGGER.info("%s: Skipping npm ci and npm install...",
+                        self.path.name)
+        elif self.context.is_noninteractive and use_npm_ci(str(self.path)):
+            LOGGER.info("%s: Running npm ci...",
+                        self.path.name)
+            subprocess.check_call([NPM_BIN, 'ci'])
+        else:
+            LOGGER.info("%s: Running npm install...",
+                        self.path.name)
+            subprocess.check_call([NPM_BIN, 'install'])
+
+    def package_json_missing(self):
+        """Check for the existence for a package.json file in the module.
+
+        Returns:
+            bool: True if the file was not found.
+
+        """
+        if not (self.path / 'package.json').is_file():
+            LOGGER.warning('%s: Module is missing a "package.json"',
+                           self.path.name)
+            return True
+        return False
 
 
 class ModuleOptions(six.moves.collections_abc.MutableMapping):  # pylint: disable=no-member

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -115,7 +115,6 @@ class RunwayModule(object):
 
     def __init__(self, context, path, options=None):
         """Initialize base class."""
-        self._env_file = None
         self.context = context
 
         self.path = path
@@ -153,13 +152,14 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
 
         Args:
             context (Context): Runway context object.
-            path (str): Path to the module.
+            path (Union[str, Path]): Path to the module.
             options (Dict[str, Dict[str, Any]]): Everything in the module
                 definition merged with applicable values from the deployment
                 definition.
 
         """
         self.check_for_npm()  # fail fast
+        options = options or {}
         super(RunwayModuleNpm, self).__init__(context, path, options)
         del self.options  # remove the attr set by the parent class
 
@@ -168,7 +168,7 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
         self.environments = options.pop('environments', None)
         self.options = options.pop('options', {})
         self.parameters = options.pop('parameters', {})
-        self.path = Path(self.path)  # convert to path object
+        self.path = path if isinstance(self.path, Path) else Path(self.path)
 
         for k, v in options.items():
             setattr(self, k, v)

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import uuid
 
 import yaml
 
@@ -16,10 +17,9 @@ from runway.hooks.staticsite.util import get_hash_of_files
 
 from ..s3_util import (does_s3_object_exist, download, ensure_bucket_exists,
                        upload)
-from ..util import change_dir, which
-from . import (ModuleOptions, RunwayModule, format_npm_command_for_logging,
-               generate_node_command, run_module_command, run_npm_install,
-               warn_on_boto_env_vars)
+from ..util import merge_dicts
+from . import (ModuleOptions, RunwayModuleNpm, format_npm_command_for_logging,
+               generate_node_command, run_module_command)
 
 if sys.version_info[0] > 2:  # TODO remove after droping python 2
     from pathlib import Path  # pylint: disable=E
@@ -46,29 +46,6 @@ def gen_sls_config_files(stage, region):
         )
         names.append("config-%s.%s" % (stage, ext))
     return names
-
-
-def get_sls_config_file(path, stage, region):
-    """Determine Serverless config file name."""
-    for name in gen_sls_config_files(stage, region):
-        if os.path.isfile(os.path.join(path, name)):
-            return name
-    return "config-%s.json" % stage  # fallback to generic json name
-
-
-def run_sls_remove(sls_cmd, env_vars):
-    """Run sls remove command."""
-    sls_process = subprocess.Popen(sls_cmd,
-                                   stdout=subprocess.PIPE,
-                                   env=env_vars)
-    stdoutdata, _stderrdata = sls_process.communicate()
-    sls_return = sls_process.wait()
-    if int(sys.version[0]) > 2:
-        stdoutdata = stdoutdata.decode('UTF-8')  # bytes -> string
-    print(stdoutdata)
-    if sls_return != 0 and (sls_return == 1 and not (
-            re.search(r"Stack '.*' does not exist", stdoutdata))):
-        sys.exit(sls_return)
 
 
 def run_sls_print(sls_opts, env_vars, path):
@@ -151,7 +128,7 @@ def deploy_package(sls_opts, bucketname, context, path):
     shutil.rmtree(package_dir)
 
 
-class Serverless(RunwayModule):
+class Serverless(RunwayModuleNpm):
     """Serverless Runway Module."""
 
     def __init__(self, context, path, options=None):
@@ -166,180 +143,223 @@ class Serverless(RunwayModule):
 
         """
         super(Serverless, self).__init__(context, path, options)
-        del self.options  # remove the attr set by the parent class
-        options.pop('path', None)  # this
 
-        self._raw_path = options.pop('path', None)  # unresolved path
-        self.environments = options.pop('environments', {})
-        self.options = ServerlessOptions.parse(**options.pop('options', {}))
-        self.parameters = options.pop('parameters', {})
+        self.options = ServerlessOptions.parse(**self.options)
+        self.region = self.context.env_region
+        self.stage = self.context.env_name
 
-        for k, v in options.items():
-            setattr(self, k, v)
+    @property
+    def cli_args(self):
+        """Generate CLI args from self used in all Serverless commands.
 
-        LOGGER.warning(self.path)
-
-    def run_cmd(self, command, *args, arg_list=None, exit_on_error=True):
-        """Run a command with this modules underlying CLI.
-
-        Args:
-            command (str): The command to be executed with Serverless.
-
-        Keyword Args:
-            arg_list (Optional[List[str]]): List of arguments to include in
-                the command.
-            exit_on_error (bool): Perform sys.exit if the command fails.
+        Returns:
+            List[str]
 
         """
-        args = list(args)
-        args.extend(arg_list or [])
-        args.insert(0, command)
+        result = ['--region', self.region,
+                  '--stage', self.stage]
+        if 'DEBUG' in self.context.env_vars:
+            result.append('--verbose')
+        return result
+
+    @property
+    def env_file(self):
+        """Find the environment file for the module.
+
+        Returns:
+            Path: Path object for the environment file that was found.
+
+        """
+        if not self._env_file:
+            for name in gen_sls_config_files(self.stage, self.region):
+                test_path = Path(self.path) / name
+                if test_path.is_file():
+                    self._env_file = test_path
+                    break
+        return self._env_file
+
+    @property
+    def skip(self):
+        """Determine if the module should be skipped.
+
+        Returns:
+            bool: To skip, or not to skip, that is the question.
+
+        """
+        if not self.package_json_missing():
+            if self.parameters or self.environments or self.env_file:
+                return False
+            LOGGER.warning('%s: No config file for this stage/region found '
+                           '(looking for one of "%s")', self.path.name,
+                           ', '.join(gen_sls_config_files(self.stage,
+                                                          self.region)))
+        else:
+            LOGGER.warning('%s: The Serverless module type requires a package '
+                           'file specifying serverless in devDependencies',
+                           self.path.name)
+        LOGGER.warning('%s: Skipping module', self.path.name)
+        return True
+
+    def extend_serverless_yml(self, func):
+        """Extend the Serverless config file with additional YAML from options.
+
+        Args:
+            func (Callable): Callable to use after handling the Serverless
+                config file.
+
+        """
+        self.npm_install()  # doing this here for a cleaner log
+        LOGGER.info('%s: Extending Serverless config from runway.yml...',
+                    self.path.name)
+        final_yml = merge_dicts(self.sls_print(skip_install=True),
+                                self.options.extend_serverless_yml)
+        # using a unique name to prevent collisions when run in parallel
+        tmp_file = self.path / '{}.tmp.serverless.yml'.format(uuid.uuid4())
+        LOGGER.info('%s: Creating temporary serverless config... "%s"',
+                    self.path.name, tmp_file.name)
+        tmp_file.write_text(yaml.safe_dump(final_yml))
+
+        try:
+            # update args from options with the new config name
+            self.options.update_args('config', str(tmp_file.name))
+            func(skip_install=True)
+        finally:
+            tmp_file.unlink()  # always cleanup the temp file
+
+    def gen_cmd(self, command, args_list=None):
+        """Generate and log a Serverless command.
+
+        This does not execute the command, only prepares it for use.
+
+        Args:
+            command (str): The Serverless command to be executed.
+            args_list (Optiona[List[str]]): Additional arguments to include
+                in the generated command.
+
+        Returns:
+            List[str]: The full command to be passed into a subprocess.
+
+        """
+        args = [command] + self.cli_args + self.options.args
+        args.extend(args_list or [])
+        if command not in ['remove', 'print'] and self.context.is_noninteractive:
+            args.append('--conceal')  # hide secrets from serverless output
         cmd = generate_node_command(command='sls',
                                     command_opts=args,
                                     path=self.path)
-        run_module_command(cmd_list=cmd,
-                           env_vars=self.context.env_vars,
-                           exit_on_error=exit_on_error)
+        self.log_npm_command(cmd)
+        return cmd
 
-    def print(self, item_path=None, output_format='yaml'):
-        """Print the Serverless file with all variables resolved.
+    def sls_deploy(self, skip_install=False):
+        """Execute ``sls deploy`` command.
+
+        Args:
+            skip_install (bool): Skip ``npm install`` before running the
+                Serverless command. (*default:* ``False``)
+
+        """
+        if not skip_install:
+            self.npm_install()
+
+        if self.options.promotezip:
+            # TODO refactor deploy_package to be part of the class
+            deploy_package(['deploy', *self.cli_args, *self.options.args],
+                           self.options.promotezip['bucketname'],
+                           self.context,
+                           str(self.path))
+            return
+        run_module_command(cmd_list=self.gen_cmd('deploy'),
+                           env_vars=self.context.env_vars)
+
+    def sls_print(self, item_path=None, output_format='yaml', skip_install=False):
+        """Execute ``sls print`` command.
 
         Keyword Args:
             item_path (Optional[str]): Period-separated path to print a
                 sub-value (eg: "provider.name").
             output_format (str) Print configuration in given format
                 ("yaml", "json", "text"). *(default: yaml)*
+            skip_install (bool): Skip ``npm install`` before running the
+                Serverless command. (*default:* ``False``)
 
         Returns:
-            Path: Path object for the output file.
+            Dict[str, Any]: Resolved Serverless config file.
 
         Raises:
             SystemExit: If a runway-tmp.serverless.yml file already exists.
 
         """
-        args = ['print',
-                '--region', self.context.env_region,
-                '--stage', self.context.env_name,
-                '--format', output_format]
+        if not skip_install:
+            self.npm_install()
+
+        args = ['--format', output_format]
         if item_path:
             args.extend(['--path', item_path])
-        args.extend(self.options.args)
+        return yaml.safe_load(subprocess.check_output(self.gen_cmd('print'),
+                                                      env=self.context.env_vars))
 
-        output_file = Path(self.path) / 'runway-tmp.serverless.yml'
-        if output_file.exists():
-            LOGGER.error('Unable to save resolved Serverless file. '
-                         'Runway temporary file already exists: %s',
-                         output_file)
-            sys.exit(1)
+    def sls_remove(self, skip_install=False):
+        """Execute ``sls remove`` command.
 
-        with open(output_file, 'w') as file_:
-            proc = subprocess.Popen(generate_node_command(command='sls',
-                                                          command_opts=args,
-                                                          path=self.path),
-                                    cwd=self.path, stdout=file_,
-                                    env=self.context.env_vars)
-            if proc.wait() != 0:
-                file_.close()
-                output_file.unlink()
-                sys.exit(proc.returncode)
-        return output_file
+        Args:
+            skip_install (bool): Skip ``npm install`` before running the
+                Serverless command. (*default:* ``False``)
 
-    def run_serverless(self, command='deploy'):
-        """Run Serverless."""
-        response = {'skipped_configs': False}
-        sls_opts = [command]
-
-        if not which('npm'):
-            LOGGER.error('"npm" not found in path or is not executable; '
-                         'please ensure it is installed correctly.')
-            sys.exit(1)
-
-        if 'CI' in self.context.env_vars and command != 'remove':
-            sls_opts.append('--conceal')  # Hide secrets from serverless output
-
-        if 'DEBUG' in self.context.env_vars:
-            sls_opts.append('-v')  # Increase logging if requested
-
-        warn_on_boto_env_vars(self.context.env_vars)
-
-        sls_opts.extend(['-r', self.context.env_region])
-        sls_opts.extend(['--stage', self.context.env_name])
-        sls_env_file = get_sls_config_file(self.path,
-                                           self.context.env_name,
-                                           self.context.env_region)
-        sls_opts.extend(self.options.args)
-
-        sls_cmd = generate_node_command(command='sls',
-                                        command_opts=sls_opts,
-                                        path=self.path)
-
-        if (
-                self.parameters or
-                os.path.isfile(os.path.join(self.path, sls_env_file))
-        ):
-            if os.path.isfile(os.path.join(self.path, 'package.json')):
-                with change_dir(self.path):
-                    run_npm_install(self.path, {'options': self.options},
-                                    self.context)
-                    if command == 'deploy' and self.options.promotezip:
-                        deploy_package(sls_opts,
-                                       self.options.promotezip['bucketname'],
-                                       self.context,
-                                       self.path)
-                        return response
-
-                    LOGGER.info("Running sls %s on %s (\"%s\")",
-                                command,
-                                os.path.basename(self.path),
-                                format_npm_command_for_logging(sls_cmd))
-                    if command == 'remove':
-                        # Need to account for exit code 1 on any removals after
-                        # the first
-                        run_sls_remove(sls_cmd, self.context.env_vars)
-                    else:
-                        run_module_command(cmd_list=sls_cmd,
-                                           env_vars=self.context.env_vars)
-            else:
-                LOGGER.warning(
-                    "Skipping serverless %s of %s; no \"package.json\" "
-                    "file was found (need a package file specifying "
-                    "serverless in devDependencies)",
-                    command,
-                    os.path.basename(self.path))
-        else:
-            response['skipped_configs'] = True
-            LOGGER.info(
-                "Skipping serverless %s of %s; no config file for "
-                "this stage/region found (looking for one of \"%s\")",
-                command,
-                os.path.basename(self.path),
-                ', '.join(gen_sls_config_files(self.context.env_name,
-                                               self.context.env_region)))
-        return response
+        """
+        if not skip_install:
+            self.npm_install()
+        stack_missing = False  # track output for acceptable error
+        proc = subprocess.Popen(self.gen_cmd('remove'),
+                                stdout=subprocess.PIPE,
+                                env=self.context.env_vars,
+                                bufsize=1, universal_newlines=True)
+        with proc.stdout:  # live output
+            for line in proc.stdout:
+                print(line, end='')
+                if re.search(r"Stack '.*' does not exist", line):
+                    stack_missing = True
+        if proc.wait() != 0 and not stack_missing:
+            sys.exit(proc.returncode)
 
     def plan(self):
-        """Skip sls planning."""
+        """Entrypoint for Runway's plan action."""
         LOGGER.info('Planning not currently supported for Serverless')
 
     def deploy(self):
-        """Run sls deploy."""
-        self.run_serverless(command='deploy')
+        """Entrypoint for Runway's deploy action."""
+        if self.skip:
+            return
+        if self.options.extend_serverless_yml:
+            self.extend_serverless_yml(self.sls_deploy)
+        else:
+            self.sls_deploy()
 
     def destroy(self):
-        """Run serverless remove."""
-        self.run_serverless(command='remove')
+        """Entrypoint for Runway's destroy action."""
+        if self.skip:
+            return
+        if self.options.extend_serverless_yml:
+            self.extend_serverless_yml(self.sls_remove)
+        else:
+            self.sls_remove()
 
 
 class ServerlessOptions(ModuleOptions):
     """Module options for Serverless."""
 
-    def __init__(self, args=None, promotezip=None, skip_npm_ci=False):
+    def __init__(self, args=None, extend_serverless_yml=None, promotezip=None,
+                 skip_npm_ci=False):
         """Instantiate class.
 
         Keyword Args:
             args (Optional[List[str]]): Arguments to append to Serverless CLI
                 commands. These will always be placed after the default
                 arguments provided by Runway.
+            extend_serverless_yml (Optional[Dict[str, Any]]): If provided,
+                a temporary Serverless config will be created will be created
+                from what exists in the module directory then the value of
+                this option will be merged into it. The temporary file will
+                be deleted at the end of execution.
             promotezip (Optional[Dict[str, str]]): If provided, promote
                 Serverless generated zip files between environments from a
                 *build* AWS account.
@@ -349,10 +369,42 @@ class ServerlessOptions(ModuleOptions):
         """
         super(ServerlessOptions, self).__init__()
         self._arg_parser = self._create_arg_parser()
-        self.args = args or []
-        self.cli_args, _ = self._arg_parser.parse_known_args(self.args)
+        self.extend_serverless_yml = extend_serverless_yml or {}
+        cli_args, self._unknown_cli_args = \
+            self._arg_parser.parse_known_args(args)
+        self._cli_args = vars(cli_args)  # convert argparse.Namespace to dict
         self.promotezip = promotezip or {}
         self.skip_npm_ci = skip_npm_ci
+
+    @property
+    def args(self):
+        """Args to pass to the CLI.
+
+        Returns:
+            List[str]: List of arguments.
+
+        """
+        known_args = []
+        for key, val in self._cli_args.items():
+            if isinstance(val, str):
+                known_args.extend(['--%s' % key, val])
+        return known_args + self._unknown_cli_args
+
+    def update_args(self, key, value):
+        """Update a known CLI argument.
+
+        Args:
+            key (str): Dict key to be updated.
+            value (str): New value
+
+        Raises:
+            KeyError: The key provided for update is now a known arg.
+
+        """
+        if key in self._cli_args:
+            self._cli_args[key] = value
+        else:
+            raise KeyError(key)
 
     @staticmethod
     def _create_arg_parser():
@@ -377,6 +429,11 @@ class ServerlessOptions(ModuleOptions):
             args (Optional[List[str]]): Arguments to append to Serverless CLI
                 commands. These will always be placed after the default
                 arguments provided by Runway.
+            extend_serverless_yml (Optional[Dict[str, Any]]): If provided,
+                a temporary Serverless config will be created will be created
+                from what exists in the module directory then the value of
+                this option will be merged into it. The temporary file will
+                be deleted at the end of execution.
             promotezip (Optional[Dict[str, str]]): If provided, promote
                 Serverless generated zip files between environments from a
                 *build* AWS account.
@@ -395,5 +452,6 @@ class ServerlessOptions(ModuleOptions):
             raise ValueError('"bucketname" must be specified when using '
                              '"promotezip": {}'.format(promotezip))
         return cls(args=kwargs.get('args'),
+                   extend_serverless_yml=kwargs.get('extend_serverless_yml'),
                    promotezip=promotezip,
                    skip_npm_ci=kwargs.get('skip_npm_ci', False))

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -137,6 +137,7 @@ class Serverless(RunwayModuleNpm):
                 definition.
 
         """
+        options = options or {}
         super(Serverless, self).__init__(context, path, options.copy())
 
         self.options = ServerlessOptions.parse(**options.get('options', {}))

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -227,8 +227,8 @@ class Serverless(RunwayModuleNpm):
             try:
                 tmp_file.unlink()  # always cleanup the temp file
             except OSError as err:
-                # catch error raised if file does not exist
-                LOGGER.debug(err)
+                # catch error raised if file does not exist but this is fine
+                LOGGER.debug('%s: %s', self.path.name, err)
 
     def gen_cmd(self, command, args_list=None):
         """Generate and log a Serverless command.

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -137,9 +137,9 @@ class Serverless(RunwayModuleNpm):
                 definition.
 
         """
-        super(Serverless, self).__init__(context, path, options)
+        super(Serverless, self).__init__(context, path, options.copy())
 
-        self.options = ServerlessOptions.parse(**self.options)
+        self.options = ServerlessOptions.parse(**options.get('options', {}))
         self.region = self.context.env_region
         self.stage = self.context.env_name
 

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -263,7 +263,7 @@ class Serverless(RunwayModuleNpm):
 
         if self.options.promotezip:
             # TODO refactor deploy_package to be part of the class
-            deploy_package(['deploy', *self.cli_args, *self.options.args],
+            deploy_package(['deploy'] + self.cli_args + self.options.args,
                            self.options.promotezip['bucketname'],
                            self.context,
                            str(self.path))

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -45,7 +45,7 @@ def gen_sls_config_files(stage, region):
 
 def run_sls_print(sls_opts, env_vars, path):
     """Run sls print command."""
-    sls_info_opts = sls_opts
+    sls_info_opts = list(sls_opts)
     sls_info_opts[0] = 'print'
     sls_info_opts.extend(['--format', 'yaml'])
     sls_info_cmd = generate_node_command(command='sls',
@@ -84,8 +84,7 @@ def deploy_package(sls_opts, bucketname, context, path):
     hashes = get_src_hash(sls_config, path)
 
     sls_opts[0] = 'package'
-    sls_opts.extend(['--package', os.path.relpath(package_dir,
-                                                  path)])
+    sls_opts.extend(['--package', package_dir])
     sls_package_cmd = generate_node_command(command='sls',
                                             command_opts=sls_opts,
                                             path=path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ exclude_lines =
     # defensive exceptions
     raise AssertionError
     raise NotImplimentedError
+    if self.context.is_python3:
+    if not self.context.is_python3:
 
 [coverage:run]
 concurrency =

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,6 +1,7 @@
 """Test classes."""
 import io
 import os
+import sys
 
 import boto3
 from botocore.stub import Stubber
@@ -175,7 +176,10 @@ class MockProcess(object):  # pylint: disable=too-few-public-methods
         io_base = io.StringIO() if self.text_mode else io.BytesIO()
 
         if result:
-            io_base.write(result)
+            if sys.version_info.major < 3:
+                io_base.write(result.decode('UTF-8'))
+            else:
+                io_base.write(result)
             io_base.seek(0)  # return to the begining of the stream
         return io_base
 

--- a/tests/module/conftest.py
+++ b/tests/module/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest fixtures and plugins."""
+import pytest
+
+
+@pytest.fixture
+def patch_module_npm(monkeypatch):
+    """Patch methods and functions used during init of RunwayModuleNpm."""
+    monkeypatch.setattr('runway.module.RunwayModuleNpm.check_for_npm',
+                        lambda x: None)
+    monkeypatch.setattr('runway.module.warn_on_boto_env_vars', lambda x: None)

--- a/tests/module/test_module.py
+++ b/tests/module/test_module.py
@@ -1,17 +1,135 @@
 """Test runway.module.__init__."""
-# pylint: disable=no-self-use
+# pylint: disable=no-self-use,unused-argument
+import logging
 import sys
 from contextlib import contextmanager
+from mock import MagicMock, call, patch
 
 import pytest
 
-from runway.module import ModuleOptions
+from runway.module import NPM_BIN, ModuleOptions, RunwayModuleNpm
+
+if sys.version_info[0] > 2:  # TODO remove after droping python 2
+    from pathlib import Path  # pylint: disable=E
+else:
+    from pathlib2 import Path  # pylint: disable=E
 
 
 @contextmanager
 def does_not_raise():
     """Use for conditional pytest.raises when using parametrize."""
     yield
+
+
+class TestRunwayModuleNpm(object):
+    """Test runway.module.RunwayModuleNpm."""
+
+    @patch.object(RunwayModuleNpm, 'check_for_npm', MagicMock(return_value=None))
+    @patch('runway.module.warn_on_boto_env_vars')
+    def test_init(self, mock_warn, runway_context, tmp_path):
+        """Test init and the attributes set in init."""
+        options = {
+            'environments': True,  # can only be True of a falsy value (but not dict)
+            'options': {'test_option': 'option_value'},
+            'parameters': {'test_parameter': 'parameter_value'}
+        }
+        obj = RunwayModuleNpm(context=runway_context,
+                              path=str(tmp_path),
+                              options=options.copy())
+
+        obj.check_for_npm.assert_called_once()  # pylint: disable=no-member
+        assert obj.context == runway_context
+        assert obj.environments == options['environments']
+        assert obj.options == options['options']
+        assert obj.parameters == options['parameters']
+        assert isinstance(obj.path, Path)
+        assert str(obj.path) == str(tmp_path)
+        mock_warn.assert_called_once_with(runway_context.env_vars)
+
+    @patch('runway.module.which')
+    @patch('runway.module.warn_on_boto_env_vars', MagicMock(return_value=None))
+    def test_check_for_npm(self, mock_which, caplog, runway_context):
+        """Test check_for_npm."""
+        mock_which.side_effect = ['something',  # first call during init
+                                  None]  # explicit call
+        obj = RunwayModuleNpm(context=runway_context,
+                              path='./tests',
+                              options={})
+        caplog.set_level(logging.WARNING, logger='runway')
+
+        with pytest.raises(SystemExit):
+            assert not obj.check_for_npm()
+
+        assert ['tests: "npm" not found in path or is not executable; '
+                'please ensure it is installed correctly.'] == \
+            [rec.message for rec in caplog.records]
+
+    @patch('runway.module.format_npm_command_for_logging')
+    def test_log_npm_command(self, mock_log, caplog, patch_module_npm,
+                             runway_context):
+        """Test log_npm_command."""
+        mock_log.return_value = 'success'
+        obj = RunwayModuleNpm(context=runway_context,
+                              path='./tests',
+                              options={})
+        caplog.set_level(logging.INFO, logger='runway')
+        assert not obj.log_npm_command(['npm', 'test'])
+        mock_log.assert_called_once_with(['npm', 'test'])
+        assert ['tests: Running "success"'] == [rec.message
+                                                for rec in caplog.records]
+
+    @patch('runway.module.use_npm_ci')
+    @patch('runway.module.subprocess')
+    def test_npm_install(self, moc_proc, mock_ci, caplog, patch_module_npm,
+                         runway_context):
+        """Test npm_install."""
+        caplog.set_level(logging.INFO, logger='runway')
+        obj = RunwayModuleNpm(context=runway_context,
+                              path='./tests',
+                              options={})
+        expected_logs = []
+        expected_calls = []
+
+        obj.options['skip_npm_ci'] = True
+        assert not obj.npm_install()
+        expected_logs.append('tests: Skipping npm ci and npm install...')
+
+        obj.options['skip_npm_ci'] = False
+        obj.context.env_vars['CI'] = True
+        mock_ci.return_value = True
+        assert not obj.npm_install()
+        expected_logs.append('tests: Running npm ci...')
+        expected_calls.append(call([NPM_BIN, 'ci']))
+
+        obj.context.env_vars['CI'] = False
+        assert not obj.npm_install()
+        expected_logs.append('tests: Running npm install...')
+        expected_calls.append(call([NPM_BIN, 'install']))
+
+        obj.context.env_vars['CI'] = True
+        mock_ci.return_value = False
+        assert not obj.npm_install()
+        expected_logs.append('tests: Running npm install...')
+        expected_calls.append(call([NPM_BIN, 'install']))
+
+        assert expected_logs == [rec.message for rec in caplog.records]
+        moc_proc.check_call.assert_has_calls(expected_calls)
+
+    def test_package_json_missing(self, caplog, patch_module_npm,
+                                  runway_context, tmp_path):
+        """Test package_json_missing."""
+        caplog.set_level(logging.WARNING, logger='runway')
+        obj = RunwayModuleNpm(context=runway_context,
+                              path=str(tmp_path),
+                              options={})
+
+        assert obj.package_json_missing()
+        assert [
+            '{}: Module is missing a "package.json"'.format(tmp_path.name)
+        ] == [rec.message for rec in caplog.records]
+
+        (tmp_path / 'package.json').touch()
+        assert not obj.package_json_missing()
 
 
 class TestModuleOptions(object):

--- a/tests/module/test_module.py
+++ b/tests/module/test_module.py
@@ -3,9 +3,9 @@
 import logging
 import sys
 from contextlib import contextmanager
-from mock import MagicMock, call, patch
 
 import pytest
+from mock import MagicMock, call, patch
 
 from runway.module import NPM_BIN, ModuleOptions, RunwayModuleNpm
 

--- a/tests/module/test_serverless.py
+++ b/tests/module/test_serverless.py
@@ -1,13 +1,352 @@
 """Test runway.module.serverless."""
 # pylint: disable=no-self-use,unused-argument
-import pytest
+import logging
+import subprocess
 
-from runway.module.serverless import ServerlessOptions
+import pytest
+import yaml
+from mock import ANY, MagicMock, patch
+
+from runway.module.serverless import (Serverless, ServerlessOptions,
+                                      gen_sls_config_files)
+
+from ..factories import MockProcess
 
 
 @pytest.mark.usefixtures('patch_module_npm')
 class TestServerless(object):
     """Test runway.module.serverless.Serverless."""
+
+    def test_cli_args(self, runway_context):
+        """Test cli_args."""
+        obj = Serverless(runway_context, './tests')
+
+        assert obj.cli_args == ['--region', runway_context.env_region,
+                                '--stage', runway_context.env_name]
+
+        runway_context.env_vars['DEBUG'] = '1'
+        assert obj.cli_args == ['--region', runway_context.env_region,
+                                '--stage', runway_context.env_name,
+                                '--verbose']
+
+    def test_deploy(self, monkeypatch, runway_context):
+        """Test deploy."""
+        # pylint: disable=no-member
+        monkeypatch.setattr(Serverless, 'extend_serverless_yml', MagicMock())
+        monkeypatch.setattr(Serverless, 'sls_deploy', MagicMock())
+        obj = Serverless(runway_context, './tests')
+
+        monkeypatch.setattr(Serverless, 'skip', True)
+        assert not obj.deploy()
+        obj.extend_serverless_yml.assert_not_called()
+        obj.sls_deploy.assert_not_called()
+
+        monkeypatch.setattr(Serverless, 'skip', False)
+        monkeypatch.setattr(obj.options, 'extend_serverless_yml', True)
+        assert not obj.deploy()
+        obj.extend_serverless_yml.assert_called_once_with(obj.sls_deploy)
+        obj.sls_deploy.assert_not_called()
+
+        monkeypatch.setattr(obj.options, 'extend_serverless_yml', False)
+        assert not obj.deploy()
+        obj.extend_serverless_yml.assert_called_once()
+        obj.sls_deploy.assert_called_once_with()
+
+    def test_destroy(self, monkeypatch, runway_context):
+        """Test destroy."""
+        # pylint: disable=no-member
+        monkeypatch.setattr(Serverless, 'extend_serverless_yml', MagicMock())
+        monkeypatch.setattr(Serverless, 'sls_remove', MagicMock())
+        obj = Serverless(runway_context, './tests')
+
+        monkeypatch.setattr(Serverless, 'skip', True)
+        assert not obj.destroy()
+        obj.extend_serverless_yml.assert_not_called()
+        obj.sls_remove.assert_not_called()
+
+        monkeypatch.setattr(Serverless, 'skip', False)
+        monkeypatch.setattr(obj.options, 'extend_serverless_yml', True)
+        assert not obj.destroy()
+        obj.extend_serverless_yml.assert_called_once_with(obj.sls_remove)
+        obj.sls_remove.assert_not_called()
+
+        monkeypatch.setattr(obj.options, 'extend_serverless_yml', False)
+        assert not obj.destroy()
+        obj.extend_serverless_yml.assert_called_once()
+        obj.sls_remove.assert_called_once_with()
+
+    def test_env_file(self, runway_context, tmp_path):
+        """Test env_file.
+
+        Testing the precedence of each path, create the files in order from
+        lowerst to highest. After creating the file, the property's value
+        is checked then cleared since the value is cached after the first
+        time it is resolved.
+
+        """
+        env_dir = tmp_path / 'env'
+        env_dir.mkdir()
+        obj = Serverless(runway_context, tmp_path)
+        assert not obj.env_file
+        del obj.env_file
+
+        config_test_json = tmp_path / 'config-test.json'
+        config_test_json.touch()
+        assert obj.env_file == config_test_json
+        del obj.env_file
+
+        env_test_json = env_dir / 'test.json'
+        env_test_json.touch()
+        assert obj.env_file == env_test_json
+        del obj.env_file
+
+        config_test_us_east_1_json = tmp_path / 'config-test-us-east-1.json'
+        config_test_us_east_1_json.touch()
+        assert obj.env_file == config_test_us_east_1_json
+        del obj.env_file
+
+        env_test_us_east_1_json = env_dir / 'test-us-east-1.json'
+        env_test_us_east_1_json.touch()
+        assert obj.env_file == env_test_us_east_1_json
+        del obj.env_file
+
+        config_test_yml = tmp_path / 'config-test.yml'
+        config_test_yml.touch()
+        assert obj.env_file == config_test_yml
+        del obj.env_file
+
+        env_test_yml = env_dir / 'test.yml'
+        env_test_yml.touch()
+        assert obj.env_file == env_test_yml
+        del obj.env_file
+
+        config_test_us_east_1_yml = tmp_path / 'config-test-us-east-1.yml'
+        config_test_us_east_1_yml.touch()
+        assert obj.env_file == config_test_us_east_1_yml
+        del obj.env_file
+
+        env_test_us_east_1_yml = env_dir / 'test-us-east-1.yml'
+        env_test_us_east_1_yml.touch()
+        assert obj.env_file == env_test_us_east_1_yml
+        del obj.env_file
+
+    @patch('runway.module.serverless.merge_dicts')
+    def test_extend_serverless_yml(self, mock_merge, monkeypatch,
+                                   runway_context, tmp_path):
+        """Test extend_serverless_yml."""
+        # pylint: disable=no-member
+        mock_func = MagicMock()
+        mock_merge.return_value = {'key': 'val'}
+        monkeypatch.setattr(Serverless, 'npm_install', MagicMock())
+        monkeypatch.setattr(Serverless, 'sls_print',
+                            MagicMock(return_value='original'))
+        monkeypatch.setattr(ServerlessOptions, 'update_args', MagicMock())
+
+        options = {
+            'extend_serverless_yml': {'new-key': 'val'}
+        }
+        obj = Serverless(runway_context, tmp_path,
+                         options={'options': options})
+
+        assert not obj.extend_serverless_yml(mock_func)
+        obj.npm_install.assert_called_once()
+        obj.sls_print.assert_called_once()
+        mock_merge.assert_called_once_with('original',
+                                           options['extend_serverless_yml'])
+        mock_func.assert_called_once_with(skip_install=True)
+        obj.options.update_args.assert_called_once_with('config', ANY)
+
+        tmp_file = obj.options.update_args.call_args[0][1]
+        # 'no way to check the prefix since it will be a uuid'
+        assert tmp_file.endswith('.tmp.serverless.yml')
+        assert not (tmp_path / tmp_file).exists(), \
+            'should always be deleted after calling "func"'
+
+    @patch('runway.module.serverless.generate_node_command')
+    @pytest.mark.parametrize('command', [('deploy'), ('remove'), ('print')])
+    def test_gen_cmd(self, mock_cmd, command, monkeypatch, runway_context,
+                     tmp_path):
+        """Test gen_cmd."""
+        monkeypatch.setattr(Serverless, 'log_npm_command', MagicMock())
+        mock_cmd.return_value = ['success']
+        obj = Serverless(runway_context, tmp_path,
+                         {'options': {'args': ['--config', 'test']}})
+        expected_opts = [command,
+                         '--region', runway_context.env_region,
+                         '--stage', runway_context.env_name,
+                         '--config', 'test',
+                         '--extra-arg']
+
+        assert obj.gen_cmd(command, args_list=['--extra-arg']) == ['success']
+        mock_cmd.assert_called_once_with(command='sls',
+                                         command_opts=expected_opts,
+                                         path=tmp_path)
+        obj.log_npm_command.assert_called_once_with(['success'])
+        mock_cmd.reset_mock()
+
+        obj.context.env_vars['CI'] = '1'
+        if command not in ['remove', 'print']:
+            expected_opts.append('--conceal')
+        assert obj.gen_cmd(command, args_list=['--extra-arg']) == ['success']
+        mock_cmd.assert_called_once_with(command='sls',
+                                         command_opts=expected_opts,
+                                         path=tmp_path)
+
+    def test_init(self, runway_context):
+        """Test init and the attributes set in init."""
+        obj = Serverless(runway_context, './tests',
+                         {'options': {'skip_npm_ci': True}})
+        assert isinstance(obj.options, ServerlessOptions)
+        assert obj.region == runway_context.env_region
+        assert obj.stage == runway_context.env_name
+
+    def test_plan(self, caplog, runway_context):
+        """Test plan."""
+        caplog.set_level(logging.INFO, logger='runway')
+        obj = Serverless(runway_context, './tests')
+
+        assert not obj.plan()
+        assert ['Planning not currently supported for Serverless'] == \
+            caplog.messages
+
+    def test_skip(self, caplog, monkeypatch, runway_context, tmp_path):
+        """Test skip."""
+        caplog.set_level(logging.WARNING, logger='runway')
+        obj = Serverless(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'package_json_missing', lambda: True)
+        monkeypatch.setattr(obj, 'env_file', False)
+
+        assert obj.skip
+        assert ['{}: The Serverless module type requires a package file '
+                'specifying serverless in devDependencies'.format(tmp_path.name),
+                '{}: Skipping module'.format(tmp_path.name)] == caplog.messages
+        caplog.clear()
+
+        monkeypatch.setattr(obj, 'package_json_missing', lambda: False)
+        assert obj.skip
+        assert ['{}: No config file for this stage/region found (looking for '
+                'one of "{}")'.format(tmp_path.name,
+                                      ', '.join(gen_sls_config_files(obj.stage,
+                                                                     obj.region))),
+                '{}: Skipping module'.format(tmp_path.name)] == caplog.messages
+        caplog.clear()
+
+        obj.environments = True
+        assert not obj.skip
+        obj.environments = False
+
+        obj.parameters = True
+        assert not obj.skip
+        obj.parameters = False
+
+        obj.env_file = True
+        assert not obj.skip
+
+    @patch('runway.module.serverless.deploy_package')
+    @patch('runway.module.serverless.run_module_command')
+    def test_sls_deploy(self, mock_run, mock_deploy, monkeypatch,
+                        runway_context, tmp_path):
+        """Test sls_deploy."""
+        # pylint: disable=no-member
+        monkeypatch.setattr(Serverless, 'gen_cmd',
+                            MagicMock(return_value=['deploy']))
+        monkeypatch.setattr(Serverless, 'npm_install', MagicMock())
+        obj = Serverless(runway_context, tmp_path,
+                         options={'options': {'args': ['--config', 'test.yml']}})
+
+        assert not obj.sls_deploy()
+        obj.npm_install.assert_called_once()
+        obj.gen_cmd.assert_called_once_with('deploy')
+        mock_run.assert_called_once_with(cmd_list=['deploy'],
+                                         env_vars=runway_context.env_vars)
+
+        obj.options.promotezip['bucketname'] = 'test-bucket'
+        assert not obj.sls_deploy(skip_install=True)
+        obj.npm_install.assert_called_once()
+        mock_deploy.assert_called_once_with(
+            ['deploy',
+             '--region', runway_context.env_region,
+             '--stage', runway_context.env_name,
+             '--config', 'test.yml'],
+            'test-bucket',
+            runway_context,
+            str(tmp_path)
+        )
+        mock_run.assert_called_once()
+
+    def test_sls_print(self, monkeypatch, runway_context):
+        """Test sls_print."""
+        # pylint: disable=no-member
+        expected_dict = {'status': 'success'}
+        mock_check_output = MagicMock(return_value=yaml.safe_dump(expected_dict))
+        monkeypatch.setattr(Serverless, 'gen_cmd',
+                            MagicMock(return_value=['print']))
+        monkeypatch.setattr(Serverless, 'npm_install', MagicMock())
+        monkeypatch.setattr('subprocess.check_output', mock_check_output)
+        obj = Serverless(runway_context, './tests')
+
+        assert obj.sls_print() == expected_dict
+        obj.npm_install.assert_called_once()
+        mock_check_output.assert_called_once_with(['print'],
+                                                  env=runway_context.env_vars)
+        obj.gen_cmd.assert_called_once_with('print',
+                                            args_list=['--format', 'yaml'])
+        obj.gen_cmd.reset_mock()
+
+        assert obj.sls_print(item_path='something.status',
+                             skip_install=True) == expected_dict
+        obj.npm_install.assert_called_once()
+        obj.gen_cmd.assert_called_once_with('print',
+                                            args_list=['--format', 'yaml',
+                                                       '--path', 'something.status'])
+
+    def test_sls_remove(self, monkeypatch, runway_context):
+        """Test sls_remove."""
+        # pylint: disable=no-member
+        # TODO use pytest-subprocess for when dropping python 2
+        sls_error = [
+            '  Serverless Error ---------------------------------------',
+            '',
+            "  Stack 'test-stack' does not exist",
+            '',
+            '  Get Support --------------------------------------------',
+            '     Docs:          docs.serverless.com',
+            '     Bugs:          github.com/serverless/serverless/issues',
+            '     Issues:        forum.serverless.com'
+        ]
+        mock_popen = MagicMock(return_value=MockProcess(returncode=0,
+                                                        stdout='success'))
+        monkeypatch.setattr('subprocess.Popen', mock_popen)
+        monkeypatch.setattr(Serverless, 'gen_cmd',
+                            MagicMock(return_value=['remove']))
+        monkeypatch.setattr(Serverless, 'npm_install', MagicMock())
+
+        obj = Serverless(runway_context, './tests')
+        assert not obj.sls_remove()
+        obj.npm_install.assert_called_once()
+        obj.gen_cmd.assert_called_once_with('remove')
+        mock_popen.assert_called_once_with(['remove'],
+                                           bufsize=1,
+                                           env=runway_context.env_vars,
+                                           stdout=subprocess.PIPE,
+                                           universal_newlines=True)
+        mock_popen.return_value.wait.assert_called_once()
+
+        mock_popen = MagicMock(return_value=MockProcess(returncode=1,
+                                                        stdout=sls_error))
+
+        monkeypatch.setattr('subprocess.Popen', mock_popen)
+        assert not obj.sls_remove(skip_install=True)
+        obj.npm_install.assert_called_once()
+        mock_popen.return_value.wait.assert_called_once()
+
+        sls_error[2] = '  Some other error'
+        mock_popen = MagicMock(return_value=MockProcess(returncode=1,
+                                                        stdout=sls_error))
+        monkeypatch.setattr('subprocess.Popen', mock_popen)
+        with pytest.raises(SystemExit):
+            assert not obj.sls_remove()
+        mock_popen.return_value.wait.assert_called_once()
 
 
 class TestServerlessOptions(object):

--- a/tests/module/test_serverless.py
+++ b/tests/module/test_serverless.py
@@ -167,6 +167,7 @@ class TestServerless(object):
     def test_gen_cmd(self, mock_cmd, command, monkeypatch, runway_context,
                      tmp_path):
         """Test gen_cmd."""
+        # pylint: disable=no-member
         monkeypatch.setattr(Serverless, 'log_npm_command', MagicMock())
         mock_cmd.return_value = ['success']
         obj = Serverless(runway_context, tmp_path,

--- a/tests/module/test_serverless.py
+++ b/tests/module/test_serverless.py
@@ -193,13 +193,22 @@ class TestServerless(object):
                                          command_opts=expected_opts,
                                          path=tmp_path)
 
-    def test_init(self, runway_context):
+    def test_init(self, caplog, runway_context):
         """Test init and the attributes set in init."""
+        caplog.set_level(logging.ERROR, logger='runway')
         obj = Serverless(runway_context, './tests',
                          {'options': {'skip_npm_ci': True}})
         assert isinstance(obj.options, ServerlessOptions)
         assert obj.region == runway_context.env_region
         assert obj.stage == runway_context.env_name
+
+        with pytest.raises(SystemExit):
+            assert not Serverless(runway_context, './tests',
+                                  {'options': {
+                                      'promotezip': {'invalid': 'value'}
+                                  }})
+        assert ['tests: "bucketname" must be provided when using '
+                '"options.promotezip": {\'invalid\': \'value\'}'] == caplog.messages
 
     def test_plan(self, caplog, runway_context):
         """Test plan."""

--- a/tests/module/test_serverless.py
+++ b/tests/module/test_serverless.py
@@ -1,0 +1,78 @@
+"""Test runway.module.serverless."""
+# pylint: disable=no-self-use,unused-argument
+import pytest
+
+from runway.module.serverless import ServerlessOptions
+
+
+@pytest.mark.usefixtures('patch_module_npm')
+class TestServerless(object):
+    """Test runway.module.serverless.Serverless."""
+
+
+class TestServerlessOptions(object):
+    """Test runway.module.serverless.ServerlessOptions."""
+
+    @pytest.mark.parametrize('args, expected', [
+        (['--config', 'something'], ['--config', 'something']),
+        (['--config', 'something', '--unknown-arg', 'value'],
+         ['--config', 'something', '--unknown-arg', 'value']),
+        (['-c', 'something'], ['--config', 'something']),
+        (['-u'], ['-u'])
+    ])
+    def test_args(self, args, expected):
+        """Test args."""
+        obj = ServerlessOptions(args=args,
+                                extend_serverless_yml={},
+                                promotezip={})
+        assert obj.args == expected
+
+    @pytest.mark.parametrize('config', [
+        ({'args': ['--config', 'something']}),
+        ({'extend_serverless_yml': {'new_key': 'test_value'}}),
+        ({'promotezip': {'bucketname': 'test-bucket'}}),
+        ({'skip_npm_ci': True}),
+        ({'args': ['--config', 'something'],
+          'extend_serverless_yml': {'new_key': 'test_value'}}),
+        ({'args': ['--config', 'something'],
+          'extend_serverless_yml': {'new_key': 'test_value'},
+          'promotezip': {'bucketname': 'test-bucket'}}),
+        ({'args': ['--config', 'something'],
+          'extend_serverless_yml': {'new_key': 'test_value'},
+          'promotezip': {'bucketname': 'test-bucket'},
+          'skip_npm_ci': True}),
+        ({'args': ['--config', 'something'],
+          'extend_serverless_yml': {'new_key': 'test_value'},
+          'promotezip': {'bucketname': 'test-bucket'},
+          'skip_npm_ci': False})
+    ])
+    def test_parse(self, config):
+        """Test parse."""
+        obj = ServerlessOptions.parse(**config)
+
+        assert obj.args == config.get('args', [])
+        assert obj.extend_serverless_yml == \
+            config.get('extend_serverless_yml', {})
+        assert obj.promotezip == config.get('promotezip', {})
+        assert obj.skip_npm_ci == config.get('skip_npm_ci', False)
+
+    def test_parse_invalid_promotezip(self):
+        """Test parse with invalid promotezip value."""
+        with pytest.raises(ValueError):
+            assert not ServerlessOptions.parse(promotezip={'key': 'value'})
+
+    def test_update_args(self):
+        """Test update_args."""
+        obj = ServerlessOptions(args=['--config', 'something',
+                                      '--unknown-arg', 'value'],
+                                extend_serverless_yml={},
+                                promotezip={})
+        assert obj.args == ['--config', 'something',
+                            '--unknown-arg', 'value']
+
+        obj.update_args('config', 'something-else')
+        assert obj.args == ['--config', 'something-else',
+                            '--unknown-arg', 'value']
+
+        with pytest.raises(KeyError):
+            obj.update_args('invalid-key', 'anything')


### PR DESCRIPTION
## Summary

Ability to _extend_ a serverless file from the Runway config by merging the content of the resolved serverless file (`sls print`) with the content provided via a module options.

## Why This Is Needed

Serverless does not have the concept of `parameters` that can be passed in as CLI args (yes, you can pass any custom args to the CLI but its not a standard practice) like Terraform and CDK has. This limits parameterized values in remote modules to use environment variables to pass values.

This also resolves #263 as it can cover the use case described.

## What Changed

### Added

- `runway.module.__init__.RunwayModuleNpm`
  - base class for modules that use npm, this contains methods for easy interaction
- `runway.module.serverless.ServerlessOptions` for parsing module options
- the serverless module now accepts a `extend_serverless_yml` option
  - must be a dict of valid serverless configuration
  - if provided:
    - resolve the serverless file
    - merge option value into the resolved serverless file
    - write the result to a temp file
    - pass the temp file's name into args passed to the serverless cli using the `--config` option
    - remove the temp file

### Changed

- the logic of `runway.module.serverless.Serverless.run_serverless` is now split out into smaller, narrowly scoped methods for easier testing
- `runway.module.serverless.deploy_package` now uses absolute path instead of relative path when running `serverless` package
- Runway will not exit gracefully when using a serverless module with the `promotezip` option that is missing `bucketname` instead of showing the user a 
raw ValueError

### Fixed

- the value of `environments` is once again used to determine if a serverless module should be skipped (resolves #266)

### Removed

- functions and methods from `ruwnay.module.serverless` that duplicate functionality covered in the new methods