### PR TITLE
add logic to use `--no-color` with cdk, cpm, sls, and tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `-no-color`/`--no-color` option automatically added to cdk, npm, sls, and tf commands
+  - looks at `RUNWAY_COLORIZE` env var for an explicit enable/disable
+  - if not set, checks `sys.stdout.isatty()` to determine if option should be provided
 
 ## [1.8.0] - 2020-05-16
 ### Fixed

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,10 +39,15 @@ version = '.'.join(release.split('.')[:2])
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinxcontrib.apidoc'
 ]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None)  # link to python docs
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/developers/advanced_configuration.rst
+++ b/docs/source/developers/advanced_configuration.rst
@@ -12,34 +12,44 @@ Environment Variables
 Environment variables can be used to alter the functionality of Runway.
 
 **CI (Any)**
-    If not ``undefined``, Runway will operate in non-iterative mode,
+  If not ``undefined``, Runway will operate in non-iterative mode,
 
 **DEBUG (Any)**
-    If not ``undefined``, debug logs will be shown.
+  If not ``undefined``, debug logs will be shown.
 
 **DEPLOY_ENVIRONMENT (str)**
-    Explicitly define the deploy environment.
+  Explicitly define the deploy environment.
 
 **CFNGIN_STACK_POLL_TIME (int)**
-    Number of seconds between CloudFormation API calls. Adjusting this will
-    impact API throttling. (`default:` ``30``)
+  Number of seconds between CloudFormation API calls. Adjusting this will
+  impact API throttling. (`default:` ``30``)
+
+**RUNWAY_COLORIZE (str)**
+  Explicitly enable/disable colorized output for :ref:`CDK <mod-cdk>`, :ref:`Serverless <mod-sls>`, and :ref:`Terraform <mod-tf>` modules.
+  Having this set to a truthy value will prevent ``-no-color``/``--no-color`` from being added to any commands even if stdout is not a TTY.
+  Having this set to a falsy value will include ``-no-color``/``--no-color`` in commands even if stdout is a TTY.
+  If the IaC tool has other mechanisms for disabling color output, using a truthy value will not circumvent them.
+
+  Truthy values are ``y``, ``yes``, ``t``, ``true``, ``on`` and ``1``.
+  Falsy values are ``n``, ``no``, ``f``, ``false``, ``off`` and ``0``.
+  Raises :exc:`ValueError` if anything else is used.
 
 **RUNWAY_MAX_CONCURRENT_MODULES (int)**
-    Max number of modules that can be deployed to concurrently.
-    (`default:` ``min(61, os.cpu_count())``)
+  Max number of modules that can be deployed to concurrently.
+  (`default:` ``min(61, os.cpu_count())``)
 
-    On Windows, this must be equal to or lower than ``61``.
+  On Windows, this must be equal to or lower than ``61``.
 
-    **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
-    together, please consider the nature of their relationship when
-    manually setting this value. (``parallel_regions * child_modules``)
+  **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
+  together, please consider the nature of their relationship when
+  manually setting this value. (``parallel_regions * child_modules``)
 
 **RUNWAY_MAX_CONCURRENT_REGIONS (int)**
-    Max number of regions that can be deployed to concurrently.
-    (`default:` ``min(61, os.cpu_count())``)
+  Max number of regions that can be deployed to concurrently.
+  (`default:` ``min(61, os.cpu_count())``)
 
-    On Windows, this must be equal to or lower than ``61``.
+  On Windows, this must be equal to or lower than ``61``.
 
-    **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
-    together, please consider the nature of their relationship when
-    manually setting this value. (``parallel_regions * child_modules``)
+  **IMPORTANT:** When using ``parallel_regions`` and ``child_modules``
+  together, please consider the nature of their relationship when
+  manually setting this value. (``parallel_regions * child_modules``)

--- a/docs/source/serverless/advanced_features.rst
+++ b/docs/source/serverless/advanced_features.rst
@@ -155,8 +155,8 @@ The value of ``args`` must be a list of arguments/options to pass to the CLI.
 Each element of the argument/option should be it's own list item (e.g. ``--config sls.yml`` would be ``['--config', 'sls.yml']``).
 
 .. important::
