### PR TITLE
add cfn lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cfn` Lookup usable in Runway and CFNgin config files
+
+### Changed
+- `terraform_backend_cfn_outputs` option is now deprecated
+- `xref` Lookup is now deprecated
 
 ## [1.10.1] - 2020-07-20
 ### Fixed

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,15 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: clean docs open help Makefile
+
+clean:
+	rm -rf build/html/*
+
+docs: clean html open
+
+open:
+	open build/html/index.html
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -6,9 +6,9 @@
 
 .. _cfngin-lookups:
 
-=======
+#######
 Lookups
-=======
+#######
 
 .. note:: Runway lookups and CFNgin lookups are not interchangeable. While they
           do share a similar base class and syntax, they exist in two different
@@ -76,6 +76,7 @@ Runway's CFNgin includes the following lookup types:
 
 - `output lookup`_
 - `ami lookup`_
+- `cfn lookup`_
 - `custom lookup`_
 - `default lookup`_
 - `dynamodb lookup`_
@@ -87,10 +88,22 @@ Runway's CFNgin includes the following lookup types:
 - ssm_ lookup
 - `xref lookup`_
 
+**********
+cfn Lookup
+**********
+
+.. important::
+  The Stack must exist in CloudFormation before the config using this Lookup begins processing to successfully get a value.
+  This means that it must have been deployed using another Runway module, deployed from a config that is run before the one using it, deployed manually, or deployed in the same config using ``required``/``required_by`` to specify a dependency between the Stacks.
+
+.. automodule:: runway.lookups.handlers.cfn
+
+
 .. _`output lookup`:
 
+*************
 Output Lookup
--------------
+*************
 
 The ``output`` lookup takes a value of the format:
 ``<stack name>::<output name>`` and retrieves the output from the given stack
@@ -109,8 +122,9 @@ You can specify an output lookup with the following syntax:
 
 .. _`default lookup`:
 
+**************
 default Lookup
---------------
+**************
 
 The ``default`` lookup type will check if a value exists for the variable
 in the environment file, then fall back to a default defined in the CFNgin
@@ -143,8 +157,9 @@ value.
 
 .. _`kms lookup`:
 
+**********
 KMS Lookup
-----------
+**********
 
 The ``kms`` lookup type decrypts its input value.
 
@@ -183,8 +198,9 @@ value is large) using the ``file://`` prefix, ie::
 
 .. _`xref lookup`:
 
+***********
 XRef Lookup
------------
+***********
 
 The ``xref`` lookup type is very similar to the ``output`` lookup type, the
 difference being that ``xref`` resolves output values from stacks that
@@ -211,8 +227,9 @@ requirements.
 
 .. _`rxref lookup`:
 
+************
 RXRef Lookup
-------------
+************
 
 The ``rxref`` lookup type is very similar to the ``xref`` lookup type,
 the difference being that ``rxref`` will lookup output values from stacks
@@ -252,8 +269,9 @@ within the same CFNgin YAML config.
 
 .. _`file lookup`:
 
+***********
 File Lookup
------------
+***********
 
 The ``file`` lookup type allows the loading of arbitrary data from files on
 disk. The lookup additionally supports using a ``codec`` to manipulate or
@@ -367,16 +385,18 @@ Basic examples::
         Resource: "{{MyResource}}"
 
 
+***
 ssm
----
+***
 
 .. automodule:: runway.lookups.handlers.ssm
 
 
 .. _`ssmstore lookup`:
 
+**************************
 SSM Parameter Store Lookup
---------------------------
+**************************
 
 .. deprecated:: 1.5.0
   Replaced by ssm_
@@ -409,10 +429,12 @@ values)
 The region can be omitted (e.g. ``DBUser: ${ssmstore MyDBUser}``), in which
 case ``us-east-1`` will be assumed.
 
+
 .. _`dynamodb lookup`:
 
+***************
 DynamoDb Lookup
---------------------------
+***************
 
 The ``dynamodb`` lookup type retrieves a value from a DynamoDb table.
 
@@ -450,8 +472,9 @@ You can lookup values inside of a map.
 
 .. _`envvar lookup`:
 
+************************
 Shell Environment Lookup
-------------------------
+************************
 
 The ``envvar`` lookup type retrieves a value from a variable in the shell's
 environment.
@@ -472,10 +495,12 @@ in the lookup, like so::
 
   DBUser: ${envvar file://dbuser_file.txt}
 
+
 .. _`ami lookup`:
 
+**************
 EC2 AMI Lookup
---------------
+**************
 
 The ``ami`` lookup is meant to search for the most recent AMI created that
 matches the given filters.
@@ -506,10 +531,12 @@ Example::
   # Note: The region is optional, and defaults to the current CFNgin region
   ImageId: ${ami [<region>@]owners:self,888888888888,amazon name_regex:server[0-9]+ architecture:i386}
 
+
 .. _`hook_data lookup`:
 
+****************
 Hook Data Lookup
-----------------
+****************
 
 When using hooks, you can have the hook store results in the
 `hook_data`_ dictionary on the context by setting ``data_key`` in the hook
@@ -548,15 +575,16 @@ limited or no effect:
 
 .. _`custom lookup`:
 
+*************
 Custom Lookup
---------------
+*************
 
 A custom lookup may be registered within the config.
 For more information see `Configuring Lookups <configuration.html#lookups>`_.
 
 
 Writing A Custom Lookup
