### PR TITLE
allow runway tests to exit 0 without signaling failure

### DIFF
--- a/runway/commands/runway/test.py
+++ b/runway/commands/runway/test.py
@@ -78,6 +78,8 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                 # tool it is wrapping.
                 if not isinstance(err, SystemExit):
                     traceback.print_exc()
+                elif err.code == 0:
+                    next  # Tests calling sys.exit(0) don't indicate failure
                 LOGGER.error('Test failed: %s', test.name)
                 if test.required:
                     LOGGER.error('Failed test was required, the remaining '


### PR DESCRIPTION
This will check the exit code of tests so any that have called sys.exit(0) (e.g. yamllint) won't trigger Runway to count it as failed.