-  Do not provide ``--region <region>`` or ``--stage <stage>`` here.
-  These will be provided by Runway.
+  Do not provide ``--region <region>`` or ``--stage <stage>`` here, these will be provided by Runway.
+  Runway will also provide ``--no-color`` if stdout is not a TTY.
 
 
 .. rubric:: Runway Example

--- a/docs/source/terraform/advanced_features.rst
+++ b/docs/source/terraform/advanced_features.rst
@@ -154,7 +154,7 @@ The value of each key in the map must be a list as described in the previous sec
 
 .. important::
   The following arguments/options are provided by Runway and should not be provided manually:
-  *auto-approve*, *backend-config*, *force*, *reconfigure*, *update*, and *var-file*.
+  *auto-approve*, *backend-config*, *force*, *no-color*, *reconfigure*, *update*, and *var-file*.
   Providing any of these manually could result in unintended side-effects.
 
 

--- a/runway/context.py
+++ b/runway/context.py
@@ -76,7 +76,7 @@ class Context(object):
                 for name in AWS_ENV_VARS if self.env_vars.get(name)}
 
     @cached_property
-    def disable_color(self):
+    def no_color(self):
         """Wether to explicitly disable color output.
 
         Primarily applies to IaC being wrapped by Runway.

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -87,17 +87,22 @@ def use_npm_ci(path):
 def run_npm_install(path, options, context):
     """Run npm install/ci."""
     # Use npm ci if available (npm v5.7+)
+    cmd = [NPM_BIN, '<place-holder>']
+    if context.no_color:
+        cmd.append('--no-color')
     if options.get('options', {}).get('skip_npm_ci'):
         LOGGER.info("Skipping npm ci or npm install on %s...",
                     os.path.basename(path))
-    elif context.env_vars.get('CI') and use_npm_ci(path):
+        return
+    if context.env_vars.get('CI') and use_npm_ci(path):
         LOGGER.info("Running npm ci on %s...",
                     os.path.basename(path))
-        subprocess.check_call([NPM_BIN, 'ci'])
+        cmd[1] = 'ci'
     else:
         LOGGER.info("Running npm install on %s...",
                     os.path.basename(path))
-        subprocess.check_call([NPM_BIN, 'install'])
+        cmd[1] = 'install'
+    subprocess.check_call(cmd)
 
 
 def warn_on_boto_env_vars(env_vars):
@@ -195,17 +200,22 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
 
     def npm_install(self):
         """Run ``npm install``."""
+        cmd = [NPM_BIN, '<place-holder>']
+        if self.context.no_color:
+            cmd.append('--no-color')
         if self.options.get('skip_npm_ci'):
             LOGGER.info("%s: Skipping npm ci and npm install...",
                         self.path.name)
-        elif self.context.is_noninteractive and use_npm_ci(str(self.path)):
+            return
+        if self.context.is_noninteractive and use_npm_ci(str(self.path)):
             LOGGER.info("%s: Running npm ci...",
                         self.path.name)
-            subprocess.check_call([NPM_BIN, 'ci'])
+            cmd[1] = 'ci'
         else:
             LOGGER.info("%s: Running npm install...",
                         self.path.name)
-            subprocess.check_call([NPM_BIN, 'install'])
+            cmd[1] = 'install'
+        subprocess.check_call(cmd)
 
     def package_json_missing(self):
         """Check for the existence for a package.json file in the module.

--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -39,6 +39,8 @@ class CloudDevelopmentKit(RunwayModule):
         """Run CDK."""
         response = {'skipped_configs': False}
         cdk_opts = [command]
