### PR TITLE
cfnlint now invoked with runpy.run_module, warn when missing templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - the value of `environments` is once again used to determine if a serverless module should be skipped
+- Runway now invokes cfn-lint as if it were interacting with the CLI to remove version compatibility issues
 
 ## [1.7.3] - 2020-04-29
 ### Fixed

--- a/runway/tests/handlers/cfn_lint.py
+++ b/runway/tests/handlers/cfn_lint.py
@@ -1,14 +1,18 @@
 """cfn-list test runner."""
-from __future__ import print_function
-
 import logging
-import os
+import runpy
 import sys
-from typing import Dict, Any  # pylint: disable=unused-import
+from typing import Any, Dict  # pylint: disable=unused-import
 
-import cfnlint.core
+import yaml
 
-from runway.tests.handlers.base import TestHandler
+from ...util import argv
+from .base import TestHandler
+
+if sys.version_info.major < 3:
+    from pathlib2 import Path  # pylint: disable=E
+else:
+    from pathlib import Path  # pylint: disable=E
 
 TYPE_NAME = 'cfn-lint'
 LOGGER = logging.getLogger('runway')
@@ -16,45 +20,6 @@ LOGGER = logging.getLogger('runway')
 
 class CfnLintHandler(TestHandler):
     """Lints CFN."""
-
-    @staticmethod
-    def run_cfnlint(cli_args):
-        # type: (str) -> int
-        """Modify cfnlint.__main__.main to work here.
-
-        https://github.com/aws-cloudformation/cfn-python-lint
-
-        Args:
-            cli_args: A string of comand line args as defined by cfn-lint.
-
-        Returns:
-            An exit code.
-
-        """
-        try:
-            (args, filenames, formatter) = cfnlint.core.get_args_filenames(cli_args)
-            matches = []
-            for filename in filenames:
-                LOGGER.debug('Begin linting of file: %s', str(filename))
-                (template, rules, template_matches) = cfnlint.core.get_template_rules(filename,
-                                                                                      args)
-                if not template_matches:
-                    matches.extend(
-                        # no-value issue is a py2 pylint false positive
-                        cfnlint.core.run_cli(  # pylint: disable=no-value-for-parameter
-                            filename, template, rules,
-                            args.regions, args.override_spec))
-                else:
-                    matches.extend(template_matches)
-                LOGGER.debug('Completed linting of file: %s', str(filename))
-
-            matches_output = formatter.print_matches(matches)
-            if matches_output:
-                print(matches_output)
-            return cfnlint.core.get_exit_code(matches)
-        except cfnlint.core.CfnLintExitException as err:
-            LOGGER.error(str(err))
-            return err.exit_code
 
     @classmethod
     def handle(cls, name, args):
@@ -64,13 +29,21 @@ class CfnLintHandler(TestHandler):
         Relies on .cfnlintrc file to be located beside the Runway config file.
 
         """
-        cfnlintrc_path = os.path.join(os.getcwd(), '.cfnlintrc')
+        cfnlintrc = Path('./.cfnlintrc')
 
-        if not os.path.isfile(cfnlintrc_path):
-            LOGGER.error('File must exist to use this test: %s', cfnlintrc_path)
+        if not cfnlintrc.is_file():
+            LOGGER.error('File must exist to use this test: %s', cfnlintrc)
             sys.exit(1)
 
-        exit_code = cls.run_cfnlint(args.get('cli_args', ''))
-
-        if exit_code != 0:
-            sys.exit(exit_code)
+        # prevent duplicate log messages by not passing to the root logger
+        logging.getLogger('cfnlint').propagate = False
+        try:
+            with argv(*['cfn-lint'] + args.get('cli_args', [])):
+                runpy.run_module('cfnlint', run_name='__main__')
+        except SystemExit as err:  # this call will always result in SystemExit
+            if err.code != 0:  # ignore zero exit codes but re-raise for non-zero
+                if not (yaml.safe_load(cfnlintrc.read_text()) or
+                        {}).get('templates'):
+                    LOGGER.warning('cfnlintrc is missing a "templates" '
+                                   'section which is required by cfn-lint')
+                raise


### PR DESCRIPTION

## Why This Is Needed

resolves #262 

## What Changed

### Added

- cfn-lint test now warns about the `.cfnlintrc` file needing a `templates` section if the test fails and the file does not contain this section

### Fixed

- Runway now invokes cfn-lint as if it were interacting with the CLI to remove version compatibility issues
