### PR TITLE
add `future.strict_environment` config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ integration_tests/test_cfngin/tests/[0-9][0-9]_*.yaml
 
 # Programatically generated doc pages
 docs/source/apidocs
+
+# vscode settings
+.vscode/bookmarks.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `-no-color`/`--no-color` option automatically added to cdk, npm, sls, and tf commands
   - looks at `RUNWAY_COLORIZE` env var for an explicit enable/disable
   - if not set, checks `sys.stdout.isatty()` to determine if option should be provided
+- `future.static_environments` top-level configuration option
+  - modifies how `deployment.environments`/`module.environments` are handled
 
 ### Changed
 - a@e check_auth will now try to refresh tokens 5 minutes before expiration instead of waiting for it to expire
 - `runway test` will now return a non-zero exit code if any non-required tests failed
 - `static-react` sample uses npm instead of yarn
 - `yamllint` is now invoked using `runpy` instead of using `runway run-python`
+- log format of module skip information no longer includes extra characters and is now prefixed by the module name
 
 ### Fixed
 - issue where `yamllint` and `cfnlint` could not be imported/executed from the Pyinstaller executables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `-no-color`/`--no-color` option automatically added to cdk, npm, sls, and tf commands
   - looks at `RUNWAY_COLORIZE` env var for an explicit enable/disable
   - if not set, checks `sys.stdout.isatty()` to determine if option should be provided
-- `future.static_environments` top-level configuration option
+- `future.strict_environments` top-level configuration option
   - modifies how `deployment.environments`/`module.environments` are handled
 
 ### Changed

--- a/docs/source/runway_config.rst
+++ b/docs/source/runway_config.rst
@@ -12,39 +12,127 @@
 
 .. _runway-config:
 
+##################
 Runway Config File
-==================
+##################
 
+
+***********************
 Top-Level Configuration
-^^^^^^^^^^^^^^^^^^^^^^^
+***********************
 
 .. autoclass:: runway.config.Config
 
+
 .. _runway-deployment:
 
+**********
 Deployment
-^^^^^^^^^^
+**********
 
 .. autoclass:: runway.config.DeploymentDefinition
 
+
+.. _runway-future:
+
+******
+Future
+******
+
+Toggles to opt-in to future, potentially backward compatibility breaking functionality before it is made standard in the next major release.
+
+Availability of these toggles will be removed at each major release as the functionality will then be made standard.
+
+**static_environments (bool)**
+  When enabled, handling of ``environments`` for Deployment_ and Module_ definitions is changed to prevent processing of modules when the current environment is not defined in the Runway config file.
+
+  If ``environments`` is defined and the current :ref:`deploy environment <term-deploy-env>` is not in the definition, the module will be skipped.
+  If ``environments`` is not defined, the module will be processed. This does not mean that action will be taken but that the type of the module will then determine if action will be taken.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+      future:
+        static_environments: true
+
+      deployments:
+        - environments:
+            prod:
+              - 111111111111/us-east-1
+              - 111111111111/us-west-2
+            dev:
+              - 222222222222
+          modules:
+            - path: sampleapp-01.cfn
+            - path: sampleapp-02.cfn
+              environments:
+                dev: 222222222222/us-east-1
+                feature/something-new: true
+          regions: &regions
+            - ca-central-1
+            - us-east-1
+            - us-west-2
+        - modules:
+            - path: sampleapp-03.cfn
+            - path: sampleapp-04.cfn
+              environments:
+                dev-ca:
+                  - ca-cental-1
+          regions: *regions
+
+  Given the above Runway configuration file, the following will occur for each module:
+
+  **sampleapp-01.cfn**
+    Processed if:
+
+    - environment is **prod** and AWS account ID is **111111111111** and region is (**us-east-1** or **us-west-2**)
+    - environment is **dev** and AWS account ID is **222222222222** and region is *anything*
+
+    All other combinations will result in the module being skipped.
+
+  **sampleapp-02.cfn**
+    Processed if:
+
+    - environment is **prod** and AWS account ID is **111111111111** and region is (**us-east-1** or **us-west-2**)
+    - environment is **dev** and AWS account ID is **222222222222** and region is **us-east-1**
+    - environment is **feature/something-new** and AWS account ID is *anything* and region is *anything*
+
+    All other combinations will result in the module being skipped.
+
+  **sampleapp-03.cfn**
+    Processed if:
+
+    - environment is *anything* and AWS account ID is *anything* and region is *anything*
+
+  **sampleapp-04.cfn**
+    Processed if:
+
+    - environment is **dev-ca** and AWS account ID is *anything* and region is **ca-central-1**
+
+    All other combinations will result in the module being skipped.
+
+  .. versionadded:: 1.9.0
+
+
 .. _runway-module:
 