-~~~~~~~~~~~~~~~~~~~~~~~
+=======================
 
 A custom lookup must be in an executable, importable python package or standalone file.
 The lookup must be importable using your current ``sys.path``.

--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -202,6 +202,9 @@ value is large) using the ``file://`` prefix, ie::
 XRef Lookup
 ***********
 
+.. deprecated:: 1.11.0
+  Replaced by `cfn lookup`_
+
 The ``xref`` lookup type is very similar to the ``output`` lookup type, the
 difference being that ``xref`` resolves output values from stacks that
 aren't contained within the current CFNgin namespace, but are existing stacks

--- a/docs/source/lookups.rst
+++ b/docs/source/lookups.rst
@@ -1,7 +1,8 @@
 .. _Lookups:
 
+#######
 Lookups
-=======
+#######
 
 Runway Lookups allow the use of variables within the Runway config file. These
 variables can then be passed along to :ref:`deployments <runway-deployment>`,
@@ -48,17 +49,31 @@ expect.
 .. automodule:: runway.lookups.handlers.base
 
 
-.. _build-in-lookups:
+.. _built-in-lookups:
 
-Build-in Lookups
-^^^^^^^^^^^^^^^^
+****************
+Built-in Lookups
+****************
+
+
+.. _cfn lookup:
+.. _cfn-lookup:
+
+cfn
+===
+
+.. important::
+  The Stack must exist in CloudFormation before the module using this Lookup begins processing to successfully get a value.
+  This means that the Stack must have been deployed by another module, run before the one using this Lookup, or it must have been created external to Runway.
+
+.. automodule:: runway.lookups.handlers.cfn
 
 
 .. _env lookup:
 .. _env-lookup:
 
 env
-~~~
+===
 
 .. automodule:: runway.lookups.handlers.env
 
@@ -67,7 +82,7 @@ env
 .. _ssm-lookup:
 
 ssm
-~~~
+===
 
 .. automodule:: runway.lookups.handlers.ssm
 
@@ -76,6 +91,6 @@ ssm
 .. _var-lookup:
 
 var
-~~~
+===
 
 .. automodule:: runway.lookups.handlers.var

--- a/docs/source/terraform/advanced_features.rst
+++ b/docs/source/terraform/advanced_features.rst
@@ -71,12 +71,18 @@ Backend config options can also be specified as a module option in the `Runway C
   ---
   deployments:
     - modules:
-        - path: sampleapp.tf
+        - path: sampleapp-01.tf
           options:
             terraform_backend_config:
               bucket: mybucket
               dynamodb_table: mytable
               region: us-east-1
+        - path: sampleapp-02.tf
+          options:
+            terraform_backend_config:
+              bucket: ${cfn common-tf-state.TerraformStateBucketName}
+              dynamodb_table: ${cfn common-tf-state.TerraformStateTableName}
+              region: ${env AWS_REGION}
 
 .. rubric:: Deployment Level
 .. code-block:: yaml
@@ -91,46 +97,6 @@ Backend config options can also be specified as a module option in the `Runway C
           bucket: ${ssm ParamNameHere::region=us-east-1}
           dynamodb_table: ${ssm ParamNameHere::region=us-east-1}
           region: ${env AWS_REGION}
-
-
-runway.yml From CloudFormation Outputs
-======================================
-
-A recommended option for managing the state bucket and table is to create
-them via CloudFormation (try running ``runway gen-sample cfn`` to get a
-template and stack definition for bucket/table stack). To further support this,
-backend config options can be looked up directly from CloudFormation
-outputs.
-
-.. rubric:: Module Level
-.. code-block:: yaml
-
-  ---
-  deployments:
-    - modules:
-        - path: sampleapp.tf
-          options:
-            terraform_backend_config:
-              region: us-east-1
-            terraform_backend_cfn_outputs:
-              bucket: StackName::OutputName  # e.g. common-tf-state::TerraformStateBucketName
-              dynamodb_table: StackName::OutputName  # e.g. common-tf-state::TerraformStateTableName
-
-
-.. rubric:: Deployment Level
-.. code-block:: yaml
-
-  ---
-  deployments:
-    - modules:
-        - path: sampleapp-01.tf
-        - path: sampleapp-02.tf
-      module_options:  # shared between all modules in deployment
-        terraform_backend_config:
-          region: us-east-1
-        terraform_backend_cfn_outputs:
-          bucket: StackName::OutputName  # e.g. common-tf-state::TerraformStateBucketName
-          dynamodb_table: StackName::OutputName  # e.g. common-tf-state::TerraformLockTableName
 
 
 ----

