### PR TITLE
the friendly error when npm can't be found has returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `runway test` will now return a non-zero exit code if any non-required tests failed
 - `static-react` sample uses npm instead of yarn
 
+### Fixed
+- the friendly error when npm can't be found has returned
+
 ## [1.8.0] - 2020-05-16
 ### Fixed
 - the value of `environments` is once again used to determine if a serverless module should be skipped

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -163,7 +163,6 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
                 definition.
 
         """
-        self.check_for_npm()  # fail fast
         options = options or {}
         super(RunwayModuleNpm, self).__init__(context, path, options)
         del self.options  # remove the attr set by the parent class
@@ -178,6 +177,7 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
         for k, v in options.items():
             setattr(self, k, v)
 
+        self.check_for_npm()  # fail fast
         warn_on_boto_env_vars(self.context.env_vars)
 
     def check_for_npm(self):


### PR DESCRIPTION
## Why This Is Needed

resolves #336 

## What Changed

### Changed

- `.check_for_npm()` is now run after all attributes are set