+******
 Module
-^^^^^^
+******
 
 .. autoclass:: runway.config.ModuleDefinition
 
 .. _runway-module-path:
 
 Path
-----
+====
 
 .. automodule:: runway.path.Path
 
 .. _runway-module-path-git:
 
 Git
-~~~
+---
 
 Git remote resources can be used as modules for your Runway project. Below is
 an example of git remote path.
@@ -77,28 +165,34 @@ where the module is housed
 accepts three different types of options: `commit`, `tag`, or `branch`. These
 respectively point the repository at the reference id specified.
 
+
 Type
-----
+====
 
 .. automodule:: runway.runway_module_type.RunwayModuleType
 
 
 .. _runway-test:
 
+****
 Test
-^^^^
+****
 
 .. autoclass:: runway.config.TestDefinition
 
+
 .. _runway-variables:
 
+*********
 Variables
-^^^^^^^^^
+*********
 
 .. autoclass:: runway.config.VariablesDefinition
 
+
+******
 Sample
-^^^^^^
+******
 
 .. rubric:: runway.yml
 .. code-block:: yaml

--- a/docs/source/runway_config.rst
+++ b/docs/source/runway_config.rst
@@ -43,7 +43,7 @@ Toggles to opt-in to future, potentially backward compatibility breaking functio
 
 Availability of these toggles will be removed at each major release as the functionality will then be made standard.
 
-**static_environments (bool)**
+**strict_environments (bool)**
   When enabled, handling of ``environments`` for Deployment_ and Module_ definitions is changed to prevent processing of modules when the current environment is not defined in the Runway config file.
 
   If ``environments`` is defined and the current :ref:`deploy environment <term-deploy-env>` is not in the definition, the module will be skipped.
@@ -53,7 +53,7 @@ Availability of these toggles will be removed at each major release as the funct
   .. code-block:: yaml
 
       future:
-        static_environments: true
+        strict_environments: true
 
       deployments:
         - environments:

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -8,8 +8,7 @@ import sys
 from builtins import input
 # pylint trips up on this in virtualenv
 # https://github.com/PyCQA/pylint/issues/73
-from distutils.util import \
-    strtobool  # noqa pylint: disable=no-name-in-module,import-error
+from distutils.util import strtobool  # noqa pylint: disable=E
 
 import boto3
 import six

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -301,7 +301,8 @@ def validate_environment(context, module, env_def, strict=False):
                         'module will determine deployment', module.name)
             return None
         return validate_environment(context, module,
-                                    env_def.get(context.env_name, False))
+                                    env_def.get(context.env_name, False),
+                                    strict)
 
     account_id = context.account_id
     accepted_values = ['{}/{}'.format(account_id, context.env_region),
@@ -343,8 +344,10 @@ class ModulesCommand(RunwayCommand):
                           command=command)
         context.env_vars['RUNWAYCONFIG'] = self.runway_config_path
 
-        if self.runway_config.strict:
-            LOGGER.warning('!!!! STRICT MODE IS ENABLED !!!!')
+        if self.runway_config.future.enabled:
+            LOGGER.info('Future functionality enabled: %s',
+                        ', '.join(self.runway_config.future.enabled))
+            LOGGER.info('')
 
         # set default names if needed
         for i, deployment in enumerate(deployments):
@@ -562,7 +565,8 @@ class ModulesCommand(RunwayCommand):
         module_opts['environment'] = module_opts['environments'].get(
             context.env_name, {}
         )
-        if isinstance(module_opts['environment'], dict) and not self.runway_config.strict:
+        if isinstance(module_opts['environment'], dict) and \
+                not self.runway_config.future.strict_environments:
             module_opts['parameters'].update(module_opts['environment'])
             if module_opts['parameters']:
                 # deploy if env is empty but params are provided
@@ -572,7 +576,7 @@ class ModulesCommand(RunwayCommand):
                 context=context,
                 module=module,
                 env_def=module_opts['environments'],
-                strict=self.runway_config.strict
+                strict=self.runway_config.future.strict_environments
             )
             if module_opts['environment'] is False:  # ignore None
                 return  # skip if env validation fails

--- a/runway/commands/modules_command.py
+++ b/runway/commands/modules_command.py
@@ -273,7 +273,7 @@ def validate_environment(context, module, env_def, strict=False):
             Environment definition. This should usually be the merged dict of
             a deployment and module environment definition but will recursively
             handle nested portions of the definition.
-        strict (bool): Wither to consider the current environment missing from
+        strict (bool): Wether to consider the current environment missing from
             definition as a failure.
 
     Returns:

