### PR TITLE
a@e refresh token with 5 minutes remaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - looks at `RUNWAY_COLORIZE` env var for an explicit enable/disable
   - if not set, checks `sys.stdout.isatty()` to determine if option should be provided
 
+### Changed
+- a@e check_auth will now try to refresh tokens 5 minutes before expiration instead of waiting for it to expire
+
 ## [1.8.0] - 2020-05-16
 ### Fixed
 - the value of `environments` is once again used to determine if a serverless module should be skipped

--- a/runway/hooks/staticsite/auth_at_edge/templates/check_auth/__init__.py
+++ b/runway/hooks/staticsite/auth_at_edge/templates/check_auth/__init__.py
@@ -71,7 +71,7 @@ def handler(event, _context):
 
         # If we have a refresh token and the expiration date has passed
         # then forward the user to the refresh agent
-        if now > exp_date and refresh_token:
+        if now > (exp_date - datetime.timedelta(minutes=5)) and refresh_token:
             headers = {
                 # Redirect the user to the refresh agent
                 'location': [


### PR DESCRIPTION
## Why This Is Needed

resolves #269 

## What Changed

### Changed

- a@e check_auth will now try to refresh tokens 5 minutes before expiration instead of waiting for it to expire
