### PR TITLE
update env managers to use pathlib & have useful attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- env managers now use pathlib
+- env managers have some new attributes and methods for handling envs (relocated from functions)
 
 ## [1.10.1] - 2020-07-20
 ### Fixed

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -65,13 +65,8 @@ def download_kb_release(version,  # noqa pylint: disable=too-many-locals,too-man
     shutil.move(os.path.join(download_dir, filename),
                 str(version_dir / filename))
     shutil.rmtree(download_dir)
-    os.chmod(  # ensure it is executable
-        os.path.join(version_dir, filename),
-        os.stat(os.path.join(version_dir,
-                             filename)).st_mode | 0o0111
-    )
     result = version_dir / filename
-    result.chmod(result.stat().st_mode | 0o0111)
+    result.chmod(result.stat().st_mode | 0o0111)  # ensure it is executable
 
 
 def get_version_requested(path):

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -10,7 +10,7 @@ import tempfile
 from six.moves.urllib.request import urlretrieve  # pylint: disable=E
 from six.moves.urllib.error import URLError  # pylint: disable=E
 
-from . import EnvManager, ensure_versions_dir_exists, handle_bin_download_error
+from . import EnvManager, handle_bin_download_error
 from ..util import md5sum
 
 LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ RELEASE_URI = 'https://storage.googleapis.com/kubernetes-release/release'
 def download_kb_release(version,  # noqa pylint: disable=too-many-locals,too-many-branches
                         versions_dir, kb_platform=None, arch=None):
     """Download kubectl and return path to it."""
-    version_dir = os.path.join(versions_dir, version)
+    version_dir = versions_dir / version
 
     if arch is None:
         arch = (
@@ -61,46 +61,44 @@ def download_kb_release(version,  # noqa pylint: disable=too-many-locals,too-man
                      filename, kb_hash)
         sys.exit(1)
 
-    os.mkdir(version_dir)
+    version_dir.mkdir(parents=True, exist_ok=True)
     shutil.move(os.path.join(download_dir, filename),
-                os.path.join(version_dir, filename))
+                str(version_dir / filename))
     shutil.rmtree(download_dir)
     os.chmod(  # ensure it is executable
         os.path.join(version_dir, filename),
         os.stat(os.path.join(version_dir,
                              filename)).st_mode | 0o0111
     )
+    result = version_dir / filename
+    result.chmod(result.stat().st_mode | 0o0111)
 
 
 def get_version_requested(path):
     """Return string listing requested kubectl version."""
-    kb_version_path = os.path.join(path,
-                                   KB_VERSION_FILENAME)
-    if not os.path.isfile(kb_version_path):
+    kb_version_path = path / KB_VERSION_FILENAME
+    if not kb_version_path.is_file():
         LOGGER.error('kubectl install attempted and no %s file present to '
                      'dictate the version; please create it. (e.g. write '
                      '"1.14.0", without quotes, to the file and try again)',
                      KB_VERSION_FILENAME)
         sys.exit(1)
-    with open(kb_version_path, 'r') as stream:
-        ver = stream.read().rstrip()
-    return ver
+    return kb_version_path.read_text().strip()
 
 
 class KBEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
     """kubectl version management.
 
-    Designed to be compatible with https://github.com/alexppg/kbenv .
+    Designed to be compatible with https://github.com/alexppg/kbenv.
+
     """
 
     def __init__(self, path=None):
         """Initialize class."""
-        super(KBEnvManager, self).__init__('kbenv', path)
+        super(KBEnvManager, self).__init__('kubectl', 'kbenv', path)
 
     def install(self, version_requested=None):
         """Ensure kubectl is available."""
-        versions_dir = ensure_versions_dir_exists(self.env_dir)
-
         if not version_requested:
             version_requested = get_version_requested(self.path)
 
@@ -109,18 +107,15 @@ class KBEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
 
         # Return early (i.e before reaching out to the internet) if the
         # matching version is already installed
-        if os.path.isdir(os.path.join(versions_dir,
-                                      version_requested)):
+        if (self.versions_dir / version_requested).is_dir():
             LOGGER.verbose("kubectl version %s already installed; using "
                            "it...", version_requested)
-            return os.path.join(versions_dir,
-                                version_requested,
-                                'kubectl') + self.command_suffix
+            self.current_version = version_requested
+            return str(self.bin)
 
         LOGGER.info("downloading and using kubectl version %s ...",
                     version_requested)
-        download_kb_release(version_requested, versions_dir)
+        download_kb_release(version_requested, self.versions_dir)
         LOGGER.verbose("downloaded kubectl %s successfully", version_requested)
-        return os.path.join(versions_dir,
-                            version_requested,
-                            'kubectl') + self.command_suffix
+        self.current_version = version_requested
+        return str(self.bin)

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -76,7 +76,7 @@ def download_tf_release(version,  # noqa pylint: disable=too-many-locals,too-man
     tf_zipfile.close()
     shutil.rmtree(download_dir)
     result = version_dir / ('terraform' + command_suffix)
-    result.chmod(result.stat().st_mode | 0o0111)
+    result.chmod(result.stat().st_mode | 0o0111)  # ensure it is executable
 
 
 def get_available_tf_versions(include_prerelease=False):
@@ -188,8 +188,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
 
         # Now that a version has been selected, skip downloading if it's
         # already been downloaded
-        if os.path.isdir(os.path.join(self.versions_dir,
-                                      version)):
+        if (self.versions_dir / version).is_dir():
             LOGGER.verbose("Terraform version %s already installed; using it...",
                            version)
             self.current_version = version

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -115,6 +115,18 @@ def patch_time(monkeypatch):
     monkeypatch.setattr('time.sleep', lambda s: None)
 
 
+@pytest.fixture
+def platform_darwin(monkeypatch):
+    """Patch platform.system to always return "Darwin"."""
+    monkeypatch.setattr('platform.system', lambda: 'Darwin')
+
+
+@pytest.fixture
+def platform_windows(monkeypatch):
+    """Patch platform.system to always return "Windows"."""
+    monkeypatch.setattr('platform.system', lambda: 'Windows')
+
+
 @pytest.fixture(scope='function')
 def patch_runway_config(request, monkeypatch, runway_config):
     """Patch Runway config and return a mock config object."""

--- a/tests/unit/env_mgr/__init__.py
+++ b/tests/unit/env_mgr/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/unit/env_mgr/test_env_mgr.py
+++ b/tests/unit/env_mgr/test_env_mgr.py
@@ -1,5 +1,7 @@
 """Test runway.env_mgr."""
 # pylint: disable=no-self-use,unused-argument
+from mock import MagicMock
+
 from runway.env_mgr import EnvManager
 
 
@@ -9,7 +11,8 @@ class TestEnvManager(object):
     def test_bin(self, platform_darwin, cd_tmp_path, monkeypatch):
         """Test bin."""
         home = cd_tmp_path / 'home'
-        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.setattr('runway.env_mgr.Path.home',
+                            MagicMock(return_value=home))
         obj = EnvManager('test-bin', 'test-dir')
         obj.current_version = '1.0.0'
 
@@ -18,7 +21,8 @@ class TestEnvManager(object):
     def test_darwin(self, platform_darwin, cd_tmp_path, monkeypatch):
         """Test init on Darwin platform."""
         home = cd_tmp_path / 'home'
-        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.setattr('runway.env_mgr.Path.home',
+                            MagicMock(return_value=home))
         obj = EnvManager('test-bin', 'test-dir')
 
         assert not obj.current_version
@@ -36,7 +40,8 @@ class TestEnvManager(object):
     def test_windows(self, platform_windows, cd_tmp_path, monkeypatch):
         """Test init on Windows platform."""
         home = cd_tmp_path / 'home'
-        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.setattr('runway.env_mgr.Path.home',
+                            MagicMock(return_value=home))
         monkeypatch.delenv('APPDATA', raising=False)
         obj = EnvManager('test-bin', 'test-dir')
 

--- a/tests/unit/env_mgr/test_env_mgr.py
+++ b/tests/unit/env_mgr/test_env_mgr.py
@@ -1,0 +1,62 @@
+"""Test runway.env_mgr."""
+# pylint: disable=no-self-use,unused-argument
+from runway.env_mgr import EnvManager
+
+
+class TestEnvManager(object):
+    """Test runway.env_mgr.EnvManager."""
+
+    def test_bin(self, platform_darwin, cd_tmp_path, monkeypatch):
+        """Test bin."""
+        home = cd_tmp_path / 'home'
+        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        obj = EnvManager('test-bin', 'test-dir')
+        obj.current_version = '1.0.0'
+
+        assert obj.bin == home / '.test-dir' / 'versions' / '1.0.0' / 'test-bin'
+
+    def test_darwin(self, platform_darwin, cd_tmp_path, monkeypatch):
+        """Test init on Darwin platform."""
+        home = cd_tmp_path / 'home'
+        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        obj = EnvManager('test-bin', 'test-dir')
+
+        assert not obj.current_version
+        assert obj.command_suffix == ''
+        assert obj.env_dir_name == '.test-dir'
+        assert obj.env_dir == home / '.test-dir'
+        assert obj.versions_dir == home / '.test-dir' / 'versions'
+
+    def test_path(self, cd_tmp_path):
+        """Test how path attribute is set."""
+        assert EnvManager('', '', path=str(cd_tmp_path)).path == cd_tmp_path
+        assert EnvManager('', '', path=cd_tmp_path).path == cd_tmp_path
+        assert EnvManager('', '').path == cd_tmp_path
+
+    def test_windows(self, platform_windows, cd_tmp_path, monkeypatch):
+        """Test init on Windows platform."""
+        home = cd_tmp_path / 'home'
+        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.delenv('APPDATA', raising=False)
+        obj = EnvManager('test-bin', 'test-dir')
+
+        expected_env_dir = home / 'AppData' / 'Roaming' / 'test-dir'
+
+        assert not obj.current_version
+        assert obj.command_suffix == '.exe'
+        assert obj.env_dir_name == 'test-dir'
+        assert obj.env_dir == expected_env_dir
+        assert obj.versions_dir == expected_env_dir / 'versions'
+
+    def test_windows_appdata(self, platform_windows, cd_tmp_path, monkeypatch):
+        """Test init on Windows platform."""
+        monkeypatch.setenv('APPDATA', str(cd_tmp_path / 'custom_path'))
+        obj = EnvManager('test-bin', 'test-dir')
+
+        expected_env_dir = cd_tmp_path / 'custom_path' / 'test-dir'
+
+        assert not obj.current_version
+        assert obj.command_suffix == '.exe'
+        assert obj.env_dir_name == 'test-dir'
+        assert obj.env_dir == expected_env_dir
+        assert obj.versions_dir == expected_env_dir / 'versions'


### PR DESCRIPTION
## Why This Is Needed

pathlib provides easier manipulation of the file system.

env managers now has attributes for getting the binary path and current version number instead of needing to parse the return value of `.install()` to extract the information since it has already been parsed by the env manager then joined for the return. I need the current version of Terraform selected for another feature being worked on. Updating this to be more useful made more sense than parsing the return value again.

## What Changed

### Added

- added attributes to the `EnvManager` base class for getting the binary path as a path object and the current version number

### Changed

- `EnvManager` and it's subclasses now use `pathlib` for file/path manipulation instead of `os`
- moved function logic from `runway.env_mgr.__init__.py` into the `EnvManager` base class for ease of use