--- a/runway/config.py
+++ b/runway/config.py
@@ -438,7 +438,7 @@ class FutureDefinition(MutableMap):
         """Instantiate class.
 
         Keyword Args:
-            strict_environments (bool): Wither to enable strict environments.
+            strict_environments (bool): Wether to enable strict environments.
 
         """
         self.strict_environments = strict_environments

--- a/runway/config.py
+++ b/runway/config.py
@@ -433,8 +433,8 @@ class FutureDefinition(MutableMap):
 
     """
 
-    def __init__(self, *_args, strict_environments=False, **kwargs):
-        # type: (Any, bool, bool) -> None
+    def __init__(self, strict_environments=False, **kwargs):
+        # type: (bool, bool) -> None
         """Instantiate class.
 
         Keyword Args:

--- a/runway/config.py
+++ b/runway/config.py
@@ -424,7 +424,7 @@ class ModuleDefinition(ConfigComponent):  # pylint: disable=too-many-instance-at
 
 
 class FutureDefinition(MutableMap):
-    """Opt-in to future default functionality before the next major release.
+    """Opt-in to future functionality before the next major release.
 
     Availability of these toggles will be removed at each major release as
     the functionality will then be considered current.
@@ -438,7 +438,7 @@ class FutureDefinition(MutableMap):
         """Instantiate class.
 
         Keyword Args:
-            strict_environments (bool): Either to enable strict environments.
+            strict_environments (bool): Wither to enable strict environments.
 
         """
         self.strict_environments = strict_environments

