### PR TITLE
add py wheel package to urlshortener action

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -497,6 +497,7 @@ jobs:
       - name: Install Dependencies & Run Script
         working-directory: .github/scripts/urlshortener
         run: |
+          pip install wheel
           pip install -r requirements.txt
           python update_urls.py \
             --bucket-name $BUCKET_NAME \


### PR DESCRIPTION
Aiming to elminate errors from GH actions logs like:
```
Could not build wheels for boto3-stubs, since package 'wheel' is not installed.
```
Seen in [this GH action run](https://github.com/onicagroup/runway/actions/runs/106880173).

Not certain it's related to subsequent `Union` error -- I couldn't reproduce it in my own quick test.