### PR TITLE
aws_lambda hook can use internal pip when zipping dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - ability to extend a Serverless configuration file the `extend_serverless_yml` option
 
+### Changed
+- when `sys.frozen`, `runway run-python` will be used by `runway.cfngin.hooks.aws_lambda` to run a dynamically generated script that can use internal `pip` unless a python path is explicitly provided
+
 ### Fixed
 - the value of `environments` is once again used to determine if a serverless module should be skipped
 

--- a/runway.file.spec
+++ b/runway.file.spec
@@ -85,11 +85,13 @@ import troposphere  # noqa
 import awacs  # noqa
 import awscli  # noqa
 import botocore  # noqa
+import pip  # noqa
 hiddenimports.extend(get_submodules(runway))
 hiddenimports.extend(get_submodules(troposphere))
 hiddenimports.extend(get_submodules(awacs))
 hiddenimports.extend(get_submodules(awscli))
 hiddenimports.extend(get_submodules(botocore))
+hiddenimports.extend(get_submodules(pip))
 # needed due to pkg_resources dropping python2 support
 # can be removed on the next pyinstaller release
 # https://github.com/pypa/setuptools/issues/1963#issuecomment-582084099

--- a/runway.file.spec
+++ b/runway.file.spec
@@ -9,7 +9,7 @@ import os
 import pkgutil
 from pkg_resources import get_distribution, get_entry_info
 
-from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 
 # distutils not included with virtualenv < 20 so we have to import it here
 # can be removed once we can upgrade virtualenv and pyinstaller
@@ -40,7 +40,7 @@ def get_submodules(package):
     """
     return [name for _, name, _ in
             pkgutil.walk_packages(path=package.__path__,
-                                  prefix=package.__name__+'.',
+                                  prefix=package.__name__ + '.',
                                   onerror=lambda x: None)]
 
 
@@ -72,6 +72,9 @@ data_files.append(('{}/botocore/data'.format(get_distribution('botocore').locati
                    'botocore/data/'))
 data_files.append(('{}/awscli/data'.format(get_distribution('awscli').location),
                    'awscli/data/'))
+data_files.extend(collect_data_files('distutils'))
+data_files.extend(collect_data_files('pip'))
+data_files.extend(collect_data_files('wheel'))
 data_files.append(copy_metadata('runway')[0])  # support scm version
 
 # pyinstaller is not able to find dependencies of dependencies
@@ -86,12 +89,15 @@ import awacs  # noqa
 import awscli  # noqa
 import botocore  # noqa
 import pip  # noqa
+import wheel  # noqa
 hiddenimports.extend(get_submodules(runway))
 hiddenimports.extend(get_submodules(troposphere))
 hiddenimports.extend(get_submodules(awacs))
 hiddenimports.extend(get_submodules(awscli))
 hiddenimports.extend(get_submodules(botocore))
 hiddenimports.extend(get_submodules(pip))
+hiddenimports.extend(get_submodules(wheel))
+hiddenimports.extend(get_submodules(distutils))
 # needed due to pkg_resources dropping python2 support
 # can be removed on the next pyinstaller release
 # https://github.com/pypa/setuptools/issues/1963#issuecomment-582084099

--- a/runway.folder.spec
+++ b/runway.folder.spec
@@ -86,12 +86,13 @@ import troposphere  # noqa
 import awacs  # noqa
 import awscli  # noqa
 import botocore  # noqa
+import pip  # noqa
 hiddenimports.extend(get_submodules(runway))
 hiddenimports.extend(get_submodules(troposphere))
 hiddenimports.extend(get_submodules(awacs))
 hiddenimports.extend(get_submodules(awscli))
-hiddenimports.extend(get_submodules(awscli))
 hiddenimports.extend(get_submodules(botocore))
+hiddenimports.extend(get_submodules(pip))
 # needed due to pkg_resources dropping python2 support
 # can be removed on the next pyinstaller release
 # https://github.com/pypa/setuptools/issues/1963#issuecomment-582084099

--- a/runway.folder.spec
+++ b/runway.folder.spec
@@ -9,7 +9,7 @@ import os
 import pkgutil
 from pkg_resources import get_distribution, get_entry_info
 
-from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 
 # distutils not included with virtualenv < 20 so we have to import it here
 # can be removed once we can upgrade virtualenv and pyinstaller
@@ -40,7 +40,7 @@ def get_submodules(package):
     """
     return [name for _, name, _ in
             pkgutil.walk_packages(path=package.__path__,
-                                  prefix=package.__name__+'.',
+                                  prefix=package.__name__ + '.',
                                   onerror=lambda x: None)]
 
 