+        if self.context.no_color:
+            cdk_opts.append('--no-color')
 
         if not which('npm'):
             LOGGER.error('"npm" not found in path or is not executable; '
@@ -95,7 +97,8 @@ class CloudDevelopmentKit(RunwayModule):
                                 cdk_opts.append('--require-approval=never')
                             bootstrap_command = generate_node_command(
                                 'cdk',
-                                ['bootstrap'] + cdk_context_opts,
+                                ['bootstrap'] + cdk_context_opts +
+                                (['--no-color'] if self.context.no_color else []),
                                 self.path
                             )
                             LOGGER.info('Running cdk bootstrap...')

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -246,6 +246,8 @@ class Serverless(RunwayModuleNpm):
         """
         args = [command] + self.cli_args + self.options.args
         args.extend(args_list or [])
+        if self.context.disable_color and '--no-color' not in args:
+            args.append('--no-color')
         if command not in ['remove', 'print'] and self.context.is_noninteractive:
             args.append('--conceal')  # hide secrets from serverless output
         cmd = generate_node_command(command='sls',
@@ -268,7 +270,10 @@ class Serverless(RunwayModuleNpm):
         if self.options.promotezip:
             # TODO refactor deploy_package to be part of the class
             self.path.absolute()
-            deploy_package(['deploy'] + self.cli_args + self.options.args,
+            sls_opts = ['deploy'] + self.cli_args + self.options.args
+            if self.context.disable_color and '--no-color' not in sls_opts:
+                sls_opts.append('--no-color')
+            deploy_package(sls_opts,
                            self.options.promotezip['bucketname'],
                            self.context,
                            str(self.path))

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -246,7 +246,7 @@ class Serverless(RunwayModuleNpm):
         """
         args = [command] + self.cli_args + self.options.args
         args.extend(args_list or [])
-        if self.context.disable_color and '--no-color' not in args:
+        if self.context.no_color and '--no-color' not in args:
             args.append('--no-color')
         if command not in ['remove', 'print'] and self.context.is_noninteractive:
             args.append('--conceal')  # hide secrets from serverless output
@@ -271,7 +271,7 @@ class Serverless(RunwayModuleNpm):
             # TODO refactor deploy_package to be part of the class
             self.path.absolute()
             sls_opts = ['deploy'] + self.cli_args + self.options.args
-            if self.context.disable_color and '--no-color' not in sls_opts:
+            if self.context.no_color and '--no-color' not in sls_opts:
                 sls_opts.append('--no-color')
             deploy_package(sls_opts,
                            self.options.promotezip['bucketname'],

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -40,12 +40,12 @@ def get_workspace_tfvars_file(path, environment, region):
 
 def run_terraform_init(tf_bin,  # pylint: disable=too-many-arguments
                        module_path, module_options, env_name, env_region,
-                       env_vars, disable_color=False):
+                       env_vars, no_color=False):
     """Run Terraform init."""
     cmd_opts = {'env_vars': env_vars,
                 'exit_on_error': False,
                 'cmd_list': [tf_bin, 'init', '-reconfigure']}
-    if disable_color:
+    if no_color:
         cmd_opts['cmd_list'].append('-no-color')
 
     if module_options.backend_config.init_args:
@@ -108,7 +108,7 @@ class Terraform(RunwayModule):
         """Run Terraform."""
         response = {'skipped_configs': False}
         tf_cmd = [command]
-        if self.context.disable_color:
+        if self.context.no_color:
             tf_cmd.append('-no-color')
         options = TerraformOptions.parse(self.context, self.path,
                                          **self.options.get('options', {}))
@@ -175,7 +175,7 @@ class Terraform(RunwayModule):
                     env_name=self.context.env_name,
                     env_region=self.context.env_region,
                     env_vars=env_vars,
-                    disable_color=self.context.disable_color
+                    no_color=self.context.no_color
                 )
 
                 LOGGER.debug('Checking current Terraform workspace...')
@@ -183,7 +183,7 @@ class Terraform(RunwayModule):
                     [tf_bin,
                      'workspace',
                      'show'] + (['-no-color']
-                                if self.context.disable_color else []),
+                                if self.context.no_color else []),
                     env=env_vars
                 ).strip().decode()
                 if current_tf_workspace != self.context.env_name:
@@ -195,7 +195,7 @@ class Terraform(RunwayModule):
                                  'workspaces...')
                     available_tf_envs = subprocess.check_output(
                         [tf_bin, 'workspace', 'list'] +
-                        (['-no-color'] if self.context.disable_color else []),
+                        (['-no-color'] if self.context.no_color else []),
                         env=env_vars
                     ).decode()
                     if re.compile("^[*\\s]\\s%s$" % self.context.env_name,
@@ -203,7 +203,7 @@ class Terraform(RunwayModule):
                         run_module_command(
                             cmd_list=[tf_bin, 'workspace', 'select',
                                       self.context.env_name] +
-                            (['-no-color'] if self.context.disable_color else []),
+                            (['-no-color'] if self.context.no_color else []),
                             env_vars=env_vars
                         )
                     else:
@@ -213,7 +213,7 @@ class Terraform(RunwayModule):
                         run_module_command(
                             cmd_list=[tf_bin, 'workspace', 'new',
                                       self.context.env_name] +
-                            (['-no-color'] if self.context.disable_color else []),
+                            (['-no-color'] if self.context.no_color else []),
                             env_vars=env_vars
                         )
                     LOGGER.info('Re-running terraform init after workspace '
@@ -225,13 +225,13 @@ class Terraform(RunwayModule):
                         env_name=self.context.env_name,
                         env_region=self.context.env_region,
                         env_vars=env_vars,
-                        disable_color=self.context.disable_color
+                        no_color=self.context.no_color
                     )
                 LOGGER.info('Executing "terraform get" to update remote '
                             'modules')
                 run_module_command(
                     cmd_list=[tf_bin, 'get', '-update=true'] +
-                    (['-no-color'] if self.context.disable_color else []),
+                    (['-no-color'] if self.context.no_color else []),
                     env_vars=env_vars
                 )
                 LOGGER.info("Running Terraform %s on %s (\"%s\")",

--- a/tests/module/test_serverless.py
+++ b/tests/module/test_serverless.py
@@ -178,7 +178,7 @@ class TestServerless(object):
         """Test gen_cmd."""
         # pylint: disable=no-member
         monkeypatch.setattr(Serverless, 'log_npm_command', MagicMock())
-        monkeypatch.setattr(runway_context, 'disable_color', False)
+        monkeypatch.setattr(runway_context, 'no_color', False)
         mock_cmd.return_value = ['success']
         obj = Serverless(runway_context, tmp_path,
                          {'options': {'args': ['--config', 'test']}})
@@ -196,7 +196,7 @@ class TestServerless(object):
         mock_cmd.reset_mock()
 
         obj.context.env_vars['CI'] = '1'
-        monkeypatch.setattr(runway_context, 'disable_color', True)
+        monkeypatch.setattr(runway_context, 'no_color', True)
         expected_opts.append('--no-color')
         if command not in ['remove', 'print']:
             expected_opts.append('--conceal')
@@ -270,7 +270,7 @@ class TestServerless(object):
                         runway_context, tmp_path):
         """Test sls_deploy."""
         # pylint: disable=no-member
-        monkeypatch.setattr(runway_context, 'disable_color', False)
+        monkeypatch.setattr(runway_context, 'no_color', False)
         monkeypatch.setattr(Serverless, 'gen_cmd',
                             MagicMock(return_value=['deploy']))
         monkeypatch.setattr(Serverless, 'npm_install', MagicMock())
@@ -297,7 +297,7 @@ class TestServerless(object):
         )
         mock_run.assert_called_once()
 
