### PR TITLE
fix RunwayModule not subscriptable & awacs/troposphere unload causing isinstance inconsistencies

### DIFF
--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -109,11 +109,13 @@ class CFNgin(object):
             sys_path = self.sys_path
         config_files = self.find_config_files(sys_path=sys_path)
 
-        with SafeHaven(environ=self.__ctx.env_vars):
+        with SafeHaven(environ=self.__ctx.env_vars,
+                       sys_modules_exclude=['awacs', 'troposphere']):
             for config in config_files:
                 ctx = self.load(config)
                 LOGGER.info('%s: deploying...', os.path.basename(config))
-                with SafeHaven(argv=['stacker', 'build', ctx.config_path]):
+                with SafeHaven(argv=['stacker', 'build', ctx.config_path],
+                               sys_modules_exclude=['awacs', 'troposphere']):
                     action = build.Action(
                         context=ctx,
                         provider_builder=self._get_provider_builder(

--- a/runway/module/__init__.py
+++ b/runway/module/__init__.py
@@ -147,6 +147,18 @@ class RunwayModule(object):
         raise NotImplementedError('You must implement the destroy() method '
                                   'yourself!')
 
+    def __getitem__(self, key):
+        """Make the object subscriptable.
+
+        Args:
+            key (str): Attribute to get.
+
+        Returns:
+            Any
+
+        """
+        return getattr(self, key)
+
 
 class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
     """Base class for Runway modules that use npm."""

--- a/tests/cfngin/test_cfngin.py
+++ b/tests/cfngin/test_cfngin.py
@@ -121,12 +121,15 @@ class TestCFNgin(object):
                                          {'concurrency': 0,
                                           'tail': False}])
         patch_safehaven.assert_has_calls([
-            call(environ=context.env_vars),
+            call(environ=context.env_vars,
+                 sys_modules_exclude=['awacs', 'troposphere']),
             call.__enter__(),
-            call(argv=['stacker', 'build', str(tmp_path / 'basic.yml')]),
+            call(argv=['stacker', 'build', str(tmp_path / 'basic.yml')],
+                 sys_modules_exclude=['awacs', 'troposphere']),
             call.__enter__(),
             call.__exit__(None, None, None),
-            call(argv=['stacker', 'build', str(tmp_path / 'basic2.yml')]),
+            call(argv=['stacker', 'build', str(tmp_path / 'basic2.yml')],
+                 sys_modules_exclude=['awacs', 'troposphere']),
             call.__enter__(),
             call.__exit__(None, None, None),
             call.__exit__(None, None, None),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -191,6 +191,22 @@ class TestSafeHaven(object):
         assert caplog.messages[:2] == expected_logs
         assert caplog.messages[-1] == 'leaving the safe haven...'
 
+    def test_sys_modules_exclude(self, monkeypatch):
+        """Test sys.modules interations with excluded module."""
+        monkeypatch.setattr(SafeHaven, 'reset_all', MagicMock())
+
+        module = 'tests.fixtures.mock_hooks'
+
+        assert module not in sys.modules
+        with SafeHaven(sys_modules_exclude=module) as obj:
+            from .fixtures import mock_hooks  # noqa pylint: disable=E,W,C
+            assert module in sys.modules
+            obj.reset_sys_modules()
+        assert module in sys.modules
+        # cleanup
+        del sys.modules[module]
+        assert module not in sys.modules
+
     @pytest.mark.parametrize('provided', TEST_PARAMS)
     def test_sys_path(self, provided, caplog, monkeypatch):
         """Test sys.path interactions."""


### PR DESCRIPTION

## Why This Is Needed

resolves #360 and fixes an unreported bug introduced by #354 

## What Changed

### Changed

- subclasses of `RunwayModule` are now subscriptable
- `SafeHaven` is now able to exclude modules from being unloaded

### Fixed

- fixed an issue causing module commands to raise _"TypeError: object is not subscriptable"_
- fixed an issue where troposphere was unable to properly assess types for some objects