--- a/runway/cfngin/lookups/handlers/xref.py
+++ b/runway/cfngin/lookups/handlers/xref.py
@@ -12,7 +12,7 @@ TYPE_NAME = "xref"
 class XrefLookup(LookupHandler):
     """Xref lookup."""
 
-    DEPRECATION_MSG = ('xref lookup has been deprecated; '
+    DEPRECATION_MSG = ('xref Lookup has been deprecated; '
                        'use the cfn lookup instead')
 
     @classmethod

--- a/runway/cfngin/lookups/handlers/xref.py
+++ b/runway/cfngin/lookups/handlers/xref.py
@@ -1,14 +1,19 @@
 """Handler for fetching outputs from fully qualified stacks."""
 # pylint: disable=arguments-differ,unused-argument
+import logging
 from runway.lookups.handlers.base import LookupHandler
 
 from .output import deconstruct
 
+LOGGER = logging.getLogger(__name__)
 TYPE_NAME = "xref"
 
 
 class XrefLookup(LookupHandler):
     """Xref lookup."""
+
+    DEPRECATION_MSG = ('xref lookup has been deprecated; '
+                       'use the cfn lookup instead')
 
     @classmethod
     def handle(cls, value, context=None, provider=None, **kwargs):
@@ -36,6 +41,7 @@ class XrefLookup(LookupHandler):
                 conf_value: ${xref fully-qualified-stack-name::SomeOutputName}
 
         """
+        LOGGER.warning(cls.DEPRECATION_MSG)
         if provider is None:
             raise ValueError('Provider is required')
 

--- a/runway/cfngin/lookups/registry.py
+++ b/runway/cfngin/lookups/registry.py
@@ -3,7 +3,7 @@ import logging
 
 from six import string_types
 
-from runway.lookups.handlers import ssm
+from runway.lookups.handlers import cfn, ssm
 from runway.util import DOC_SITE, load_object_from_string
 
 from ..exceptions import FailedVariableLookup, UnknownLookupType
@@ -84,6 +84,7 @@ def resolve_lookups(variable, context, provider):
 
 
 register_lookup_handler(ami.TYPE_NAME, ami.AmiLookup)
+register_lookup_handler(cfn.TYPE_NAME, cfn.CfnLookup)
 register_lookup_handler(default.TYPE_NAME, default.DefaultLookup)
 register_lookup_handler(dynamodb.TYPE_NAME, dynamodb.DynamodbLookup)
 register_lookup_handler(envvar.TYPE_NAME, envvar.EnvvarLookup)

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -76,7 +76,7 @@ def get_output_dict(stack):
 
     """
     if not stack.get('Outputs'):
-        return outputs
+        return {}
     outputs = {
         output['OutputKey']: output['OutputValue']
         for output in stack.get('Outputs', [])

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -75,14 +75,15 @@ def get_output_dict(stack):
         stack.
 
     """
-    outputs = {}
     if not stack.get('Outputs'):
         return outputs
-
-    for output in stack['Outputs']:
-        LOGGER.debug("    %s %s: %s", stack['StackName'], output['OutputKey'],
-                     output['OutputValue'])
-        outputs[output['OutputKey']] = output['OutputValue']
+    outputs = {
+        output['OutputKey']: output['OutputValue']
+        for output in stack.get('Outputs', [])
+    }
+    LOGGER.debug(
+        '%s stack outputs: %s', stack['StackName'], json.dumps(outputs)
+    )
     return outputs
 
 

--- a/runway/lookups/handlers/__init__.py
+++ b/runway/lookups/handlers/__init__.py
@@ -1,4 +1,5 @@
 """Import classes."""
+from . import cfn  # noqa: F401
 from . import env  # noqa: F401
 from . import ssm  # noqa: F401
 from . import var  # noqa: F401

--- a/runway/lookups/handlers/base.py
+++ b/runway/lookups/handlers/base.py
@@ -2,8 +2,9 @@
 
 .. _lookup arguments:
 
+****************
 Lookup Arguments
-^^^^^^^^^^^^^^^^
+****************
 
 Arguments can be passed to Lookups to effect how they function.
 
@@ -27,7 +28,7 @@ that all Lookups accept.
 .. _Common Lookup Arguments:
 
 Common Lookup Arguments
-~~~~~~~~~~~~~~~~~~~~~~~
+=======================
 
 **default (Any)**
     If the Lookup is unable to find a value for the provided query, this
@@ -80,7 +81,7 @@ Common Lookup Arguments
 .. code-block:: yaml
 
   deployments:
-    - environments:
+    - parameters:
         some_variable: ${var some_value::default=my_value}
         comma_list: ${var my_list::default=undefined, transform=str}
 

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -1,6 +1,6 @@
 """Retrieve a value from CloudFormation Stack Outputs.
 
-They query syntax for this lookup is ``<stack-name>.<output-name>``.
+The query syntax for this lookup is ``<stack-name>.<output-name>``.
 When specifying the output name, be sure to use the *Logical ID* of
 the output; not the *Export.Name*.
 

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -27,9 +27,9 @@ This Lookup supports all :ref:`Common Lookup Arguments`.
         path: sampleapp.tf
         options:
           terraform_backend_config:
-            region: us-east-1
             bucket: ${cfn common-tf-state.TerraformStateBucketName::region=us-east-1}
             dynamodb_table: ${cfn common-tf-state.TerraformStateTableName::region=us-east-1}
+            region: us-east-1
 
 .. code-block:: yaml
   :caption: CFNgin config

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -65,13 +65,6 @@ LOGGER = logging.getLogger(__name__)
 TYPE_NAME = "cfn"
 
 OutputQuery = namedtuple('OutputQuery', ('stack_name', 'output_name'))
-OutputQuery.__doc__ = """Named tuple representing the query for a Stack output.
-
-Attrs:
-    stack_name (str): CloudFormation Stack name.
-    output_name (str): CloudFormation Stack output name.
-
-"""
 
 
 class CfnLookup(LookupHandler):

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -1,4 +1,46 @@
-"""Retrieve a value from CloudFormation Stack outputs."""
+"""Retrieve a value from CloudFormation Stack Outputs.
+
+They query syntax for this lookup is ``<stack-name>.<output-name>``.
+When specifying the output name, be sure to use the *Logical ID* of
+the output; not the *Export.Name*.
+
+If the Lookup is unable to find a CloudFormation Stack Output matching the
+provided query, the default value is returned or an exception is raised
+to show why the value could be be resolved (e.g. Stack does not exist or
+output does not exist on the Stack).
+
+.. seealso::
+    https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html
+
+
+.. rubric:: Arguments
+
+This Lookup supports all :ref:`Common Lookup Arguments`.
+
+
+.. rubric:: Example
+.. code-block:: yaml
+  :caption: Runway config
+
+  deployments:
+    - modules:
+        path: sampleapp.tf
+        options:
+          terraform_backend_config:
+            region: us-east-1
+            bucket: ${cfn common-tf-state.TerraformStateBucketName::region=us-east-1}
+            dynamodb_table: ${cfn common-tf-state.TerraformStateTableName::region=us-east-1}
+
+.. code-block:: yaml
+  :caption: CFNgin config
+
+  stacks:
+    my-stack:
+      variables:
+        SomeParameter: ${cfn AnotherStack.OutputName}
+
+
+"""
 # pylint: disable=arguments-differ
 import json
 import logging
@@ -33,7 +75,7 @@ Attrs:
 
 
 class CfnLookup(LookupHandler):
-    """CloudFormation Stack output lookup."""
+    """CloudFormation Stack Output lookup."""
 
     @staticmethod
     def should_use_provider(args, provider):

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -59,7 +59,7 @@ from .base import LookupHandler
 if TYPE_CHECKING:
     from runway.context import Context as RunwayContext  # noqa: F401 pylint: disable=W
     from runway.cfngin.context import Context as CFNginContext  # noqa: F401 pylint: disable=W
-    from runway.cfngin.providers.aws.default import Provider
+    from runway.cfngin.providers.aws.default import Provider  # noqa: F401 pylint: disable=W
 
 LOGGER = logging.getLogger(__name__)
 TYPE_NAME = "cfn"
@@ -126,7 +126,8 @@ class CfnLookup(LookupHandler):
                context,  # type: Union['CFNginContext', 'RunwayContext']
                provider=None,  # type: Optional['Provider']
                **_  # type: Any
-               ):
+               # TODO remove disable when droping python 2 support
+               ):  # pylint: disable=bad-continuation
         # type: (...) -> Any
         """Retrieve a value from CloudFormation Stack outputs.
 

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -1,0 +1,106 @@
+"""Retrieve a value from CloudFormation Stack outputs."""
+# pylint: disable=arguments-differ
+import logging
+import json
+from collections import namedtuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union  # pylint: disable=W
+
+from .base import LookupHandler
+from runway.cfngin.exceptions import OutputDoesNotExist
+
+# python2 supported pylint sees this is cyclic even though its only for type checking
+# pylint: disable=cyclic-import
+if TYPE_CHECKING:
+    from runway.context import Context as RunwayContext  # noqa: F401 pylint: disable=W
+    from runway.cfngin.context import Context as CFNginContext  # noqa: F401 pylint: disable=W
+    from runway.cfngin.providers.aws.default import Provider
+
+LOGGER = logging.getLogger(__name__)
+TYPE_NAME = "cfn"
+
+OutputQuery = namedtuple('OutputQuery', ('stack_name', 'output_name'))
+OutputQuery.__doc__ = """Named tuple representing the query for a Stack output.
+
+Attrs:
+    stack_name (str): CloudFormation Stack name.
+    output_name (str): CloudFormation Stack output name.
+
+"""
+
+
+class CfnLookup(LookupHandler):
+    """CloudFormation Stack output lookup."""
+
+    @staticmethod
+    def should_use_provider(args, provider):
+        # type: (Dict[str, str], Optional['Provider']) -> bool
+        """Determine if the provider should be used for the lookup."""
+        if provider:
+            if args.get('region') and provider.region != args['region']:
+                LOGGER.debug('not using provider; requested region does not match')
+                return False
+            LOGGER.debug('using provider')
+            return True
+        return False
+
+    @staticmethod
+    def get_stack_output(client, query):
+        """Get CloudFormation Stack output.
+
+        Args:
+            client: Boto3 CloudFormation client.
+            query: What to get.
+
+        Returns:
+            str: Value of the requested output.
+
+        Raises:
+            OutputDoesNotExist: Output could not be found on the Stack.
+
+        """
+        stack = client.describe_stacks(StackName=query.stack_name)['Stacks'][0]
+        outputs = {
+            output['OutputKey']: output['OutputValue']
+            for output in stack.get('Outputs', [])
+        }
+        LOGGER.debug('stack outputs:\n%s', json.dumps(outputs))
+        return outputs[query.output_name]
+
+    @classmethod
+    def handle(cls,
+               value,  # type: str
+               context,  # type: Union['CFNginContext', 'RunwayContext']
+               provider=None,  # type: Optional['Provider']
+               **_  # type: Any
+               ):
+        # type: (...) -> Any
+        """Retrieve a value from CloudFormation Stack outputs.
+
+        Args:
+            value: The value passed to the Lookup.
+            context: The current context object.
+            provider: AWS provider.
+
+        """
+        raw_query, args = cls.parse(value)
+        try:
+            query = OutputQuery(*raw_query.split('.'))
+        except ValueError:
+            raise ValueError(
+                'query must be <stack-name>.<output-name>; got ' + raw_query
+            )
+
+        try:
+            if cls.should_use_provider(args, provider):
+                result = provider.get_output(query.stack_name, query.output_name)
+            else:
+                cfn_client = context.get_session(region=args.get('region')) \
+                    .client('cloudformation')
+                result = cls.get_stack_output(cfn_client, query)
+        except KeyError:
+            if 'default' in args:
+                args.pop('load')  # don't load a default value
+                result = args.pop('default')
+            else:
+                raise OutputDoesNotExist(query.stack_name, query.output_name)
+        return cls.format_results(result, **args)

--- a/runway/lookups/handlers/ssm.py
+++ b/runway/lookups/handlers/ssm.py
@@ -14,7 +14,7 @@ Parameters of type ``StringList`` are returned as a list.
 This Lookup supports all :ref:`Common Lookup Arguments`.
 
 
-.. Example
+.. rubric:: Example
 .. code-block:: yaml
 
   deployment:

--- a/runway/lookups/handlers/var.py
+++ b/runway/lookups/handlers/var.py
@@ -20,7 +20,7 @@ limited or no effect:
 - region
 
 
-.. Example
+.. rubric:: Example
 .. code-block:: yaml
 
   deployment:

--- a/runway/lookups/registry.py
+++ b/runway/lookups/registry.py
@@ -5,7 +5,7 @@ from six import string_types
 
 from runway.util import load_object_from_string
 
-from .handlers import env, ssm, var
+from .handlers import cfn, env, ssm, var
 from .handlers.base import LookupHandler  # noqa: F401 pylint: disable=W
 
 RUNWAY_LOOKUP_HANDLERS = {}
@@ -40,6 +40,7 @@ def unregister_lookup_handler(lookup_type):
     RUNWAY_LOOKUP_HANDLERS.pop(lookup_type, None)
 
 
+register_lookup_handler(cfn.TYPE_NAME, cfn.CfnLookup)
 register_lookup_handler(env.TYPE_NAME, env.EnvLookup)
 register_lookup_handler(ssm.TYPE_NAME, ssm.SsmLookup)
 register_lookup_handler(var.TYPE_NAME, var.VarLookup)

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -480,6 +480,10 @@ class TerraformBackendConfig(ModuleOptions):
             Dict[str, str]: Resolved values from Cloudformation.
 
         """
