### PR TITLE
fix namespace collisions when cfngin modules contribute similar names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - issue where `yamllint` and `cfnlint` could not be imported/executed from the Pyinstaller executables
+- fixed issue where CFNgin blueprints/hooks/lookups would encounter namespace collisions because imports were not being unloaded between instances
 
 ### Fixed
 - the friendly error when npm can't be found has returned

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -6,7 +6,7 @@ import sys
 
 from yaml.constructor import ConstructorError
 
-from runway.util import MutableMap, argv, cached_property, environ
+from runway.util import MutableMap, SafeHaven, cached_property
 
 from .actions import build, destroy, diff
 from .config import render_parse_load as load_config
@@ -109,11 +109,11 @@ class CFNgin(object):
             sys_path = self.sys_path
         config_files = self.find_config_files(sys_path=sys_path)
 
-        with environ(self.__ctx.env_vars):
+        with SafeHaven(environ=self.__ctx.env_vars):
             for config in config_files:
                 ctx = self.load(config)
                 LOGGER.info('%s: deploying...', os.path.basename(config))
-                with argv('stacker', 'build', ctx.config_path):
+                with SafeHaven(argv=['stacker', 'build', ctx.config_path]):
                     action = build.Action(
                         context=ctx,
                         provider_builder=self._get_provider_builder(
@@ -141,11 +141,11 @@ class CFNgin(object):
         # destroy should run in reverse to handle dependencies
         config_files.reverse()
 
-        with environ(self.__ctx.env_vars):
+        with SafeHaven(environ=self.__ctx.env_vars):
             for config in config_files:
                 ctx = self.load(config)
                 LOGGER.info('%s: destroying...', os.path.basename(config))
-                with argv('stacker', 'destroy', ctx.config_path):
+                with SafeHaven(argv=['stacker', 'destroy', ctx.config_path]):
                     action = destroy.Action(
                         context=ctx,
                         provider_builder=self._get_provider_builder(
@@ -198,12 +198,12 @@ class CFNgin(object):
         if not sys_path:
             sys_path = self.sys_path
         config_files = self.find_config_files(sys_path=sys_path)
-        with environ(self.__ctx.env_vars):
+        with SafeHaven(environ=self.__ctx.env_vars):
             for config in config_files:
                 ctx = self.load(config)
                 LOGGER.info('%s: generating change sets...',
                             os.path.basename(config))
-                with argv('stacker', 'diff', ctx.config_path):
+                with SafeHaven(argv=['stacker', 'diff', ctx.config_path]):
                     action = diff.Action(
                         context=ctx,
                         provider_builder=self._get_provider_builder(

--- a/runway/util.py
+++ b/runway/util.py
@@ -305,8 +305,10 @@ class SafeHaven(AbstractContextManager):
         self.__os_environ = deepcopy(os.environ)
         self.__sys_argv = list(sys.argv)
         # deepcopy can't pickle sys.modules and dict()/.copy() are not safe
+        # pylint: disable=unnecessary-comprehension
         self.__sys_modules = {k: v for k, v in sys.modules.items()}
         self.__sys_path = list(sys.path)
+        # more informative origin for log statements
         self.log = logging.getLogger('runway.' + self.__class__.__name__)
 
         if isinstance(argv, list):
@@ -318,6 +320,7 @@ class SafeHaven(AbstractContextManager):
 
     def reset_all(self):
         """Reset all values cached by this context manager."""
+        self.log.debug('resetting all managed values...')
         self.reset_os_environ()
         self.reset_sys_argv()
         self.reset_sys_modules()
@@ -336,6 +339,8 @@ class SafeHaven(AbstractContextManager):
     def reset_sys_modules(self):
         """Reset the value of sys.modules."""
         self.log.debug('resetting sys.modules: %s', self.__sys_modules)
+        # sys.modules can be manipulated to force reloading modules but,
+        # replacing it outright does not work as expected
         for module in list(sys.modules.keys()):
             if module not in self.__sys_modules:
                 self.log.debug('removed sys.module: {"%s": "%s"}', module,
@@ -353,10 +358,12 @@ class SafeHaven(AbstractContextManager):
             SafeHaven: Instance of the context manager.
 
         """
+        self.log.debug('entering a safe haven...')
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit the context manager."""
+        self.log.debug('leaving the safe haven...')
         self.reset_all()
 
 

--- a/runway/util.py
+++ b/runway/util.py
@@ -425,7 +425,6 @@ def environ(env=None, **kwargs):
     os.environ.update(env)
 
     try:
-        print('Entered environ...')
         yield
     finally:
         # always restore original values

--- a/runway/util.py
+++ b/runway/util.py
@@ -10,12 +10,17 @@ import platform
 import re
 import stat
 import sys
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import contextmanager
 from subprocess import check_call
 from typing import (Any, Dict, Iterator,  # noqa pylint: disable=unused-import
                     List, Optional, Union)
 
 import six
+
+if sys.version_info >= (3, 6):
+    from contextlib import AbstractContextManager  # pylint: disable=E
+else:
+    AbstractContextManager = object
 
 AWS_ENV_VARS = ('AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY',
                 'AWS_SESSION_TOKEN')

--- a/tests/fixtures/empty_module.py
+++ b/tests/fixtures/empty_module.py
@@ -1,0 +1,5 @@
+"""Used to test SafeHaven sys.modules reset.
+
+!!DO NOT IMPORT FOR ANY OTHER TEST UNLESS IT UNLOADS THIS MODULE ON TEARDOWN!!
+
+"""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -101,16 +101,17 @@ def test_argv():
     assert sys.argv == orig_expected, 'validate value returned to original'
 
 
-@patch.object(os, 'environ', {'TEST_PARAM': 'initial value'})
 def test_environ():
     """Test environ."""
-    orig_expected = {'TEST_PARAM': 'initial value'}
+    orig_expected = dict(os.environ)
     override = {'TEST_PARAM': 'override', 'new_param': 'value'}
+    override_expected = dict(orig_expected)
+    override_expected.update(override)
 
     assert os.environ == orig_expected, 'validate original value'
 
     with environ(override):
-        assert os.environ == override, 'validate override'
+        assert os.environ == override_expected, 'validate override'
         assert os.environ.pop('new_param') == 'value'
 
     assert os.environ == orig_expected, 'validate value returned to original'


### PR DESCRIPTION
## Why This Is Needed

resolves #349

## What Changed

### Added

- add context manager that resets various `os` and `sys` values upon exit

### Changed

- CFNgin will now revert `os.environ`, `sys.argv`, `sys.modules`, and `sys.path` upon action completion for each config file in a module and again after the module is finished
- updated `environ` logic to match other, similar context managers

### Fixed

- CFNging namespace collisions between each module and each config file within a module
