### PR TITLE
fix aws alias/id validation when assumed and async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- fixed an issue where AWS account alias/id validation was not using a context object with assumed credentials when running in parallel
+- fixed an issue where AWS account alias/id validation was not using the context object with assumed credentials when running in parallel
 
 ## [1.10.0] - 2020-07-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixed an issue where AWS account alias/id validation was not using a context object with assumed credentials when running in parallel
 
 ## [1.10.0] - 2020-07-16
 ### Changed

--- a/runway/core/components/_deployment.py
+++ b/runway/core/components/_deployment.py
@@ -214,7 +214,7 @@ class Deployment(object):
 
         with aws.AssumeRole(context, **self.assume_role_config):
             self.definition.resolve(context, self._variables)
-            self.validate_account_credentials()
+            self.validate_account_credentials(context)
             Module.run_list(action=action,
                             context=context,
                             deployment=self.definition,
@@ -222,16 +222,19 @@ class Deployment(object):
                             modules=self.definition.modules,
                             variables=self._variables)
 
-    def validate_account_credentials(self):
-        # type: () -> None
+    def validate_account_credentials(self, context=None):
+        # type: (Optional[Context]) -> None
         """Exit if requested deployment account doesn't match credentials.
+
+        Args:
+            context (Optional[Context]): Context object.
 
         Raises:
             SystemExit: AWS Account associated with the current credentials
                 did not match the defined criteria.
 
         """
-        account = aws.AccountDetails(self.ctx)
+        account = aws.AccountDetails(context or self.ctx)
         if self.account_id_config:
             if self.account_id_config != account.id:
                 self.logger.error('current AWS account "%s" does not match '

--- a/tests/unit/core/components/test_deployment.py
+++ b/tests/unit/core/components/test_deployment.py
@@ -268,7 +268,7 @@ class TestDeployment(object):
         assert runway_context.command == 'deploy'
         assert runway_context.env.aws_region == 'us-west-2'
         mock_resolve.assert_called_once_with(runway_context, obj._variables)
-        mock_validate.assert_called_once_with()
+        mock_validate.assert_called_once_with(runway_context)
         mock_aws.AssumeRole.assert_called_once_with(runway_context)
         mock_aws.AssumeRole().__enter__.assert_called_once()
         mock_module.run_list.assert_called_once_with(action='deploy',


### PR DESCRIPTION

## Why This Is Needed

When using parallel regions and assumed roles, validation was being performed against the original credentials instead of the assumed credentials.

## What Changed

### Fixed

- fixed an issue where AWS account alias/id validation was not using the context object with assumed credentials when running in parallel