+        LOGGER.warning(
+            'terraform_backend_cfn_outputs option has been deprecated; '
+            'use terraform_backend_config with a cfn Lookup'
+        )
         if not kwargs:
             return {}
 
@@ -510,7 +514,7 @@ class TerraformBackendConfig(ModuleOptions):
         """
         LOGGER.warning(
             'terraform_backend_ssm_params option has been deprecated; '
-            'use terraform_backend_config with an ssm lookup'
+            'use terraform_backend_config with an ssm Lookup'
         )
         return {key: client.get_parameter(Name=val, WithDecryption=True)
                      ['Parameter']['Value']  # noqa

--- a/tests/unit/lookups/handlers/test_cfn.py
+++ b/tests/unit/lookups/handlers/test_cfn.py
@@ -1,0 +1,317 @@
+"""Test runway.lookups.handlers.cfn."""
+# pylint: disable=no-self-use
+import json
+import logging
+from datetime import datetime
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+from mock import MagicMock, patch
+
+from runway.cfngin.exceptions import StackDoesNotExist, OutputDoesNotExist
+from runway.lookups.handlers.cfn import TYPE_NAME, CfnLookup, OutputQuery
+
+
+def generate_describe_stacks_stack(stack_name,
+                                   outputs,
+                                   creation_time=None,
+                                   stack_status="CREATE_COMPLETE"
+                                   ):
+    """Generate describe stacks stack.
+
+    Args:
+        stack_name (str): Name of the stack.
+        outputs (Dict[str, str]): Dictionary to be converted to stack outputs.
+        creation_time (Optional[datetime.datetime]): Stack creation time.
+        stack_status (str): Current stack status.
+
+    Returns:
+        Dict[str, Any]: Mock describe stacks['Stacks'] list item.
+
+    """
+    return {
+        "StackName": stack_name,
+        "StackId": stack_name,
+        "CreationTime": creation_time or datetime(2015, 1, 1),
+        "StackStatus": stack_status,
+        "Tags": [],
+        "EnableTerminationProtection": False,
+        "Outputs": [
+            {
+                'OutputKey': k,
+                'OutputValue': v,
+                'Description': 'test output'
+            } for k, v in outputs.items()
+        ]
+    }
+
+
+def setup_cfn_client():
+    """Create a CloudFormation client & Stubber.
+
+    Returns:
+        client, Stubber: CloudFormation client and Stubber.
+
+    """
+    client = boto3.client('cloudformation')
+    return client, Stubber(client)
+
+
+class TestCfnLookup(object):
+    """Test runway.lookups.handlers.cfn.CfnLookup."""
+
+    @patch.object(CfnLookup, 'format_results')
+    @patch.object(CfnLookup, 'parse')
+    @patch.object(CfnLookup, 'get_stack_output')
+    @patch.object(CfnLookup, 'should_use_provider')
+    def test_handle(self, mock_should_use, mock_get_stack_output,
+                    mock_parse, mock_format_results):
+        """Test handle."""
+        mock_should_use.side_effect = [True, False]
+        mock_format_results.return_value = 'success'
+        mock_context = MagicMock(name='context')
+        mock_get_stack_output.return_value = 'cls.success'
+        mock_session = MagicMock(name='session')
+        mock_context.get_session.return_value = mock_session
+        mock_session.client.return_value = mock_session
+        mock_provider = MagicMock(name='provider')
+        mock_provider.get_output.return_value = 'provider.success'
+
+        raw_query = 'test-stack.output1'
+        query = OutputQuery(*raw_query.split('.'))
+        region = 'us-west-2'
+        args = '::region={region}'.format(region=region)
+        value = raw_query + args
+        mock_parse.return_value = (raw_query, {'region': region})
+
+        # test happy path when used from CFNgin (provider)
+        assert CfnLookup.handle(
+            value, context=mock_context, provider=mock_provider
+        ) == 'success'
+        mock_parse.assert_called_once_with(value)
+        mock_provider.get_output.assert_called_once_with(*query)
+        mock_should_use.assert_called_once_with(
+            {'region': region}, mock_provider
+        )
+        mock_format_results.assert_called_once_with(
+            'provider.success', region=region
+        )
+        mock_context.get_session.assert_not_called()
+        mock_get_stack_output.assert_not_called()
+
+        # test happy path when use from runway (no provider)
+        assert CfnLookup.handle(
+            value, context=mock_context
+        ) == 'success'
+        mock_should_use.assert_called_with(
+            {'region': region}, None
+        )
+        mock_context.get_session.assert_called_once_with(region=region)
+        mock_session.client.assert_called_once_with('cloudformation')
+        mock_get_stack_output.assert_called_once_with(mock_session, query)
+        mock_format_results.assert_called_with(
+            'cls.success', region=region
+        )
+
+    @pytest.mark.parametrize('exception, default', [
+        (ClientError({}, 'something'), None),
+        (ClientError({}, 'something'), 'something'),
+        (KeyError, None),
+        (KeyError, 'something')
+    ])
+    @patch.object(CfnLookup, 'should_use_provider')
+    def test_handle_exception(self, mock_should_use, exception, default,
+                              caplog, monkeypatch):
+        """Test handle cls.get_stack_output raise exception."""
+        caplog.set_level(logging.DEBUG, logger='runway.lookups.handlers.cfn')
+        mock_context = MagicMock(name='context')
+        mock_session = MagicMock(name='session')
+        mock_context.get_session.return_value = mock_session
+        mock_session.client.return_value = mock_session
+        mock_should_use.return_value = False
+        monkeypatch.setattr(CfnLookup, 'get_stack_output', MagicMock())
+        CfnLookup.get_stack_output.side_effect = exception
+
+        raw_query = 'test-stack.output1'
+        query = OutputQuery(*raw_query.split('.'))
+
+        if default:
+            assert CfnLookup.handle(
+                raw_query + '::default=' + default, mock_context
+            ) == default
+            mock_should_use.assert_called_once_with(
+                {'default': default}, None
+            )
+            assert (
+                'unable to resolve lookup for CloudFormation Stack output '
+                '"{}"; using default'.format(raw_query)
+            ) in caplog.messages
+        else:
+            if isinstance(exception, (ClientError, StackDoesNotExist)):
+                with pytest.raises(exception.__class__):
+                    assert not CfnLookup.handle(raw_query, mock_context)
+            else:
+                with pytest.raises(OutputDoesNotExist) as excinfo:
+                    assert not CfnLookup.handle(raw_query, mock_context)
+                assert excinfo.value.stack_name == 'test-stack'
+                assert excinfo.value.output == 'output1'
+            mock_should_use.assert_called_once_with({}, None)
+
+        mock_context.get_session.assert_called_once()
+        mock_session.client.assert_called_once_with('cloudformation')
+        CfnLookup.get_stack_output.assert_called_once_with(mock_session, query)
+
+    @pytest.mark.parametrize('exception, default', [
+        (ClientError({}, 'something'), None),
+        (ClientError({}, 'something'), 'something'),
+        (KeyError, None),
+        (KeyError, 'something'),
+        (StackDoesNotExist('test-stack', 'output1'), None),
+        (StackDoesNotExist('test-stack', 'output1'), 'something')
+    ])
+    @patch.object(CfnLookup, 'should_use_provider')
+    def test_handle_provider_exception(self, mock_should_use,
+                                       exception, default, caplog):
+        """Test handle provider raise exception."""
+        caplog.set_level(logging.DEBUG, logger='runway.lookups.handlers.cfn')
+        mock_should_use.return_value = True
+        mock_provider = MagicMock(region='us-east-1')
+        mock_provider.get_output.side_effect = exception
+        raw_query = 'test-stack.output1'
+
+        if default:
+            assert CfnLookup.handle(
+                raw_query + '::default=' + default,
+                context=None,
+                provider=mock_provider
+            ) == default
+            mock_should_use.assert_called_once_with({'default': default}, mock_provider)
+            assert (
+                'unable to resolve lookup for CloudFormation Stack output '
+                '"{}"; using default'.format(raw_query)
+            ) in caplog.messages
+        else:
+            if isinstance(exception, (ClientError, StackDoesNotExist)):
+                with pytest.raises(exception.__class__):
+                    assert not CfnLookup.handle(
+                        raw_query, context=None, provider=mock_provider
+                    )
+            else:
+                with pytest.raises(OutputDoesNotExist) as excinfo:
+                    assert not CfnLookup.handle(
+                        raw_query, context=None, provider=mock_provider
+                    )
+                assert excinfo.value.stack_name == 'test-stack'
+                assert excinfo.value.output == 'output1'
+            mock_should_use.assert_called_once_with({}, mock_provider)
+        mock_provider.get_output.assert_called_once_with('test-stack', 'output1')
+
+    def test_handle_valueerror(self):
+        """Test handle raising ValueError."""
+        with pytest.raises(ValueError) as excinfo:
+            assert CfnLookup.handle('something', None)
+        assert str(excinfo.value) == \
+            'query must be <stack-name>.<output-name>; got "something"'
+
+    def test_get_stack_output(self, caplog):
+        """Test get_stack_output."""
+        caplog.set_level(logging.DEBUG, logger='runway.lookups.handlers.cfn')
+        client, stubber = setup_cfn_client()
+        stack_name = 'test-stack'
+        outputs = {'output1': 'val1', 'output2': 'val2'}
+        query = OutputQuery(stack_name, 'output1')
+
+        stubber.add_response(
+            'describe_stacks',
+            {'Stacks': [generate_describe_stacks_stack(stack_name, outputs)]},
+            {'StackName': stack_name}
+        )
+
+        with stubber:
+            assert CfnLookup.get_stack_output(client, query) == 'val1'
+
+        stubber.assert_no_pending_responses()
+        assert 'describing stack: %s' % stack_name in caplog.messages
+        assert '{} stack outputs: {}'.format(
+            stack_name, json.dumps(outputs)
+        ) in caplog.messages
+
+    def test_get_stack_output_clienterror(self, caplog):
+        """Test get_stack_output raising ClientError."""
+        caplog.set_level(logging.DEBUG, logger='runway.lookups.handlers.cfn')
+        client, stubber = setup_cfn_client()
+        stack_name = 'test-stack'
+        query = OutputQuery(stack_name, 'output1')
+
+        stubber.add_client_error(
+            'describe_stacks',
+            service_error_code='ValidationError',
+            service_message='Stack %s does not exist' % stack_name,
+            expected_params={'StackName': stack_name}
+        )
+
+        with stubber, pytest.raises(ClientError):
+            assert CfnLookup.get_stack_output(client, query)
+
+        stubber.assert_no_pending_responses()
+        assert 'describing stack: %s' % stack_name in caplog.messages
+
+    def test_get_stack_output_keyerror(self, caplog):
+        """Test get_stack_output raising KeyError."""
+        caplog.set_level(logging.DEBUG, logger='runway.lookups.handlers.cfn')
+        client, stubber = setup_cfn_client()
+        stack_name = 'test-stack'
+        outputs = {'output2': 'val2'}
+        query = OutputQuery(stack_name, 'output1')
+
+        stubber.add_response(
+            'describe_stacks',
+            {'Stacks': [generate_describe_stacks_stack(stack_name, outputs)]},
+            {'StackName': stack_name}
+        )
+
+        with stubber, pytest.raises(KeyError):
+            assert CfnLookup.get_stack_output(client, query)
+
+        stubber.assert_no_pending_responses()
+        assert 'describing stack: %s' % stack_name in caplog.messages
+        assert '{} stack outputs: {}'.format(
+            stack_name, json.dumps(outputs)
+        ) in caplog.messages
+
+    @pytest.mark.parametrize('args, provider', [
+        ({}, None),
+        ({'region': 'us-west-2'}, MagicMock(region='us-east-1'))
+    ])
+    def test_should_use_provider_falsy(self, args, provider, caplog):
+        """Test should_use_provider with falsy cases."""
+        caplog.set_level(logging.DEBUG, logger='runway.lookups.handlers.cfn')
+        assert not CfnLookup.should_use_provider(args, provider)
+        if provider:
+            assert 'not using provider; requested region does not match' \
+                in caplog.messages
+            assert 'using provider' not in caplog.messages
+
+    @pytest.mark.parametrize('args, provider', [
+        ({}, MagicMock()),
+        ({'region': 'us-east-1'}, MagicMock(region='us-east-1'))
+    ])
+    def test_should_use_provider_truthy(self, args, provider, caplog):
+        """Test should_use_provider with truthy cases."""
+        caplog.set_level(logging.DEBUG, logger='runway.lookups.handlers.cfn')
+        assert CfnLookup.should_use_provider(args, provider)
+        assert 'using provider' in caplog.messages
+
+
+def test_outputquery():
+    """Test OutputQuery."""
+    result = OutputQuery('stack_name', 'output_name')
+    assert result.stack_name == 'stack_name'
+    assert result.output_name == 'output_name'
+
+
+def test_type_name():
+    """Test runway.lookups.handlers.cfn.TYPE_NAME."""
+    assert TYPE_NAME == 'cfn'

--- a/tests/unit/lookups/handlers/test_cfn.py
+++ b/tests/unit/lookups/handlers/test_cfn.py
@@ -10,7 +10,7 @@ from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 from mock import MagicMock, patch
 
-from runway.cfngin.exceptions import StackDoesNotExist, OutputDoesNotExist
+from runway.cfngin.exceptions import OutputDoesNotExist, StackDoesNotExist
 from runway.lookups.handlers.cfn import TYPE_NAME, CfnLookup, OutputQuery
 
 

--- a/tests/unit/lookups/test_registry.py
+++ b/tests/unit/lookups/test_registry.py
@@ -24,6 +24,7 @@ class TestCommonLookupFunctionality(object):
     def test_handle_default(self, runway_context):
         """Verify default value is handled by lookups."""
         lookup_handlers = RUNWAY_LOOKUP_HANDLERS.copy()
+        lookup_handlers.pop('cfn')  # requires special testing
         lookup_handlers.pop('ssm')  # requires special testing
         for _, lookup in lookup_handlers.items():
             query = 'NOT_VALID::default=default value'
@@ -35,6 +36,7 @@ class TestCommonLookupFunctionality(object):
     def test_handle_transform(self, runway_context):
         """Verify transform is handled by lookup."""
         lookup_handlers = RUNWAY_LOOKUP_HANDLERS.copy()
+        lookup_handlers.pop('cfn')  # requires special testing
         lookup_handlers.pop('ssm')  # requires special testing
         runway_context.env_vars.update(VALUES)
 


### PR DESCRIPTION
## Summary

A lookup that can be used to get the value of a CloudFormation Stack Output. This lookup can be used in both the Runway and CFNgin config files.

resolves #319 

## What Changed

### Added

- added the `cfn` Lookup, usable in Runway and CFNgin config files

### Changed

- `terraform_backend_cfn_outputs` option is now deprecated
- `xref` Lookup is now deprecated
- update some docs to comply with the rst format outlined in the developer guide

### Fixed

- fixed some **Example** rubrics that were missing their directive
