### PR TITLE
fixed issue where tests were not properly excluded from distributable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     ],
     python_requires='>=2.6',
     keywords='cli',
-    packages=find_packages(exclude=('tests', 'integration_tests')),
+    packages=find_packages(exclude=('integration*', 'tests*')),
     install_requires=INSTALL_REQUIRES,
     setup_requires=['setuptools_scm'],
     use_scm_version={"local_scheme": local_scheme},


### PR DESCRIPTION
## Why This Is Needed

### packages in current release

```
Found existing installation: runway 1.9.0
Uninstalling runway-1.9.0:
  Would remove:
    /Users/kyle/repos/runway/.venv/bin/runway
    /Users/kyle/repos/runway/.venv/bin/stacker-runway
    /Users/kyle/repos/runway/.venv/bin/stacker-runway.cmd
    /Users/kyle/repos/runway/.venv/bin/tf-runway
    /Users/kyle/repos/runway/.venv/bin/tf-runway.cmd
    /Users/kyle/repos/runway/.venv/bin/tfenv-runway
    /Users/kyle/repos/runway/.venv/bin/tfenv-runway.cmd
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_cdk/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_cfngin/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_commands/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_moduletags/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_parallelism/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_runway_module_type_detection/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_serverless/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_sources/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_staticsite/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/integration_tests/test_terraform/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/runway-1.9.0.dist-info/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/runway/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/tests/cfngin/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/tests/commands/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/tests/fixtures/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/tests/hooks/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/tests/lookups/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/tests/module/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/tests/sources/*
Proceed (y/n)? 
```

### packages post fix

```
Found existing installation: runway 1.9.1.dev1
Uninstalling runway-1.9.1.dev1:
  Would remove:
    /Users/kyle/repos/runway/.venv/bin/runway
    /Users/kyle/repos/runway/.venv/bin/stacker-runway
    /Users/kyle/repos/runway/.venv/bin/stacker-runway.cmd
    /Users/kyle/repos/runway/.venv/bin/tf-runway
    /Users/kyle/repos/runway/.venv/bin/tf-runway.cmd
    /Users/kyle/repos/runway/.venv/bin/tfenv-runway
    /Users/kyle/repos/runway/.venv/bin/tfenv-runway.cmd
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/runway-1.9.1.dev1.dist-info/*
    /Users/kyle/repos/runway/.venv/lib/python3.7/site-packages/runway/*
Proceed (y/n)? 
```

## What Changed

### Fixed

- fixed an issue where tests were not being properly excluded from distributable