-        monkeypatch.setattr(runway_context, 'disable_color', True)
+        monkeypatch.setattr(runway_context, 'no_color', True)
         assert not obj.sls_deploy(skip_install=True)
         mock_deploy.assert_called_with(
             ['deploy',

--- a/tests/module/test_serverless.py
+++ b/tests/module/test_serverless.py
@@ -178,6 +178,7 @@ class TestServerless(object):
         """Test gen_cmd."""
         # pylint: disable=no-member
         monkeypatch.setattr(Serverless, 'log_npm_command', MagicMock())
+        monkeypatch.setattr(runway_context, 'disable_color', False)
         mock_cmd.return_value = ['success']
         obj = Serverless(runway_context, tmp_path,
                          {'options': {'args': ['--config', 'test']}})
@@ -195,6 +196,8 @@ class TestServerless(object):
         mock_cmd.reset_mock()
 
         obj.context.env_vars['CI'] = '1'
+        monkeypatch.setattr(runway_context, 'disable_color', True)
+        expected_opts.append('--no-color')
         if command not in ['remove', 'print']:
             expected_opts.append('--conceal')
         assert obj.gen_cmd(command, args_list=['--extra-arg']) == ['success']
@@ -267,6 +270,7 @@ class TestServerless(object):
                         runway_context, tmp_path):
         """Test sls_deploy."""
         # pylint: disable=no-member
+        monkeypatch.setattr(runway_context, 'disable_color', False)
         monkeypatch.setattr(Serverless, 'gen_cmd',
                             MagicMock(return_value=['deploy']))
         monkeypatch.setattr(Serverless, 'npm_install', MagicMock())
@@ -292,6 +296,19 @@ class TestServerless(object):
             str(tmp_path)
         )
         mock_run.assert_called_once()
+
+        monkeypatch.setattr(runway_context, 'disable_color', True)
+        assert not obj.sls_deploy(skip_install=True)
+        mock_deploy.assert_called_with(
+            ['deploy',
+             '--region', runway_context.env_region,
+             '--stage', runway_context.env_name,
+             '--config', 'test.yml',
+             '--no-color'],
+            'test-bucket',
+            runway_context,
+            str(tmp_path)
+        )
 
     def test_sls_print(self, monkeypatch, runway_context):
         """Test sls_print."""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -52,14 +52,14 @@ class TestContext(object):
         (ValueError, False, True)
     ])
     @patch('runway.context.sys.stdout')
-    def test_disable_color(self, mock_stdout, colorize, isatty, expected):
-        """Test disable_color."""
+    def test_no_color(self, mock_stdout, colorize, isatty, expected):
+        """Test no_color."""
         mock_stdout.isatty.return_value = isatty
         env_vars = {}
         if colorize is not None:
             env_vars['RUNWAY_COLORIZE'] = colorize
         ctx = Context('test', 'us-east-1', './tests', env_vars=env_vars)
-        assert ctx.disable_color == expected
+        assert ctx.no_color == expected
 
     def test_is_interactive(self):
         """Test is_interactive."""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,7 +3,8 @@
 import logging
 import os
 
-from mock import patch
+import pytest
+from mock import MagicMock, patch
 
 from runway.context import Context
 from runway.util import environ
@@ -39,6 +40,26 @@ class TestContext(object):
                           env_vars=TEST_CREDENTIALS.copy())
 
         assert context.current_aws_creds == TEST_CREDENTIALS
+
+    @pytest.mark.parametrize('colorize, isatty, expected', [
+        (None, True, False),
+        (None, False, True),
+        (True, False, False),
+        (False, True, True),
+        ('true', False, False),
+        ('false', True, True),
+        (ValueError, True, False),
+        (ValueError, False, True)
+    ])
+    @patch('runway.context.sys.stdout')
+    def test_disable_color(self, mock_stdout, colorize, isatty, expected):
+        """Test disable_color."""
+        mock_stdout.isatty.return_value = isatty
+        env_vars = {}
+        if colorize is not None:
+            env_vars['RUNWAY_COLORIZE'] = colorize
+        ctx = Context('test', 'us-east-1', './tests', env_vars=env_vars)
+        assert ctx.disable_color == expected
 
     def test_is_interactive(self):
         """Test is_interactive."""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import pytest
-from mock import MagicMock, patch
+from mock import patch
 
 from runway.context import Context
 from runway.util import environ


### PR DESCRIPTION
## Why This Is Needed

resolves #278 

## What Changed

### Added

- `-no-color`/`--no-color` option automatically added to cdk, npm, sls, and tf commands
  - looks at `RUNWAY_COLORIZE` env var for an explicit enable/disable
  - if not set, checks `sys.stdout.isatty()` to determine if option should be provided
