### PR TITLE
update sls autodetect to check for serverless.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- will now also check for `serverless.ts` when auto-detecting module type based on directory contents
 
 ## [1.10.0] - 2020-07-16
 ### Changed

--- a/runway/runway_module_type.py
+++ b/runway/runway_module_type.py
@@ -128,8 +128,11 @@ class RunwayModuleType(object):
     def _set_class_path_based_on_autodetection(self):
         # type() -> void
         """Based on the files detected in the base path set the class_path."""
-        if (self._is_file('serverless.yml') or self._is_file('serverless.js')) \
-                and self._is_file('package.json'):
+        if any(
+                self._is_file(sls) for sls in [
+                    'serverless.js', 'serverless.ts', 'serverless.yml'
+                ]
+        ) and self._is_file('package.json'):
             self.class_path = self.TYPE_MAP.get('serverless', None)
         elif self._has_glob('*.tf'):
             self.class_path = self.TYPE_MAP.get('terraform', None)

--- a/tests/unit/test_runway_module_type.py
+++ b/tests/unit/test_runway_module_type.py
@@ -24,6 +24,7 @@ class TestRunwayModuleType(object):
         (['overlays/', 'kustomization.yaml', 'cdk.json'], K8s),
         (['serverless.yml', 'package.json', 'cdk.json'], Serverless),
         (['serverless.js', 'package.json', 'cdk.json'], Serverless),
+        (['serverless.ts', 'package.json', 'cdk.json'], Serverless),
         (['any.tf', 'serverless.yml'], Terraform)
     ])
     def test_autodetection(self, files, expected, cd_tmp_path):


### PR DESCRIPTION

## Why This Is Needed

resolves #385 

## What Changed

### Changed

- will now also check for `serverless.ts` when auto-detecting module type based on directory contents
