### PR TITLE
allow runway tests to exit 0 without signaling failure

### DIFF
--- a/runway/commands/runway/test.py
+++ b/runway/commands/runway/test.py
@@ -79,7 +79,7 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                 if not isinstance(err, SystemExit):
                     traceback.print_exc()
                 elif err.code == 0:
-                    continue # Tests calling sys.exit(0) don't indicate failure
+                    continue  # Tests calling sys.exit(0) don't indicate failure
                 LOGGER.error('Test failed: %s', test.name)
                 if test.required:
                     LOGGER.error('Failed test was required, the remaining '

--- a/runway/commands/runway/test.py
+++ b/runway/commands/runway/test.py
@@ -78,6 +78,8 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                 # tool it is wrapping.
                 if not isinstance(err, SystemExit):
                     traceback.print_exc()
+                elif err.code == 0:
+                    next  # Tests calling sys.exit(0) don't indicate failure
                 LOGGER.error('Test failed: %s', test.name)
                 if test.required:
                     LOGGER.error('Failed test was required, the remaining '

--- a/runway/commands/runway/test.py
+++ b/runway/commands/runway/test.py
@@ -78,14 +78,15 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                 # tool it is wrapping.
                 if not isinstance(err, SystemExit):
                     traceback.print_exc()
-                elif err.code == 0:
-                    next  # Tests calling sys.exit(0) don't indicate failure
-                LOGGER.error('Test failed: %s', test.name)
-                if test.required:
-                    LOGGER.error('Failed test was required, the remaining '
-                                 'tests have been skipped')
-                    sys.exit(1)
-                failed_tests.append(test.name)
+
+                if not (isinstance(err, SystemExit) and (
+                        err.code == 0)):  # Tests calling sys.exit(0) don't indicate failure
+                    LOGGER.error('Test failed: %s', test.name)
+                    if test.required:
+                        LOGGER.error('Failed test was required, the remaining '
+                                     'tests have been skipped')
+                        sys.exit(1)
+                    failed_tests.append(test.name)
         if failed_tests:
             LOGGER.error('The following tests failed: %s',
                          ', '.join(failed_tests))

--- a/runway/commands/runway/test.py
+++ b/runway/commands/runway/test.py
@@ -78,15 +78,14 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                 # tool it is wrapping.
                 if not isinstance(err, SystemExit):
                     traceback.print_exc()
-
-                if not (isinstance(err, SystemExit) and (
-                        err.code == 0)):  # Tests calling sys.exit(0) don't indicate failure
-                    LOGGER.error('Test failed: %s', test.name)
-                    if test.required:
-                        LOGGER.error('Failed test was required, the remaining '
-                                     'tests have been skipped')
-                        sys.exit(1)
-                    failed_tests.append(test.name)
+                elif err.code == 0:
+                    next  # Tests calling sys.exit(0) don't indicate failure
+                LOGGER.error('Test failed: %s', test.name)
+                if test.required:
+                    LOGGER.error('Failed test was required, the remaining '
+                                 'tests have been skipped')
+                    sys.exit(1)
+                failed_tests.append(test.name)
         if failed_tests:
             LOGGER.error('The following tests failed: %s',
                          ', '.join(failed_tests))

--- a/runway/commands/runway/test.py
+++ b/runway/commands/runway/test.py
@@ -79,7 +79,7 @@ class Test(BaseCommand):  # pylint: disable=too-few-public-methods
                 if not isinstance(err, SystemExit):
                     traceback.print_exc()
                 elif err.code == 0:
-                    next  # Tests calling sys.exit(0) don't indicate failure
+                    continue # Tests calling sys.exit(0) don't indicate failure
                 LOGGER.error('Test failed: %s', test.name)
                 if test.required:
                     LOGGER.error('Failed test was required, the remaining '


### PR DESCRIPTION
This will check the exit code of tests so any that have called sys.exit(0) (e.g. yamllint) won't trigger Runway to count it as failed.