--- a/runway/config.py
+++ b/runway/config.py
@@ -1055,6 +1055,7 @@ class Config(ConfigComponent):
 
     def __init__(self,
                  deployments,  # type: List[Dict[str, Any]]
+                 strict=False,  # type: bool
                  tests=None,  # type: List[Dict[str, Any]]
                  ignore_git_branch=False,  # type: bool
                  variables=None  # type: Optional[Dict[str, Any]]
@@ -1067,6 +1068,7 @@ class Config(ConfigComponent):
             deployments (List[Dict[str, Any]]): A list of
                 :class:`deployments<runway.config.DeploymentDefinition>`
                 that are processed in the order they are defined.
+            strict (bool): **BETA FEATURE** Enable strict configuration.
             tests (Optional[List[Dict[str, Any]]]): A list of
                 :class:`tests<runway.config.TestDefinition>` that are
                 processed in the order they are defined.
@@ -1102,6 +1104,7 @@ class Config(ConfigComponent):
 
         """
         self.deployments = DeploymentDefinition.from_list(deployments)
+        self.strict = strict
         self.tests = TestDefinition.from_list(tests)
         self.ignore_git_branch = ignore_git_branch
 
@@ -1120,6 +1123,7 @@ class Config(ConfigComponent):
         with open(config_path) as data_file:
             config_file = yaml.safe_load(data_file)
             result = Config(config_file.pop('deployments'),
+                            config_file.pop('strict', False),
                             config_file.pop('tests', []),
                             config_file.pop('ignore_git_branch',
                                             config_file.pop(

--- a/runway/context.py
+++ b/runway/context.py
@@ -60,7 +60,7 @@ class Context(object):
 
     @property
     def account_id(self):
-        """Gets the AccountId of the current AWS account.
+        """Get the AccountId of the current AWS account.
 
         Returns:
             str: AWS Account ID.

--- a/runway/context.py
+++ b/runway/context.py
@@ -59,6 +59,17 @@ class Context(object):
         self.__inject_profile_credentials()  # TODO remove after IaC tools support AWS SSO
 
     @property
+    def account_id(self):
+        """Gets the AccountId of the current AWS account.
+
+        Returns:
+            str: AWS Account ID.
+
+        """
+        client = self.get_session().client('sts')
+        return client.get_caller_identity()['Account']
+
+    @property
     def boto3_credentials(self):
         """Return a dict of boto3 credentials."""
         return {key.lower(): value

--- a/tests/commands/test_modules_command.py
+++ b/tests/commands/test_modules_command.py
@@ -1,5 +1,6 @@
 """Tests runway/commands/modules_command.py."""
 # pylint: disable=no-self-use,redefined-outer-name
+import logging
 import os
 from copy import deepcopy
 from os import path
@@ -7,13 +8,12 @@ from os import path
 import pytest
 import yaml
 from mock import MagicMock, call, patch
-from moto import mock_sts
 
 from runway.commands.modules_command import (ModulesCommand,
                                              select_modules_to_run,
                                              validate_environment)
 from runway.config import Config
-from runway.util import environ
+from runway.util import MutableMap, environ
 
 MODULE_PATH = 'runway.commands.modules_command'
 
@@ -153,43 +153,59 @@ class TestSelectModulesToRun(object):
             module_tag_config['deployments'][0]['modules']
 
 
-class TestValidateEnvironment(object):
-    """Tests for validate_environment."""
-
-    MOCK_ACCOUNT_ID = '123456789012'
-
-    def test_bool_match(self):
-        """True bool should match."""
-        assert validate_environment('test_module', True, os.environ)
-
-    def test_bool_not_match(self):
-        """False bool should not match."""
-        assert not validate_environment('test_module', False, os.environ)
-
-    @mock_sts
-    def test_list_match(self):
-        """Env in list should match."""
-        assert validate_environment('test_module',
-                                    [self.MOCK_ACCOUNT_ID + '/us-east-1'],
-                                    os.environ)
-
-    @mock_sts
-    def test_list_not_match(self):
-        """Env not in list should not match."""
-        assert not validate_environment('test_module',
-                                        [self.MOCK_ACCOUNT_ID + '/us-east-2'],
-                                        os.environ)
-
-    @mock_sts
-    def test_str_match(self):
-        """Env in string should match."""
-        assert validate_environment('test_module',
-                                    self.MOCK_ACCOUNT_ID + '/us-east-1',
-                                    os.environ)
-
-    @mock_sts
-    def test_str_not_match(self):
-        """Env not in string should not match."""
-        assert not validate_environment('test_module',
-                                        self.MOCK_ACCOUNT_ID + '/us-east-2',
-                                        os.environ)
+@pytest.mark.parametrize('env_def, strict, expected, expected_logs', [
+    (True, False, True, ['test_module: explicitly enabled']),
+    (False, False, False, ['test_module: skipped; explicitly disabled']),
+    (['123456789012/us-east-1'], False, True, []),
+    (['123456789012/us-east-2'], False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ('123456789012/us-east-1', False, True, []),
+    ('123456789012/us-east-2', False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({}, False, None,
+     ['test_module: environment not defined; module will determine deployment']),
+    ({}, True, None,
+     ['test_module: environment not defined; module will determine deployment']),
+    ({'example': '111111111111/us-east-1'}, False, None,
+     ['test_module: environment not in definition; module will determine deployment']),
+    ({'example': '111111111111/us-east-1'}, True, False,
+     ['test_module: skipped; environment not in definition']),
+    ({'test': False}, False, False,
+     ['test_module: skipped; explicitly disabled']),
+    ({'test': True}, False, True, ['test_module: explicitly enabled']),
+    ({'test': '123456789012/us-east-1'}, False, True, []),
+    ({'test': '123456789012/us-east-2'}, False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({'test': '123456789012'}, False, True, []),
+    ({'test': '111111111111'}, False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({'test': 123456789012}, False, True, []),
+    ({'test': 111111111111}, False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({'test': 'us-east-1'}, False, True, []),
+    ({'test': 'us-east-2'}, False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({'test': ['123456789012/us-east-1', '123456789012/us-east-2']}, False,
+     True, []),
+    ({'test': ['123456789012/us-east-2']}, False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({'test': ['123456789012', '111111111111']}, False, True, []),
+    ({'test': ['111111111111']}, False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({'test': [123456789012, 111111111111]}, False, True, []),
+    ({'test': [111111111111]}, False, False,
+     ['test_module: skipped; account_id/region mismatch']),
+    ({'test': ['us-east-1', 'us-east-2']}, False, True, []),
+    ({'test': ['us-east-2']}, False, False,
+     ['test_module: skipped; account_id/region mismatch'])
+])
+def test_validate_environment(env_def, strict, expected, expected_logs,
+                              caplog, runway_context):
+    """Test validate_environment."""
+    mock_module = MutableMap(name='test_module')
+    caplog.set_level(logging.DEBUG, logger='runway')
+    assert validate_environment(runway_context, mock_module, env_def, strict) \
+        is expected
+    # all() does not give an output that can be used for troubleshooting failures
+    for log in expected_logs:
+        assert log in caplog.messages

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -199,8 +199,19 @@ class MockRunwayContext(RunwayContext):
                                                 env_root=env_root,
                                                 env_vars=env_vars,
                                                 command=command)
+        self._account_id = '123456789012'
         self._boto3_test_client = MutableMap()
         self._boto3_test_stubber = MutableMap()
+
+    @property
+    def account_id(self):
+        """Override account_id."""
+        return self._account_id
+
+    @account_id.setter
+    def account_id(self, value):
+        """Set account_id."""
+        self._account_id = value
 
     def add_stubber(self, service_name, region=None):
         """Add a stubber to context.


### PR DESCRIPTION
## Why This Is Needed

resolves #333 

## What Changed

### Added

- option for how to handle `environments` being defined but the current environment not in the definition

### Changed

- log format of skip information no longer includes extra characters and is now prefixed by the module name