@@ -73,6 +73,9 @@ data_files.append(('{}/botocore/data'.format(get_distribution('botocore').locati
                    'botocore/data/'))
 data_files.append(('{}/awscli/data'.format(get_distribution('awscli').location),
                    'awscli/data/'))
+data_files.extend(collect_data_files('distutils'))
+data_files.extend(collect_data_files('pip'))
+data_files.extend(collect_data_files('wheel'))
 data_files.append(copy_metadata('runway')[0])  # support scm version
 
 # pyinstaller is not able to find dependencies of dependencies
@@ -87,12 +90,15 @@ import awacs  # noqa
 import awscli  # noqa
 import botocore  # noqa
 import pip  # noqa
+import wheel  # noqa
 hiddenimports.extend(get_submodules(runway))
 hiddenimports.extend(get_submodules(troposphere))
 hiddenimports.extend(get_submodules(awacs))
 hiddenimports.extend(get_submodules(awscli))
 hiddenimports.extend(get_submodules(botocore))
 hiddenimports.extend(get_submodules(pip))
+hiddenimports.extend(get_submodules(wheel))
+hiddenimports.extend(get_submodules(distutils))
 # needed due to pkg_resources dropping python2 support
 # can be removed on the next pyinstaller release
 # https://github.com/pypa/setuptools/issues/1963#issuecomment-582084099

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -318,8 +318,7 @@ def handle_requirements(package_root, dest_path, requirements,
         LOGGER.info('lambda: using requirements.txt for dependencies')
         result = os.path.join(dest_path, 'requirements.txt')
         if not os.path.isfile(result):  # copy file if accidentally excluded
-            copyfile(os.path.join(package_root, 'requirements.txt'), result,
-                     follow_symlinks=True)
+            copyfile(os.path.join(package_root, 'requirements.txt'), result)
         return result
     if requirements['Pipfile'] or requirements['Pipfile.lock']:
         LOGGER.info('lambda: using pipenv for dependencies')

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -532,7 +532,7 @@ def _zip_package(package_root, includes, excludes=None, dockerize_pip=False,
                     'from runway.util import argv',
                     'with argv(*{}):'.format(json.dumps(pip_cmd[2:])),
                     '   runpy.run_module("pip", run_name="__main__")\n'
-                ]))
+                ]).decode('UTF-8'))  # TODO remove decode when dropping python 2
                 cmd = [sys.executable, 'run-python', str(tmp_script)]
             else:
                 cmd = pip_cmd

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -316,10 +316,7 @@ def handle_requirements(package_root, dest_path, requirements,
                                   timeout=pipenv_timeout)
     if requirements['requirements.txt']:
         LOGGER.info('lambda: using requirements.txt for dependencies')
-        result = os.path.join(dest_path, 'requirements.txt')
-        if not os.path.isfile(result):  # copy file if accidentally excluded
-            copyfile(os.path.join(package_root, 'requirements.txt'), result)
-        return result
+        return os.path.join(dest_path, 'requirements.txt')
     if requirements['Pipfile'] or requirements['Pipfile.lock']:
         LOGGER.info('lambda: using pipenv for dependencies')
         return _handle_use_pipenv(package_root=package_root,

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -532,7 +532,7 @@ def _zip_package(package_root, includes, excludes=None, dockerize_pip=False,
                     'from runway.util import argv',
                     'with argv(*{}):'.format(json.dumps(pip_cmd[2:])),
                     '   runpy.run_module("pip", run_name="__main__")\n'
-                ]).decode('UTF-8'))  # TODO remove decode when dropping python 2
+                ]), encoding='UTF-8')  # TODO remove encoding when dropping python 2
                 cmd = [sys.executable, 'run-python', str(tmp_script)]
             else:
                 cmd = pip_cmd

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -528,7 +528,8 @@ def _zip_package(package_root, includes, excludes=None, dockerize_pip=False,
                        '--target', tmpdir,
                        '--requirement', tmp_req]
 
