### PR TITLE
fix Kubernetes section caption

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -99,7 +99,7 @@ Kubernetes manifests can be deployed via Runway offering an ideal way to handle 
 - `Advanced Features <kubernetes/advanced_features.html>`__
 
 .. toctree::
-   :caption: CloudFormation & Troposphere
+   :caption: Kubernetes
    :maxdepth: 2
    :hidden:
 


### PR DESCRIPTION

## Why This Is Needed

The Kubernetes section shares the same caption as the CloudFormation section.

## What Changed

### Fixed

- fixed the caption of the Kubernetes section

