### PR TITLE
add message about false alarm pip errors & pip --no-color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `-no-color`/`--no-color` option automatically added to cdk, npm, sls, and tf commands
   - looks at `RUNWAY_COLORIZE` env var for an explicit enable/disable
   - if not set, checks `sys.stdout.isatty()` to determine if option should be provided
+- notice about *false alarm* compatibility errors when using pip with the aws_lambda hook
 
 ### Changed
 - a@e check_auth will now try to refresh tokens 5 minutes before expiration instead of waiting for it to expire
 - `runway test` will now return a non-zero exit code if any non-required tests failed
 - `static-react` sample uses npm instead of yarn
 - `yamllint` is now invoked using `runpy` instead of using `runway run-python`
+- aws_lambda hook will no longer use colorized pip output so its *false alarm* compatibility errors are less menacing
 
 ### Fixed
 - issue where `yamllint` and `cfnlint` could not be imported/executed from the Pyinstaller executables

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -521,8 +521,19 @@ def _zip_package(package_root, includes, excludes=None, dockerize_pip=False,
             pip_cmd = [python_path or sys.executable, '-m',
                        'pip', 'install',
                        '--target', tmpdir,
-                       '--requirement', tmp_req]
+                       '--requirement', tmp_req,
+                       '--no-color']  # disable color for potential errors
 
+            LOGGER.info(
+                'The following output from pip may include incompatibility errors. '
+                'For the most part, these can be ignored unless you are '
+                'experiencing issues with the end result. '
+                'Because of how pip handles dependencies, '
+                'these errors can be reported for incompatibility between '
+                'packages installed in your current environment and those '
+                'being installed to the targeted directory even if there are '
+                'no issues in the target directory.'
+            )
             # Pyinstaller build or explicit python path
             if getattr(sys, 'frozen', False) and not python_path:
                 script_contents = os.linesep.join([


### PR DESCRIPTION

## Why This Is Needed

resolves #345 

## What Changed

### Added

- notice about *false alarm* compatibility errors when using pip with the aws_lambda hook

### Changed

- aws_lambda hook will no longer use colorized pip output so its *false alarm* compatibility errors are less menacing
