### PR TITLE
runway test: return non-zero exit code if any non-required tests failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - a@e check_auth will now try to refresh tokens 5 minutes before expiration instead of waiting for it to expire
+- `runway test` will now return a non-zero exit code if any non-required tests failed
 
 ## [1.8.0] - 2020-05-16
 ### Fixed

--- a/docs/source/defining_tests.rst
+++ b/docs/source/defining_tests.rst
@@ -28,23 +28,20 @@ run by using the ``runway test`` :ref:`command<command-test>`.
 Test Failures
 -------------
 
-The default behavior if one of the :ref:`tests<runway-test>` fails is to
-terminate execution. The subsequent commands will not be run and a non-zero
-exit code returned. This behavior can modified to continue testing and not
-result in a non-zero exit code on a per-test basis by adding ``required: false``
-to the :ref:`test definition<runway-test>`.
+The default behavior if a :ref:`tests<runway-test>` fails is to continue running the rest of the tests and return a non-zero exit code at the end.
+This behavior can modified to allow testing to continue by adding ``required: true`` to the :ref:`test definition<runway-test>`.
+This will terminate execution if test fails and no further tests will be run.
 
-.. rubric:: Example:
+.. rubric:: Example
+.. code-block:: yaml
 
-::
-
-    tests:
-      - name: hello-world
-        type: script
-        required: false
-        args:
-          commands:
-            - echo "Hello World!"  && exit 1
+  tests:
+    - name: hello-world
+      type: script
+      required: true
+      args:
+        commands:
+          - echo "Hello World!"  && exit 1
 
 
 .. _built-in-test-types:

--- a/runway/commands/runway/test.py
+++ b/runway/commands/runway/test.py
@@ -52,6 +52,8 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                           env_vars=os.environ.copy(),
                           command='test')
 
+        failed_tests = []
+
         LOGGER.info('Found %i test(s)', len(test_definitions))
         for test in test_definitions:
             test.resolve(context, self.runway_vars)
@@ -78,4 +80,11 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                     traceback.print_exc()
                 LOGGER.error('Test failed: %s', test.name)
                 if test.required:
+                    LOGGER.error('Failed test was required, the remaining '
+                                 'tests have been skipped')
                     sys.exit(1)
+                failed_tests.append(test.name)
+        if failed_tests:
+            LOGGER.error('The following tests failed: %s',
+                         ', '.join(failed_tests))
+            sys.exit(1)


### PR DESCRIPTION
## Why This Is Needed

resolves #19

## What Changed

### Changed

- `runway test` will now return a non-zero exit code if any non-required tests failed
	- previously you had to have all tests set to `required: false` to allow all test to run in the event of a failure but it would always return `0` so it was not viable to use in ci/cd pipeline testing if you wanted all tests to be able to run
- the docs now correctly describe the default action taken when `required` is not defined on a test

## Screenshots

`required` is undefined for all tests

![image](https://user-images.githubusercontent.com/23145462/82375748-df338200-99d5-11ea-9431-6f933ff3aa6e.png)

`required: true` on `another-one`

![image](https://user-images.githubusercontent.com/23145462/82375819-fecaaa80-99d5-11ea-9636-c903a5d07a12.png)