-            if getattr(sys, 'frozen', False):  # TODO default to False
+            # Pyinstaller build or explicit python path
+            if getattr(sys, 'frozen', False) and not python_path:
                 tmp_script.write_text(os.linesep.join([
                     'import runpy',
                     'from runway.util import argv',

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -535,7 +535,7 @@ def _zip_package(package_root, includes, excludes=None, dockerize_pip=False,
                     'with argv(*{}):'.format(json.dumps(pip_cmd[2:])),
                     '   runpy.run_module("pip", run_name="__main__")\n'
                 ]))
-                cmd = ['runway', 'run-python', str(tmp_script)]
+                cmd = [sys.executable, 'run-python', str(tmp_script)]
             else:
                 cmd = pip_cmd
 

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -527,12 +527,16 @@ def _zip_package(package_root, includes, excludes=None, dockerize_pip=False,
 
             # Pyinstaller build or explicit python path
             if getattr(sys, 'frozen', False) and not python_path:
-                tmp_script.write_text(os.linesep.join([
+                script_contents = os.linesep.join([
                     'import runpy',
                     'from runway.util import argv',
                     'with argv(*{}):'.format(json.dumps(pip_cmd[2:])),
                     '   runpy.run_module("pip", run_name="__main__")\n'
-                ]), encoding='UTF-8')  # TODO remove encoding when dropping python 2
+                ])
+                # TODO remove python 2 logic when dropping python 2
+                tmp_script.write_text(script_contents
+                                      if sys.version_info.major > 2
+                                      else script_contents.decode('UTF-8'))
                 cmd = [sys.executable, 'run-python', str(tmp_script)]
             else:
                 cmd = pip_cmd

--- a/tests/cfngin/hooks/test_aws_lambda.py
+++ b/tests/cfngin/hooks/test_aws_lambda.py
@@ -5,6 +5,7 @@ import os
 import os.path
 # python2 supported pylint incorrectly detects this for python3.8
 import random  # pylint: disable=syntax-error
+import sys
 import unittest
 from io import BytesIO as StringIO
 from zipfile import ZipFile
@@ -14,6 +15,9 @@ import botocore
 import pytest
 from mock import ANY, MagicMock, patch
 from moto import mock_s3
+from testfixtures import ShouldRaise, TempDirectory, compare
+from troposphere.awslambda import Code
+
 from runway.cfngin.config import Config
 from runway.cfngin.context import Context
 from runway.cfngin.exceptions import InvalidDockerizePipConfiguration
@@ -24,8 +28,6 @@ from runway.cfngin.hooks.aws_lambda import (ZIP_PERMS_MASK, _calculate_hash,
                                             select_bucket_region,
                                             should_use_docker,
                                             upload_lambda_functions)
-from testfixtures import ShouldRaise, TempDirectory, compare
-from troposphere.awslambda import Code
 
 from ..factories import mock_provider
 from ..fixtures.mock_docker.fake_api import FAKE_CONTAINER_ID, FAKE_IMAGE_ID
@@ -537,6 +539,7 @@ class TestLambdaHooks(unittest.TestCase):
     def test_frozen(self, mock_sys, mock_proc):
         """Test building with pip when frozen."""
         mock_sys.frozen = True
+        mock_sys.version_info = sys.version_info
         with self.temp_directory_with_files() as temp_dir:
             self.run_hook(functions={
                 'MyFunction': {

--- a/tests/cfngin/hooks/test_aws_lambda.py
+++ b/tests/cfngin/hooks/test_aws_lambda.py
@@ -1,11 +1,11 @@
 """Tests for runway.cfngin.hooks.aws_lambda."""
+import logging
 # pylint: disable=invalid-name,no-self-use
 import os
 import os.path
 # python2 supported pylint incorrectly detects this for python3.8
 import random  # pylint: disable=syntax-error
 import unittest
-import logging
 from io import BytesIO as StringIO
 from zipfile import ZipFile
 
@@ -14,9 +14,6 @@ import botocore
 import pytest
 from mock import ANY, MagicMock, patch
 from moto import mock_s3
-from testfixtures import ShouldRaise, TempDirectory, compare
-from troposphere.awslambda import Code
-
 from runway.cfngin.config import Config
 from runway.cfngin.context import Context
 from runway.cfngin.exceptions import InvalidDockerizePipConfiguration
@@ -27,6 +24,8 @@ from runway.cfngin.hooks.aws_lambda import (ZIP_PERMS_MASK, _calculate_hash,
                                             select_bucket_region,
                                             should_use_docker,
                                             upload_lambda_functions)
+from testfixtures import ShouldRaise, TempDirectory, compare
+from troposphere.awslambda import Code
 
 from ..factories import mock_provider
 from ..fixtures.mock_docker.fake_api import FAKE_CONTAINER_ID, FAKE_IMAGE_ID
@@ -724,11 +723,9 @@ class TestHandleRequirements(object):
         with pytest.raises(SystemExit) as excinfo:
             handle_requirements(package_root=str(tmp_path),
                                 dest_path=str(tmp_path),
-                                requirements={
-                                    'requirements.txt': False,
-                                    'Pipfile': True,
-                                    'Pipfile.lock': False
-                                })
+                                requirements={'requirements.txt': False,
+                                              'Pipfile': True,
+                                              'Pipfile.lock': False})
         assert excinfo.value.code == 1
         assert [
             'pipenv can only be used with python installed from PyPi'


### PR DESCRIPTION
## Why This Is Needed

When using one of the Pyinstaller release of Runway with static site auth@edge, it fails to package dependencies when trying to use pip.

Resolves #272 

## What Changed

### Changed

- when `sys.frozen`, `runway run-python` will be used by `runway.cfngin.hooks.aws_lambda` to run a dynamically generated script that can use internal `pip`

---

This could use a few more tests but the current structure of the code does not easily lend itself to thorough testing.
