### PR TITLE
update env_mgr to use pathlib, added some attrs and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- env managers now use pathlib
+- env managers have some new attributes and methods for handling envs (relocated from functions)
 
 ## [1.10.1] - 2020-07-20
 ### Fixed

--- a/docs/source/terraform/advanced_features.rst
+++ b/docs/source/terraform/advanced_features.rst
@@ -27,7 +27,20 @@ If your Terraform will only ever be used with a single backend, it can be define
   }
 
 However, it's generally preferable to separate the backend configuration out from the rest of the Terraform code.
-Choose from one of the following options.
+This form of configuration is known as `partial configuration`_ and allows for dynamic or secret values to be passed in at runtime.
+
+Below are examples of how to implement `partial configuration`_ with Runway.
+All examples provided showcase the use of the s3 backend type as it is the easiest to use when going from zero to deployed (try :ref:`runway gen-sample cfngin <command-gen-sample>` for quickstart Terraform backend infrastructure).
+However, Runway supports the use of any `backend type <https://www.terraform.io/docs/backends/types/index.html>`__ (refer to Terraform's documentation for proper `partial configuration`_ instructions).
+
+.. seealso::
+  https://www.terraform.io/docs/backends/config.html#partial-configuration
+    Terraform partial configuration
+
+  https://www.terraform.io/docs/backends/types/index.html
+    Terraform backend types
+
+.. _partial configuration: https://www.terraform.io/docs/backends/config.html#partial-configuration
 
 
 Backend Config File

--- a/runway/_cli/commands/_tfenv/_install.py
+++ b/runway/_cli/commands/_tfenv/_install.py
@@ -1,11 +1,13 @@
 """Install a version of Terraform."""
 # docs: file://./../../../../docs/source/commands.rst
 import logging
+import sys
 from typing import Any  # pylint: disable=W
 
 import click
 
 from ....env_mgr.tfenv import TFEnvManager
+from ....util import DOC_SITE
 from ... import options
 
 LOGGER = logging.getLogger(__name__.replace('._', '.'))
@@ -25,5 +27,23 @@ def install(version, **_):
     exist, nothing will be installed.
 
     """
-    LOGGER.debug('terraform path: %s',
-                 TFEnvManager().install(version_requested=version))
+    try:
+        LOGGER.debug('terraform path: %s',
+                     TFEnvManager().install(version_requested=version))
+    except ValueError as err:
+        LOGGER.debug('terraform install failed', exc_info=True)
+        if 'unable to find' not in str(err):
+            LOGGER.error(
+                'unexpected error encountered when trying to install '
+                'Terraform',
+                exc_info=True
+            )
+            sys.exit(1)
+        else:
+            LOGGER.error('unable to find a .terraform-version file')
+            LOGGER.error(
+                'learn how to use Runway to manage Terraform versions at '
+                '%s/page/terraform/advanced_features.html#version-management',
+                DOC_SITE
+            )
+        sys.exit(1)

--- a/runway/_cli/commands/_tfenv/_run.py
+++ b/runway/_cli/commands/_tfenv/_run.py
@@ -7,6 +7,7 @@ from typing import Any, Tuple  # noqa pylint: disable=W
 import click
 
 from ....env_mgr.tfenv import TFEnvManager
+from ....util import DOC_SITE
 from ... import options
 
 LOGGER = logging.getLogger(__name__.replace('._', '.'))
@@ -30,4 +31,22 @@ def run(ctx, args, **_):
     before the Terraform command.
 
     """
-    ctx.exit(subprocess.call([TFEnvManager().install()] + list(args)))
+    try:
+        ctx.exit(subprocess.call([TFEnvManager().install()] + list(args)))
+    except ValueError as err:
+        LOGGER.debug('terraform install failed', exc_info=True)
+        if 'unable to find' not in str(err):
+            LOGGER.error(
+                'unexpected error encountered when trying to install '
+                'Terraform',
+                exc_info=True
+            )
+            ctx.exit(1)
+        else:
+            LOGGER.error('unable to find a .terraform-version file')
+            LOGGER.error(
+                'learn how to use Runway to manage Terraform versions at '
+                '%s/page/terraform/advanced_features.html#version-management',
+                DOC_SITE
+            )
+        ctx.exit(1)

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -65,13 +65,8 @@ def download_kb_release(version,  # noqa pylint: disable=too-many-locals,too-man
     shutil.move(os.path.join(download_dir, filename),
                 str(version_dir / filename))
     shutil.rmtree(download_dir)
-    os.chmod(  # ensure it is executable
-        os.path.join(version_dir, filename),
-        os.stat(os.path.join(version_dir,
-                             filename)).st_mode | 0o0111
-    )
     result = version_dir / filename
-    result.chmod(result.stat().st_mode | 0o0111)
+    result.chmod(result.stat().st_mode | 0o0111)  # ensure it is executable
 
 
 def get_version_requested(path):

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -10,7 +10,7 @@ import tempfile
 from six.moves.urllib.request import urlretrieve  # pylint: disable=E
 from six.moves.urllib.error import URLError  # pylint: disable=E
 
-from . import EnvManager, ensure_versions_dir_exists, handle_bin_download_error
+from . import EnvManager, handle_bin_download_error
 from ..util import md5sum
 
 LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ RELEASE_URI = 'https://storage.googleapis.com/kubernetes-release/release'
 def download_kb_release(version,  # noqa pylint: disable=too-many-locals,too-many-branches
                         versions_dir, kb_platform=None, arch=None):
     """Download kubectl and return path to it."""
-    version_dir = os.path.join(versions_dir, version)
+    version_dir = versions_dir / version
 
     if arch is None:
         arch = (
@@ -61,46 +61,44 @@ def download_kb_release(version,  # noqa pylint: disable=too-many-locals,too-man
                      filename, kb_hash)
         sys.exit(1)
 
-    os.mkdir(version_dir)
+    version_dir.mkdir(parents=True, exist_ok=True)
     shutil.move(os.path.join(download_dir, filename),
-                os.path.join(version_dir, filename))
+                str(version_dir / filename))
     shutil.rmtree(download_dir)
     os.chmod(  # ensure it is executable
         os.path.join(version_dir, filename),
         os.stat(os.path.join(version_dir,
                              filename)).st_mode | 0o0111
     )
+    result = version_dir / filename
+    result.chmod(result.stat().st_mode | 0o0111)
 
 
 def get_version_requested(path):
     """Return string listing requested kubectl version."""
-    kb_version_path = os.path.join(path,
-                                   KB_VERSION_FILENAME)
-    if not os.path.isfile(kb_version_path):
+    kb_version_path = path / KB_VERSION_FILENAME
+    if not kb_version_path.is_file():
         LOGGER.error('kubectl install attempted and no %s file present to '
                      'dictate the version; please create it. (e.g. write '
                      '"1.14.0", without quotes, to the file and try again)',
                      KB_VERSION_FILENAME)
         sys.exit(1)
-    with open(kb_version_path, 'r') as stream:
-        ver = stream.read().rstrip()
-    return ver
+    return kb_version_path.read_text().strip()
 
 
 class KBEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
     """kubectl version management.
 
-    Designed to be compatible with https://github.com/alexppg/kbenv .
+    Designed to be compatible with https://github.com/alexppg/kbenv.
+
     """
 
     def __init__(self, path=None):
         """Initialize class."""
-        super(KBEnvManager, self).__init__('kbenv', path)
+        super(KBEnvManager, self).__init__('kubectl', 'kbenv', path)
 
     def install(self, version_requested=None):
         """Ensure kubectl is available."""
-        versions_dir = ensure_versions_dir_exists(self.env_dir)
-
         if not version_requested:
             version_requested = get_version_requested(self.path)
 
@@ -109,18 +107,15 @@ class KBEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
 
         # Return early (i.e before reaching out to the internet) if the
         # matching version is already installed
-        if os.path.isdir(os.path.join(versions_dir,
-                                      version_requested)):
+        if (self.versions_dir / version_requested).is_dir():
             LOGGER.verbose("kubectl version %s already installed; using "
                            "it...", version_requested)
-            return os.path.join(versions_dir,
-                                version_requested,
-                                'kubectl') + self.command_suffix
+            self.current_version = version_requested
+            return str(self.bin)
 
         LOGGER.info("downloading and using kubectl version %s ...",
                     version_requested)
-        download_kb_release(version_requested, versions_dir)
+        download_kb_release(version_requested, self.versions_dir)
         LOGGER.verbose("downloaded kubectl %s successfully", version_requested)
-        return os.path.join(versions_dir,
-                            version_requested,
-                            'kubectl') + self.command_suffix
+        self.current_version = version_requested
+        return str(self.bin)

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -76,7 +76,7 @@ def download_tf_release(version,  # noqa pylint: disable=too-many-locals,too-man
     tf_zipfile.close()
     shutil.rmtree(download_dir)
     result = version_dir / ('terraform' + command_suffix)
-    result.chmod(result.stat().st_mode | 0o0111)
+    result.chmod(result.stat().st_mode | 0o0111)  # ensure it is executable
 
 
 def get_available_tf_versions(include_prerelease=False):
@@ -188,8 +188,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
 
         # Now that a version has been selected, skip downloading if it's
         # already been downloaded
-        if os.path.isdir(os.path.join(self.versions_dir,
-                                      version)):
+        if (self.versions_dir / version).is_dir():
             LOGGER.verbose("Terraform version %s already installed; using it...",
                            version)
             self.current_version = version

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -1,6 +1,4 @@
 """Terraform version management."""
-from distutils.version import LooseVersion  # noqa pylint: disable=import-error,no-name-in-module
-import glob
 import json
 import logging
 import os
@@ -10,15 +8,18 @@ import shutil
 import sys
 import tempfile
 import zipfile
+from distutils.version import \
+    LooseVersion  # noqa pylint: disable=import-error,no-name-in-module
 
-import hcl
 import requests
 # Old pylint on py2.7 incorrectly flags these
-from six.moves.urllib.request import urlretrieve  # pylint: disable=E
 from six.moves.urllib.error import URLError  # pylint: disable=E
+from six.moves.urllib.request import urlretrieve  # pylint: disable=E
 
+import hcl
+
+from ..util import cached_property, get_hash_for_filename, sha256sum
 from . import EnvManager, handle_bin_download_error
-from ..util import get_hash_for_filename, sha256sum
 
 LOGGER = logging.getLogger(__name__)
 TF_VERSION_FILENAME = '.terraform-version'
@@ -98,35 +99,6 @@ def get_latest_tf_version(include_prerelease=False):
     return get_available_tf_versions(include_prerelease)[0]
 
 
-def find_min_required(path):
-    """Inspect terraform files and find minimum version."""
-    found_min_required = ''
-    for filename in glob.glob(os.path.join(path, '*.tf')):
-        with open(filename, 'r') as stream:
-            tf_config = hcl.load(stream)
-            if tf_config.get('terraform', {}).get('required_version'):
-                found_min_required = tf_config.get('terraform',
-                                                   {}).get('required_version')
-                break
-
-    if found_min_required:
-        if re.match(r'^!=.+', found_min_required):
-            LOGGER.error('min required Terraform version is a negation (%s) '
-                         '- unable to determine required version',
-                         found_min_required)
-            sys.exit(1)
-        else:
-            found_min_required = re.search(r'[0-9]*\.[0-9]*(?:\.[0-9]*)?',
-                                           found_min_required).group(0)
-            LOGGER.debug("detected minimum Terraform version is %s",
-                         found_min_required)
-            return found_min_required
-    LOGGER.error('Terraform version specified as min-required, but unable to '
-                 'find a specified version requirement in this module\'s tf '
-                 'files')
-    sys.exit(1)
-
-
 def get_version_requested(path):
     """Return string listing requested Terraform version."""
     tf_version_path = path / TF_VERSION_FILENAME
@@ -150,6 +122,63 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         """Initialize class."""
         super(TFEnvManager, self).__init__('terraform', 'tfenv', path)
 
+    @cached_property
+    def backend(self):
+        """Backend config of the Terraform module.
+
+        Returns:
+            Dict[str, Any]
+
+        """
+        # Terraform can only have one backend configured; this formats the
+        # data to make it easier to work with
+        return [
+            {'type': k, 'config': v}
+            for k, v in self.terraform_block.get('backend', {None: {}}).items()
+        ][0]
+
+    @cached_property
+    def terraform_block(self):
+        """Collect Terraform configuration blocks from a Terraform module.
+
+        Returns:
+            Dict[str, Any]
+
+        """
+        result = {}
+        for tf_file in self.path.glob('*.tf'):
+            tf_config = hcl.loads(tf_file.read_text())
+            result.update(tf_config.get('terraform', {}))
+        LOGGER.debug('parsed Terraform configuration: %s', json.dumps(result))
+        return result
+
+    def get_min_required(self):
+        """Get the defined minimum required version of Terraform.
+
+        Returns:
+            str: The minimum required version as defined in the module.
+
+        """
+        version = self.terraform_block.get('required_version')
+
+        if version:
+            if re.match(r'^!=.+', version):
+                LOGGER.error('min required Terraform version is a negation (%s) '
+                             '- unable to determine required version',
+                             version)
+                sys.exit(1)
+            else:
+                version = re.search(
+                    r'[0-9]*\.[0-9]*(?:\.[0-9]*)?', version
+                ).group(0)
+                LOGGER.debug("detected minimum Terraform version is %s",
+                             version)
+                return version
+        LOGGER.error('Terraform version specified as min-required, but unable to '
+                     'find a specified version requirement in this module\'s tf '
+                     'files')
+        sys.exit(1)
+
     def install(self, version_requested=None):
         """Ensure Terraform is available."""
         if not version_requested:
@@ -157,7 +186,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
 
         if re.match(r'^min-required$', version_requested):
             LOGGER.debug('tfenv: detecting minimal required version')
-            version_requested = find_min_required(str(self.path))
+            version_requested = self.get_min_required()
 
         if re.match(r'^latest:.*$', version_requested):
             regex = re.search(r'latest:(.*)', version_requested).group(1)

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -6,8 +6,8 @@ import subprocess
 import sys
 
 import hcl
+import six
 from send2trash import send2trash
-from six import string_types
 
 from .._logging import PrefixAdaptor
 from ..cfngin.lookups.handlers.output import deconstruct
@@ -102,7 +102,7 @@ class Terraform(RunwayModule):
             except Exception:  # pylint: disable=broad-except
                 self.logger.debug('unable to parse current version',
                                   exc_info=True)
-            file_path.write_text(json.dumps(self.parameters, indent=4))
+            file_path.write_text(six.u(json.dumps(self.parameters, indent=4)))
         return file_path
 
     @cached_property
@@ -547,7 +547,7 @@ class TerraformOptions(ModuleOptions):
     @staticmethod
     def resolve_version(context, terraform_version=None, **_):
         """Resolve terraform_version option."""
-        if not terraform_version or isinstance(terraform_version, string_types):
+        if not terraform_version or isinstance(terraform_version, six.string_types):
             return terraform_version
         if isinstance(terraform_version, dict):
             return terraform_version.get(context.env.name,

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -254,7 +254,7 @@ class Terraform(RunwayModule):
         try:
             self['_%s_backend_handler' % self.tfenv.backend['type']]()
         except AttributeError:
-            self.logger.debug(
+            self.logger.verbose(
                 'backed "%s" does not require special handling',
                 self.tfenv.backend['type'], exc_info=True
             )
@@ -268,24 +268,25 @@ class Terraform(RunwayModule):
             )
             return
 
+        self.logger.verbose(
+            'forcing parameters to be written to runway-parameters.auto.tfvars.json'
+        )
+        # this is because variables cannot be added inline or via environment
+        # variables when using a remote backend
+        self.options.write_auto_tfvars = True
+
         if self.tfenv.backend['config']['workspaces'].get('prefix'):
-            self.logger.debug(
+            self.logger.verbose(
                 'handling use of backend config: remote.workspaces.prefix'
             )
             self.context.env.vars.update({'TF_WORKSPACE': self.context.env.name})
-            self.logger.debug(
+            self.logger.verbose(
                 'set environment variable "TF_WORKSPACE" to avoid prompt '
                 'during init by pre-selecting an appropriate workspace'
             )
-            self.logger.debug(
-                'forcing parameters to be written to an runway-parameters.auto.tfvars'
-            )
-            # this is because variables cannot be added inline or via environment
-            # variables when using a remote backend
-            self.options.write_auto_tfvars = True
 
         if self.tfenv.backend['config']['workspaces'].get('name'):
-            self.logger.debug(
+            self.logger.verbose(
                 'handling use of backend config: remote.workspaces.name'
             )
             # this can't be set or it will cause errors

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -751,7 +751,7 @@ class TerraformBackendConfig(ModuleOptions):
         formats = [
             'backend-{environment}-{region}.{extension}',
             'backend-{environment}.{extension}',
-            'backend*{region}.{extension}',
+            'backend-{region}.{extension}',
             'backend.{extension}'
         ]
         result = []

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -408,60 +408,25 @@ class TerraformBackendConfig(ModuleOptions):
                'terraform_backend_cfn_outputs',
                'terraform_backend_ssm_params']
 
-    def __init__(self, bucket=None, dynamodb_table=None,  # pylint: disable=too-many-arguments
-                 filename=None, region=None, key=None, encrypt=None, acl=None, kms_key_id=None,
-                 role_arn=None, assume_role_policy=None, external_id=None, session_name=None,
-                 workspace_key_prefix=None):
+    def __init__(self, **kwargs):
         """Instantiate class.
 
-        Args:
-            bucket (Optional[str]): S3 bucket name.
-            dynamodb_table (str): DynamoDB table name.
-            filename (Optional[str]): .tfvar file name for backend configuration.
-            region (Optional[str]): AWS region where both the provided DynamoDB table
-                and S3 bucket are located.
-            key (Optional[str]): S3 key suffix (filename) for the state.
-            workspace_key_prefix (Optional[str]): S3 key prefix to the environment.
-            encrypt (Optional[str]): Whether to enable server side encryption of the state file.
-            acl (Optional[str]): Canned ACL to be applied to the state file.
-            kms_key_id (Optional[str]): KMS Key to use for encrypting the state.
-            role_arn (Optional[str]): Role to assume for accessing the state.
-            assume_role_policy (Optional[str]): Permissions applied when assuming the role_arn.
-            external_id (Optional[str]): External ID to use when assuming the role_arn.
-            session_name (Optional[str]): Session name to use when assuming the role_arn.
+        See Terraform documentation for the keyword arguments needed for the
+        desired backend.
+
+        https://www.terraform.io/docs/backends/types/index.html
 
         """
         super(TerraformBackendConfig, self).__init__()
-        self.bucket = bucket
-        self.dynamodb_table = dynamodb_table
-        self.region = region
-        self.key = key
-        self.workspace_key_prefix = workspace_key_prefix
-        self.encrypt = encrypt
-        self.acl = acl
-        self.kms_key_id = kms_key_id
-
-        self.role_arn = role_arn
-        self.assume_role_policy = assume_role_policy
-        self.external_id = external_id
-        self.session_name = session_name
-
-        self.filename = filename
+        self._raw_config = kwargs
 
     @cached_property
     def init_args(self):
         """Return command line arguments for init."""
-        cmd_list = []
-        for key in ('acl', 'assume_role_policy', 'bucket', 'dynamodb_table', 'encrypt',
-                    'external_id', 'key', 'kms_key_id', 'region', 'role_arn', 'session_name',
-                    'workspace_key_prefix'):
-            if self.get(key):
-                cmd_list.append('-backend-config')
-                cmd_list.append(key + '=' + self[key])
-            else:
-                LOGGER.debug("skipping terraform backend config option \"%s\" "
-                             "-- no value provided", key)
-        return cmd_list
+        result = []
+        for k, v in self._raw_config.items():
+            result.extend(['-backend-config', '{}={}'.format(k, v)])
+        return result
 
     @staticmethod
     def resolve_cfn_outputs(client, **kwargs):
@@ -595,7 +560,9 @@ class TerraformBackendConfig(ModuleOptions):
                 client=session.client('ssm'),
                 **kwargs['terraform_backend_ssm_params']))
 
-        if result and not result.get('region'):
+        if result.get('dynamodb_table') and not result.get('region'):
+            # dynamodb_table is the only option exclusive to the s3 backend
+            # that can be used to determine if region should be inserted
             result['region'] = context.env.aws_region
 
         if path:

--- a/tests/integration/cli/commands/test_tfenv.py
+++ b/tests/integration/cli/commands/test_tfenv.py
@@ -37,7 +37,7 @@ def test_tfenv_install_no_version_file(cd_tmp_path, caplog):
     result = runner.invoke(cli, ['tfenv', 'install'])
     assert result.exit_code == 1
 
-    assert 'no .terraform-version file present' in caplog.messages[0]
+    assert 'unable to find a .terraform-version file' in '\n'.join(caplog.messages)
 
 
 def test_tfenv_install_version(caplog):
@@ -62,7 +62,7 @@ def test_tfenv_run_no_version_file(cd_tmp_path, caplog):
     result = runner.invoke(cli, ['tfenv', 'run', '--', '--help'])
     assert result.exit_code == 1
 
-    assert 'no .terraform-version file present' in caplog.messages[0]
+    assert 'unable to find a .terraform-version file' in '\n'.join(caplog.messages)
 
 
 def test_tfenv_run_separator(cd_tmp_path, capfd):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -148,7 +148,7 @@ def runway_context(request):
     env_vars = {
         'AWS_REGION': getattr(request.module, 'AWS_REGION', 'us-east-1'),
         'DEFAULT_AWS_REGION': getattr(request.module, 'AWS_REGION', 'us-east-1'),
-        'DEPLOY_ENVIRONMET': getattr(request.module, 'DEPLOY_ENVIRONMET', 'test')
+        'DEPLOY_ENVIRONMENT': getattr(request.module, 'DEPLOY_ENVIRONMENT', 'test')
     }
     creds = {
         'AWS_ACCESS_KEY_ID': 'test_access_key',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -115,6 +115,18 @@ def patch_time(monkeypatch):
     monkeypatch.setattr('time.sleep', lambda s: None)
 
 
+@pytest.fixture
+def platform_darwin(monkeypatch):
+    """Patch platform.system to always return "Darwin"."""
+    monkeypatch.setattr('platform.system', lambda: 'Darwin')
+
+
+@pytest.fixture
+def platform_windows(monkeypatch):
+    """Patch platform.system to always return "Windows"."""
+    monkeypatch.setattr('platform.system', lambda: 'Windows')
+
+
 @pytest.fixture(scope='function')
 def patch_runway_config(request, monkeypatch, runway_config):
     """Patch Runway config and return a mock config object."""

--- a/tests/unit/env_mgr/__init__.py
+++ b/tests/unit/env_mgr/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/unit/env_mgr/test_env_mgr.py
+++ b/tests/unit/env_mgr/test_env_mgr.py
@@ -1,5 +1,7 @@
 """Test runway.env_mgr."""
 # pylint: disable=no-self-use,unused-argument
+from mock import MagicMock
+
 from runway.env_mgr import EnvManager
 
 
@@ -9,7 +11,8 @@ class TestEnvManager(object):
     def test_bin(self, platform_darwin, cd_tmp_path, monkeypatch):
         """Test bin."""
         home = cd_tmp_path / 'home'
-        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.setattr('runway.env_mgr.Path.home',
+                            MagicMock(return_value=home))
         obj = EnvManager('test-bin', 'test-dir')
         obj.current_version = '1.0.0'
 
@@ -18,7 +21,8 @@ class TestEnvManager(object):
     def test_darwin(self, platform_darwin, cd_tmp_path, monkeypatch):
         """Test init on Darwin platform."""
         home = cd_tmp_path / 'home'
-        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.setattr('runway.env_mgr.Path.home',
+                            MagicMock(return_value=home))
         obj = EnvManager('test-bin', 'test-dir')
 
         assert not obj.current_version
@@ -36,7 +40,8 @@ class TestEnvManager(object):
     def test_windows(self, platform_windows, cd_tmp_path, monkeypatch):
         """Test init on Windows platform."""
         home = cd_tmp_path / 'home'
-        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.setattr('runway.env_mgr.Path.home',
+                            MagicMock(return_value=home))
         monkeypatch.delenv('APPDATA', raising=False)
         obj = EnvManager('test-bin', 'test-dir')
 

--- a/tests/unit/env_mgr/test_env_mgr.py
+++ b/tests/unit/env_mgr/test_env_mgr.py
@@ -1,0 +1,62 @@
+"""Test runway.env_mgr."""
+# pylint: disable=no-self-use,unused-argument
+from runway.env_mgr import EnvManager
+
+
+class TestEnvManager(object):
+    """Test runway.env_mgr.EnvManager."""
+
+    def test_bin(self, platform_darwin, cd_tmp_path, monkeypatch):
+        """Test bin."""
+        home = cd_tmp_path / 'home'
+        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        obj = EnvManager('test-bin', 'test-dir')
+        obj.current_version = '1.0.0'
+
+        assert obj.bin == home / '.test-dir' / 'versions' / '1.0.0' / 'test-bin'
+
+    def test_darwin(self, platform_darwin, cd_tmp_path, monkeypatch):
+        """Test init on Darwin platform."""
+        home = cd_tmp_path / 'home'
+        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        obj = EnvManager('test-bin', 'test-dir')
+
+        assert not obj.current_version
+        assert obj.command_suffix == ''
+        assert obj.env_dir_name == '.test-dir'
+        assert obj.env_dir == home / '.test-dir'
+        assert obj.versions_dir == home / '.test-dir' / 'versions'
+
+    def test_path(self, cd_tmp_path):
+        """Test how path attribute is set."""
+        assert EnvManager('', '', path=str(cd_tmp_path)).path == cd_tmp_path
+        assert EnvManager('', '', path=cd_tmp_path).path == cd_tmp_path
+        assert EnvManager('', '').path == cd_tmp_path
+
+    def test_windows(self, platform_windows, cd_tmp_path, monkeypatch):
+        """Test init on Windows platform."""
+        home = cd_tmp_path / 'home'
+        monkeypatch.setattr('runway.env_mgr.Path.home', lambda: home)
+        monkeypatch.delenv('APPDATA', raising=False)
+        obj = EnvManager('test-bin', 'test-dir')
+
+        expected_env_dir = home / 'AppData' / 'Roaming' / 'test-dir'
+
+        assert not obj.current_version
+        assert obj.command_suffix == '.exe'
+        assert obj.env_dir_name == 'test-dir'
+        assert obj.env_dir == expected_env_dir
+        assert obj.versions_dir == expected_env_dir / 'versions'
+
+    def test_windows_appdata(self, platform_windows, cd_tmp_path, monkeypatch):
+        """Test init on Windows platform."""
+        monkeypatch.setenv('APPDATA', str(cd_tmp_path / 'custom_path'))
+        obj = EnvManager('test-bin', 'test-dir')
+
+        expected_env_dir = cd_tmp_path / 'custom_path' / 'test-dir'
+
+        assert not obj.current_version
+        assert obj.command_suffix == '.exe'
+        assert obj.env_dir_name == 'test-dir'
+        assert obj.env_dir == expected_env_dir
+        assert obj.versions_dir == expected_env_dir / 'versions'

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -1,0 +1,221 @@
+"""Test runway.env_mgr.tfenv."""
+# pylint: disable=no-self-use
+import json
+
+import hcl
+import pytest
+import six
+from mock import MagicMock, patch
+
+from runway.env_mgr.tfenv import (TF_VERSION_FILENAME, TFEnvManager,
+                                  get_available_tf_versions,
+                                  get_latest_tf_version, get_version_requested)
+
+MODULE = 'runway.env_mgr.tfenv'
+
+
+@patch(MODULE + '.requests')
+def test_get_available_tf_versions(mock_requests):
+    """Test runway.env_mgr.tfenv.get_available_tf_versions."""
+    response = {
+        'terraform': {
+            'versions': {
+                '0.12.0': {},
+                '0.12.0-beta': {}
+            }
+        }
+    }
+    mock_requests.get.return_value = MagicMock(text=json.dumps(response))
+    assert get_available_tf_versions() == ['0.12.0']
+    assert get_available_tf_versions(include_prerelease=True) == [
+        '0.12.0-beta',
+        '0.12.0'
+    ]
+
+
+@patch(MODULE + '.get_available_tf_versions')
+def test_get_latest_tf_version(mock_get_available_tf_versions):
+    """Test runway.env_mgr.tfenv.get_latest_tf_version."""
+    mock_get_available_tf_versions.return_value = ['latest']
+    assert get_latest_tf_version() == 'latest'
+    mock_get_available_tf_versions.assert_called_once_with(False)
+    assert get_latest_tf_version(include_prerelease=True) == 'latest'
+    mock_get_available_tf_versions.assert_called_with(True)
+
+
+def test_get_version_requested(tmp_path):
+    """Test runway.env_mgr.tfenv.get_version_requested."""
+    tf_version = tmp_path / TF_VERSION_FILENAME
+    with pytest.raises(SystemExit) as excinfo:
+        assert get_version_requested(tmp_path)
+    assert excinfo.value.code == 1
+
+    tf_version.write_text(six.u('0.12.0'))
+    assert get_version_requested(tmp_path) == '0.12.0'
+
+
+class TestTFEnvManager(object):
+    """Test runway.env_mgr.tfenv.TFEnvManager."""
+
+    def test_backend(self, monkeypatch, tmp_path):
+        """Test backend."""
+        monkeypatch.setattr(TFEnvManager, 'terraform_block', {
+            'backend': {
+                's3': {
+                    'bucket': 'name'
+                }
+            }
+        })
+        tfenv = TFEnvManager(tmp_path)
+        assert tfenv.backend == {
+            'type': 's3',
+            'config': {
+                'bucket': 'name'
+            }
+        }
+
+        del tfenv.backend
+        monkeypatch.setattr(tfenv, 'terraform_block', {})
+        assert tfenv.backend == {
+            'type': None,
+            'config': {}
+        }
+
+    def test_get_min_required(self, monkeypatch, tmp_path):
+        """Test get_min_required."""
+        monkeypatch.setattr(TFEnvManager, 'terraform_block', {})
+        tfenv = TFEnvManager(tmp_path)
+
+        with pytest.raises(SystemExit) as excinfo:
+            assert tfenv.get_min_required()
+        assert excinfo.value.code
+
+        monkeypatch.setattr(tfenv, 'terraform_block', {
+            'required_version': '!=0.12.0'
+        })
+        with pytest.raises(SystemExit) as excinfo:
+            assert tfenv.get_min_required()
+        assert excinfo.value.code
+
+        monkeypatch.setattr(tfenv, 'terraform_block', {
+            'required_version': '~>0.12.0'
+        })
+        assert tfenv.get_min_required() == '0.12.0'
+
+    @patch(MODULE + '.get_available_tf_versions')
+    @patch(MODULE + '.get_version_requested')
+    @patch(MODULE + '.download_tf_release')
+    def test_install(self, mock_download, mock_get_version_requested,
+                     mock_available_versions, monkeypatch, tmp_path):
+        """Test install."""
+        mock_available_versions.return_value = ['0.12.0', '0.11.5']
+        mock_get_version_requested.return_value = '0.11.5'
+        monkeypatch.setattr(TFEnvManager, 'versions_dir', tmp_path)
+        tfenv = TFEnvManager(tmp_path)
+
+        assert tfenv.install('0.12.0')
+        mock_available_versions.assert_called_once_with(True)
+        mock_download.assert_called_once_with(
+            '0.12.0', tfenv.versions_dir, tfenv.command_suffix
+        )
+        assert tfenv.current_version == '0.12.0'
+
+        assert tfenv.install()
+        mock_download.assert_called_with(
+            '0.11.5', tfenv.versions_dir, tfenv.command_suffix
+        )
+        assert tfenv.current_version == '0.11.5'
+
+    @patch(MODULE + '.get_available_tf_versions')
+    @patch(MODULE + '.download_tf_release')
+    def test_install_already_installed(self, mock_download,
+                                       mock_available_versions,
+                                       monkeypatch, tmp_path):
+        """Test install with version already installed."""
+        mock_available_versions.return_value = ['0.12.0']
+        monkeypatch.setattr(TFEnvManager, 'versions_dir', tmp_path)
+        tfenv = TFEnvManager(tmp_path)
+        (tfenv.versions_dir / '0.12.0').mkdir()
+
+        assert tfenv.install('0.12.0')
+        mock_available_versions.assert_not_called()
+        mock_download.assert_not_called()
+        assert tfenv.current_version == '0.12.0'
+
+        assert tfenv.install(r'0\.12\..*')  # regex does not match dir
+
+    @patch(MODULE + '.get_available_tf_versions')
+    @patch(MODULE + '.download_tf_release')
+    def test_install_latest(self, mock_download, mock_available_versions,
+                            monkeypatch, tmp_path):
+        """Test install latest."""
+        mock_available_versions.return_value = ['0.12.0', '0.11.5']
+        monkeypatch.setattr(TFEnvManager, 'versions_dir', tmp_path)
+        tfenv = TFEnvManager(tmp_path)
+
+        assert tfenv.install('latest')
+        mock_available_versions.assert_called_once_with(False)
+        mock_download.assert_called_once_with(
+            '0.12.0', tfenv.versions_dir, tfenv.command_suffix
+        )
+        assert tfenv.current_version == '0.12.0'
+
+        assert tfenv.install('latest:0.11.5')
+        mock_available_versions.assert_called_with(False)
+        mock_download.assert_called_with(
+            '0.11.5', tfenv.versions_dir, tfenv.command_suffix
+        )
+        assert tfenv.current_version == '0.11.5'
+
+    @patch(MODULE + '.get_available_tf_versions')
+    @patch(MODULE + '.download_tf_release')
+    def test_install_min_required(self, mock_download, mock_available_versions,
+                                  monkeypatch, tmp_path):
+        """Test install min_required."""
+        mock_available_versions.return_value = ['0.12.0']
+        monkeypatch.setattr(TFEnvManager, 'versions_dir', tmp_path)
+        monkeypatch.setattr(
+            TFEnvManager, 'get_min_required', MagicMock(return_value='0.12.0')
+        )
+        tfenv = TFEnvManager(tmp_path)
+
+        assert tfenv.install('min-required')
+        mock_available_versions.assert_called_once_with(True)
+        mock_download.assert_called_once_with(
+            '0.12.0', tfenv.versions_dir, tfenv.command_suffix
+        )
+        assert tfenv.current_version == '0.12.0'
+        tfenv.get_min_required.assert_called_once_with()  # pylint: disable=no-member
+
+    @patch(MODULE + '.get_available_tf_versions')
+    @patch(MODULE + '.download_tf_release')
+    def test_install_unavailable(self, mock_download, mock_available_versions,
+                                 monkeypatch, tmp_path):
+        """Test install."""
+        mock_available_versions.return_value = []
+        monkeypatch.setattr(TFEnvManager, 'versions_dir', tmp_path)
+        tfenv = TFEnvManager(tmp_path)
+
+        with pytest.raises(SystemExit) as excinfo:
+            assert tfenv.install('0.12.0')
+        assert excinfo.value.code == 1
+        mock_available_versions.assert_called_once_with(True)
+        mock_download.assert_not_called()
+        assert not tfenv.current_version
+
+    def test_terraform_block(self, tmp_path):
+        """Test terraform_block."""
+        content = {
+            'terraform': {
+                'backend': {
+                    's3': {
+                        'bucket': 'name'
+                    }
+                }
+            }
+        }
+        tf_file = tmp_path / 'module.tf'
+        tf_file.write_text(six.u(hcl.dumps(content)))
+        tfenv = TFEnvManager(tmp_path)
+
+        assert tfenv.terraform_block == content['terraform']

--- a/tests/unit/module/test_terraform.py
+++ b/tests/unit/module/test_terraform.py
@@ -1,5 +1,5 @@
 """Tests for terraform module."""
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=no-self-use,protected-access,unused-argument
 import sys
 from contextlib import contextmanager
 from datetime import datetime
@@ -157,7 +157,7 @@ class TestTerraformBackendConfig(object):
         ({'bucket': 'test-bucket', 'dynamodb_table': 'test-table',
           'region': 'us-east-1', 'filename': 'anything'},
          ['bucket=test-bucket', 'dynamodb_table=test-table',
-          'region=us-east-1'])
+          'region=us-east-1', 'filename=anything'])
     ])
     def test_init_args(self, input_data, expected_items):
         """Test init_args."""
@@ -375,7 +375,7 @@ class TestTerraformBackendConfig(object):
 
         result = TerraformBackendConfig.parse(runway_context, './', **config)
 
-        assert result.bucket == 'foo'
-        assert result.dynamodb_table == 'bar'
-        assert result.region == expected_region
-        assert result.filename == 'success'
+        assert result._raw_config['bucket'] == 'foo'
+        assert result._raw_config['dynamodb_table'] == 'bar'
+        assert result._raw_config['region'] == expected_region
+        assert result._raw_config['filename'] == 'success'

--- a/tests/unit/module/test_terraform.py
+++ b/tests/unit/module/test_terraform.py
@@ -1,16 +1,24 @@
-"""Tests for terraform module."""
-# pylint: disable=no-self-use,protected-access,unused-argument
+"""Test runway.module.terraform."""
+# pylint: disable=no-self-use,protected-access,too-many-statements,unused-argument
+import json
+import subprocess
 import sys
 from contextlib import contextmanager
 from datetime import datetime
 
 import boto3
 import pytest
+import six
 from botocore.stub import Stubber
-from mock import patch
+from mock import MagicMock, patch
 
-from runway.module.terraform import (TerraformBackendConfig, TerraformOptions,
+from runway._logging import LogLevels
+from runway.module.terraform import (FAILED_INIT_FILENAME, Terraform,
+                                     TerraformBackendConfig, TerraformOptions,
+                                     gen_workspace_tfvars_files,
                                      update_env_vars_with_tf_var_values)
+
+MODULE = 'runway.module.terraform'
 
 
 @contextmanager
@@ -19,14 +27,22 @@ def does_not_raise():
     yield
 
 
+def test_gen_workspace_tfvars_files():
+    """Test gen_workspace_tfvars_files."""
+    assert gen_workspace_tfvars_files('test', 'us-east-1') == [
+        'test-us-east-1.tfvars',
+        'test.tfvars'
+    ]
+
+
 def test_update_env_vars_with_tf_var_values():
     """Test update_env_vars_with_tf_var_values."""
     result = update_env_vars_with_tf_var_values({}, {'foo': 'bar',
                                                      'list': ['foo', 1, True],
-                                                     'map': sorted({  # python 2
+                                                     'map': {
                                                          'one': 'two',
                                                          'three': 'four'
-                                                     })})
+                                                     }})
     expected = {
         'TF_VAR_foo': 'bar',
         'TF_VAR_list': '["foo", 1, true]',
@@ -34,6 +50,696 @@ def test_update_env_vars_with_tf_var_values():
     }
 
     assert sorted(result) == sorted(expected)  # sorted() needed for python 2
+
+
+class TestTerraform(object):
+    """Test runway.module.terraform.Terraform."""
+
+    def test_auto_tfvars(self, caplog, monkeypatch, runway_context, tmp_path):
+        """Test auto_tfvars."""
+        caplog.set_level(LogLevels.DEBUG, logger=MODULE)
+        mock_tfenv = MagicMock(current_version='0.12.0')
+        monkeypatch.setattr(Terraform, 'tfenv', mock_tfenv)
+        options = {
+            'options': {
+                'terraform_write_auto_tfvars': True
+            },
+            'parameters': {
+                'key': 'val'
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options.copy())
+        assert obj.auto_tfvars.is_file()
+        assert json.loads(obj.auto_tfvars.read_text()) == options['parameters']
+        assert 'unable to parse current version' not in '\n'.join(caplog.messages)
+
+        # check cases where the file will not be written
+        obj.auto_tfvars.unlink()
+        del obj.auto_tfvars
+        obj.options.write_auto_tfvars = False
+        assert not obj.auto_tfvars.exists()
+
+        del obj.auto_tfvars
+        obj.options.write_auto_tfvars = True
+        obj.parameters = {}
+        assert not obj.auto_tfvars.exists()
+
+    def test_auto_tfvars_invalid_version(self, caplog, monkeypatch,
+                                         runway_context, tmp_path):
+        """Test auto_tfvars with a version that cannot be converted to int."""
+        caplog.set_level(LogLevels.DEBUG, logger=MODULE)
+        mock_tfenv = MagicMock(current_version='v0.12.0')
+        monkeypatch.setattr(Terraform, 'tfenv', mock_tfenv)
+        options = {
+            'options': {
+                'terraform_write_auto_tfvars': True
+            },
+            'parameters': {
+                'key': 'val'
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options.copy())
+        assert obj.auto_tfvars.is_file()
+        assert json.loads(obj.auto_tfvars.read_text()) == options['parameters']
+        assert 'unable to parse current version' in '\n'.join(caplog.messages)
+
+    def test_auto_tfvars_unsupported_version(self, caplog, monkeypatch,
+                                             runway_context, tmp_path):
+        """Test auto_tfvars with a version that does not support it."""
+        caplog.set_level(LogLevels.WARNING, logger=MODULE)
+        mock_tfenv = MagicMock(current_version='0.9.0')
+        monkeypatch.setattr(Terraform, 'tfenv', mock_tfenv)
+        options = {
+            'options': {
+                'terraform_write_auto_tfvars': True
+            },
+            'parameters': {
+                'key': 'val'
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options.copy())
+        assert obj.auto_tfvars.is_file()
+        assert json.loads(obj.auto_tfvars.read_text()) == options['parameters']
+        assert (
+            'Terraform version does not support the use of '
+            '*.auto.tfvars; some variables may be missing'
+        ) in '\n'.join(caplog.messages)
+
+    @patch.object(Terraform, 'terraform_workspace_show')
+    def test_current_workspace(self, mock_terraform_workspace_show,
+                               runway_context, tmp_path):
+        """Test current_workspace."""
+        mock_terraform_workspace_show.return_value = 'default'
+        assert Terraform(runway_context, tmp_path).current_workspace == 'default'
+        mock_terraform_workspace_show.assert_called_once_with()
+
+    @pytest.mark.parametrize('filename, expected', [
+        ('test-us-east-1.tfvars', 'test-us-east-1.tfvars'),
+        ('test.tfvars', 'test.tfvars'),
+        (['test-us-east-1.tfvars', 'test.tfvars'], 'test-us-east-1.tfvars'),
+        ([], None)
+    ])
+    def test_env_file(self, filename, expected, runway_context, tmp_path):
+        """Test env_file."""
+        obj = Terraform(runway_context, tmp_path)
+
+        if isinstance(filename, list):
+            for name in filename:
+                (tmp_path / name).touch()
+        else:
+            (tmp_path / filename).touch()
+        if expected:
+            assert obj.env_file == ['-var-file=' + expected]
+        else:
+            assert not obj.env_file
+
+    def test_init(self, runway_context, tmp_path):
+        """Test class instantiation."""
+        options = {
+            'environments': {
+                'test': 'something'
+            },
+            'parameters': {
+                'key1': 'val1'
+            },
+            'nonstandard_key': 'something'
+        }
+        obj = Terraform(runway_context, tmp_path, options=options.copy())
+
+        assert obj.logger
+        assert obj.path == tmp_path
+        assert obj.environments == options['environments']
+        assert isinstance(obj.options, TerraformOptions)
+        assert obj.parameters == options['parameters']
+        assert obj.required_workspace == runway_context.env.name
+
+        assert obj.nonstandard_key == options['nonstandard_key']  # pylint: disable=no-member
+
+    def test_init_options_workspace(self, runway_context, tmp_path):
+        """Test class instantiation with workspace option."""
+        options = {
+            'options': {
+                'terraform_workspace': 'default'
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options.copy())
+        assert obj.required_workspace == options['options']['terraform_workspace']
+
+    @pytest.mark.parametrize('env, param, expected', [
+        (False, False, True),
+        (True, False, False),
+        (False, True, False),
+        (True, True, False)
+    ])
+    def test_skip(self, env, param, expected,
+                  monkeypatch, runway_context, tmp_path):
+        """Test skip."""
+        monkeypatch.setattr(Terraform, 'env_file', env)
+        obj = Terraform(runway_context, tmp_path)
+        obj.parameters = param
+        assert obj.skip == expected
+
+    @patch(MODULE + '.TFEnvManager')
+    def test_tfenv(self, mock_tfenv, monkeypatch, runway_context, tmp_path):
+        """Test tfenv."""
+        mock_tfenv.return_value = 'tfenv'
+        obj = Terraform(runway_context, tmp_path)
+
+        monkeypatch.setattr(obj, 'tf_version_file', False)
+        assert obj.tfenv == 'tfenv'
+        mock_tfenv.assert_called_once_with(tmp_path)
+
+        del obj.tfenv
+        monkeypatch.setattr(obj, 'tf_version_file', tmp_path)
+        assert obj.tfenv == 'tfenv'
+        mock_tfenv.assert_called_with(tmp_path.parent)
+
+    def test_tf_bin_file(self, monkeypatch, runway_context, tmp_path):
+        """Test tf_bin version in file."""
+        mock_tfenv = MagicMock()
+        mock_tfenv.install.return_value = 'success'
+        monkeypatch.setattr(Terraform, 'tfenv', mock_tfenv)
+        monkeypatch.setattr(Terraform, 'tf_version_file', True)
+        obj = Terraform(runway_context, tmp_path)
+        assert obj.tf_bin == 'success'
+        mock_tfenv.install.assert_called_once_with()
+
+    @patch(MODULE + '.which')
+    def test_tf_bin_global(self, mock_which, monkeypatch,
+                           runway_context, tmp_path):
+        """Test tf_bin from global install."""
+        monkeypatch.setattr(Terraform, 'tf_version_file', False)
+        mock_which.return_value = True
+        obj = Terraform(runway_context, tmp_path)
+        assert obj.tf_bin == 'terraform'
+        mock_which.assert_called_once_with('terraform')
+
+    @patch(MODULE + '.which')
+    def test_tf_bin_missing(self, mock_which, caplog, monkeypatch,
+                            runway_context, tmp_path):
+        """Test tf_bin missing."""
+        caplog.set_level(LogLevels.ERROR, logger=MODULE)
+        monkeypatch.setattr(Terraform, 'tf_version_file', False)
+        mock_which.return_value = False
+        obj = Terraform(runway_context, tmp_path)
+        with pytest.raises(SystemExit) as excinfo:
+            assert obj.tf_bin
+        assert excinfo.value.code == 1
+        mock_which.assert_called_once_with('terraform')
+        assert 'terraform not available and a version to install not specified' \
+            in '\n'.join(caplog.messages)
+
+    def test_tf_bin_options(self, monkeypatch, runway_context, tmp_path):
+        """Test tf_bin version in options."""
+        mock_tfenv = MagicMock()
+        mock_tfenv.install.return_value = 'success'
+        monkeypatch.setattr(Terraform, 'tfenv', mock_tfenv)
+        options = {
+            'options': {
+                'terraform_version': '0.12.0'
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options)
+        assert obj.tf_bin == 'success'
+        mock_tfenv.install.assert_called_once_with('0.12.0')
+
+    def test_tf_version_file(self, runway_context, tmp_path):
+        """Test tf_version_file."""
+        subdir = tmp_path / 'subdir'
+        subdir.mkdir()
+        runway_context.env.root_dir = tmp_path
+
+        # no version file
+        obj = Terraform(runway_context, subdir)
+        assert not obj.tf_version_file
+        del obj.tf_version_file
+
+        # version file in parent directory
+        expected = tmp_path / '.terraform-version'
+        expected.touch()
+        assert obj.tf_version_file == expected
+        del obj.tf_version_file
+
+        # version file in module dir
+        expected = subdir / '.terraform-version'
+        expected.touch()
+        assert obj.tf_version_file == expected
+        del obj.tf_version_file
+
+    @patch(MODULE + '.send2trash')
+    def test_cleanup_failed_init(self, mock_send2trash, runway_context, tmp_path):
+        """Test cleanup_failed_init."""
+        obj = Terraform(runway_context, tmp_path)
+
+        dot_tf = tmp_path / '.terraform'
+        failed_init_file = dot_tf / FAILED_INIT_FILENAME
+
+        # dir and file don't exit
+        assert not obj.cleanup_failed_init()
+        mock_send2trash.assert_not_called()
+
+        # file doesn't exist but dir does
+        dot_tf.mkdir()
+        assert not obj.cleanup_failed_init()
+        mock_send2trash.assert_not_called()
+
+        # file exists
+        failed_init_file.touch()
+        assert not obj.cleanup_failed_init()
+        mock_send2trash.assert_called_once_with(str(dot_tf))
+
+    @pytest.mark.parametrize('command, args_list, expected', [
+        ('init', ['-backend-config', 'bucket=name'],
+         ['init', '-backend-config', 'bucket=name']),
+        (['workspace', 'list'], None, ['workspace', 'list']),
+        (['workspace', 'new'], ['test'], ['workspace', 'new', 'test'])
+    ])
+    def test_gen_command(self, command, args_list, expected,
+                         monkeypatch, runway_context, tmp_path):
+        """Test gen_command."""
+        monkeypatch.setattr(Terraform, 'tf_bin', 'terraform')
+        expected.insert(0, 'terraform')
+
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj.context, 'no_color', False)
+        assert obj.gen_command(command, args_list=args_list) == expected
+
+        monkeypatch.setattr(obj.context, 'no_color', True)
+        expected.append('-no-color')
+        assert obj.gen_command(command, args_list=args_list) == expected
+
+    def test_handle_backend_no_handler(self, caplog, monkeypatch,
+                                       runway_context, tmp_path):
+        """Test handle_backend with no handler."""
+        caplog.set_level(LogLevels.DEBUG, logger=MODULE)
+        mock_get_full_configuration = MagicMock(return_value={})
+        backend = {
+            'type': 'unsupported',
+            'config': {}
+        }
+
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'tfenv', MagicMock(backend=backend))
+        monkeypatch.setattr(
+            obj.options.backend_config,
+            'get_full_configuration',
+            mock_get_full_configuration
+        )
+        assert not obj.handle_backend()
+        mock_get_full_configuration.assert_not_called()
+        assert 'backed "unsupported" does not require special handling' in \
+            '\n'.join(caplog.messages)
+
+    def test_handle_backend_no_type(self, caplog, monkeypatch,
+                                    runway_context, tmp_path):
+        """Test handle_backend with no type."""
+        caplog.set_level(LogLevels.INFO, logger=MODULE)
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'tfenv', MagicMock(backend={'type': None}))
+        assert not obj.handle_backend()
+        assert 'unable to determine backend for module' in \
+            '\n'.join(caplog.messages)
+
+    def test_handle_backend_remote_name(self, caplog, monkeypatch,
+                                        runway_context, tmp_path):
+        """Test handle_backend for remote backend with workspace prefix."""
+        caplog.set_level(LogLevels.DEBUG, logger=MODULE)
+        monkeypatch.setenv('TF_WORKSPACE', 'anything')
+        mock_get_full_configuration = MagicMock(return_value={})
+        backend = {
+            'type': 'remote',
+            'config': {
+                'workspaces': {
+                    'name': 'test'
+                }
+            }
+        }
+
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'tfenv', MagicMock(backend=backend))
+        monkeypatch.setattr(
+            obj.options.backend_config,
+            'get_full_configuration',
+            mock_get_full_configuration
+        )
+
+        assert not obj.handle_backend()
+        mock_get_full_configuration.assert_called_once_with()
+        assert 'TF_WORKSPACE' not in obj.context.env.vars
+        assert obj.required_workspace == 'default'
+        assert 'forcing use of static workspace "default"' in \
+            '\n'.join(caplog.messages)
+
+    def test_handle_backend_remote_prefix(self, caplog, monkeypatch,
+                                          runway_context, tmp_path):
+        """Test handle_backend for remote backend with workspace prefix."""
+        caplog.set_level(LogLevels.DEBUG, logger=MODULE)
+        monkeypatch.delenv('TF_WORKSPACE', raising=False)
+        mock_get_full_configuration = MagicMock(return_value={})
+        backend = {
+            'type': 'remote',
+            'config': {
+                'workspaces': {
+                    'prefix': 'test'
+                }
+            }
+        }
+
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'tfenv', MagicMock(backend=backend))
+        monkeypatch.setattr(
+            obj.options.backend_config,
+            'get_full_configuration',
+            mock_get_full_configuration
+        )
+
+        assert not obj.handle_backend()
+        mock_get_full_configuration.assert_called_once_with()
+        assert obj.context.env.vars['TF_WORKSPACE'] == obj.context.env.name
+        assert 'set environment variable "TF_WORKSPACE" to avoid prompt' in \
+            '\n'.join(caplog.messages)
+
+    def test_handle_backend_remote_undetermined(self, caplog, monkeypatch,
+                                                runway_context, tmp_path):
+        """Test handle_backend for remote backend with workspace undetermined."""
+        caplog.set_level(LogLevels.WARNING, logger=MODULE)
+        monkeypatch.delenv('TF_WORKSPACE', raising=False)
+        mock_get_full_configuration = MagicMock(return_value={})
+        backend = {
+            'type': 'remote',
+            'config': {}
+        }
+
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'tfenv', MagicMock(backend=backend))
+        monkeypatch.setattr(
+            obj.options.backend_config,
+            'get_full_configuration',
+            mock_get_full_configuration
+        )
+
+        assert not obj.handle_backend()
+        mock_get_full_configuration.assert_called_once_with()
+        assert '"workspaces" not defined in backend config' in \
+            '\n'.join(caplog.messages)
+
+    @patch(MODULE + '.update_env_vars_with_tf_var_values')
+    def test_handle_parameters(self, mock_update_envvars,
+                               monkeypatch, runway_context, tmp_path):
+        """Test handle_parameters."""
+        mock_update_envvars.return_value = {'result': 'success'}
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'auto_tfvars',
+                            MagicMock(
+                                exists=MagicMock(side_effect=[True, False])
+                            ))
+
+        assert not obj.handle_parameters()
+        mock_update_envvars.assert_not_called()
+
+        assert not obj.handle_parameters()
+        mock_update_envvars.assert_called_once_with(
+            runway_context.env.vars, {}
+        )
+        assert obj.context.env.vars == {'result': 'success'}
+
+    @patch(MODULE + '.run_module_command')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_apply(self, mock_gen_command, mock_run_command,
+                             monkeypatch, runway_context, tmp_path):
+        """Test terraform_apply."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        options = {
+            'options': {
+                'args': {
+                    'apply': ['arg']
+                }
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options)
+        monkeypatch.setattr(obj, 'env_file', ['env_file'])
+        monkeypatch.setattr(obj.context.env, 'ci', True)
+
+        expected_arg_list = ['env_file', 'arg', '-auto-approve=true']
+        assert not obj.terraform_apply()
+        mock_gen_command.assert_called_once_with('apply', expected_arg_list)
+        mock_run_command.assert_called_once_with(
+            ['mock_gen_command'],
+            env_vars=obj.context.env.vars,
+            logger=obj.logger
+        )
+
+        monkeypatch.setattr(obj.context.env, 'ci', False)
+        expected_arg_list[2] = '-auto-approve=false'
+        assert not obj.terraform_apply()
+        mock_gen_command.assert_called_with('apply', expected_arg_list)
+        assert mock_run_command.call_count == 2
+
+    @patch(MODULE + '.run_module_command')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_destroy(self, mock_gen_command, mock_run_command,
+                               monkeypatch, runway_context, tmp_path):
+        """Test terraform_destroy."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        obj = Terraform(runway_context, tmp_path)
+        monkeypatch.setattr(obj, 'env_file', ['env_file'])
+
+        expected_arg_list = ['-force', 'env_file']
+        assert not obj.terraform_destroy()
+        mock_gen_command.assert_called_once_with('destroy', expected_arg_list)
+        mock_run_command.assert_called_once_with(
+            ['mock_gen_command'],
+            env_vars=obj.context.env.vars,
+            logger=obj.logger
+        )
+
+    @patch(MODULE + '.run_module_command')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_get(self, mock_gen_command, mock_run_command,
+                           runway_context, tmp_path):
+        """Test terraform_get."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        obj = Terraform(runway_context, tmp_path)
+
+        assert not obj.terraform_get()
+        mock_gen_command.assert_called_once_with('get', ['-update=true'])
+        mock_run_command.assert_called_once_with(
+            ['mock_gen_command'],
+            env_vars=obj.context.env.vars,
+            logger=obj.logger
+        )
+
+    @patch(MODULE + '.run_module_command')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_init(self, mock_gen_command, mock_run_command,
+                            runway_context, tmp_path):
+        """Test terraform_init."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        options = {
+            'options': {
+                'args': {
+                    'init': ['init_arg']
+                },
+                'terraform_backend_config': {
+                    'bucket': 'name'
+                }
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options)
+
+        expected_arg_list = [
+            '-reconfigure', '-backend-config', 'bucket=name', 'init_arg'
+        ]
+        assert not obj.terraform_init()
+        mock_gen_command.assert_called_once_with('init', expected_arg_list)
+        mock_run_command.assert_called_once_with(
+            ['mock_gen_command'],
+            env_vars=obj.context.env.vars,
+            exit_on_error=False,
+            logger=obj.logger
+        )
+
+        dot_tf = tmp_path / '.terraform'
+        dot_tf.mkdir()
+        mock_run_command.side_effect = subprocess.CalledProcessError(1, '')
+        with pytest.raises(SystemExit) as excinfo:
+            assert obj.terraform_init()
+        assert excinfo.value.code == 1
+        assert (dot_tf / FAILED_INIT_FILENAME).is_file()
+
+    @patch(MODULE + '.run_module_command')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_plan(self, mock_gen_command, mock_run_command,
+                            monkeypatch, runway_context, tmp_path):
+        """Test terraform_plan."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        options = {
+            'options': {
+                'args': {
+                    'plan': ['plan_arg']
+                }
+            }
+        }
+        obj = Terraform(runway_context, tmp_path, options=options)
+        monkeypatch.setattr(obj, 'env_file', ['env_file'])
+
+        assert not obj.terraform_plan()
+        mock_gen_command.assert_called_once_with('plan', ['env_file', 'plan_arg'])
+        mock_run_command.assert_called_once_with(
+            ['mock_gen_command'],
+            env_vars=obj.context.env.vars,
+            logger=obj.logger
+        )
+
+    @patch(MODULE + '.subprocess')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_workspace_list(self, mock_gen_command, mock_subprocess,
+                                      runway_context, tmp_path):
+        """Test terraform_workspace_list."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        check_output_result = MagicMock()
+        check_output_result.decode.return_value = 'decoded'
+        mock_subprocess.check_output.return_value = check_output_result
+
+        obj = Terraform(runway_context, tmp_path)
+        assert obj.terraform_workspace_list() == 'decoded'
+        mock_gen_command.assert_called_once_with(['workspace', 'list'])
+        mock_subprocess.check_output.assert_called_once_with(
+            ['mock_gen_command'], env=obj.context.env.vars
+        )
+        check_output_result.decode.assert_called_once_with()
+
+    @patch(MODULE + '.run_module_command')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_workspace_new(self, mock_gen_command, mock_run_command,
+                                     runway_context, tmp_path):
+        """Test terraform_workspace_new."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        obj = Terraform(runway_context, tmp_path)
+
+        assert not obj.terraform_workspace_new('name')
+        mock_gen_command.assert_called_once_with(['workspace', 'new'], ['name'])
+        mock_run_command.assert_called_once_with(
+            ['mock_gen_command'],
+            env_vars=obj.context.env.vars,
+            logger=obj.logger
+        )
+
+    @patch(MODULE + '.run_module_command')
+    @patch.object(Terraform, 'terraform_workspace_show')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_workspace_select(self, mock_gen_command, mock_show,
+                                        mock_run_command, runway_context, tmp_path):
+        """Test terraform_workspace_new."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        mock_show.side_effect = ['first-val', 'second-val']
+        obj = Terraform(runway_context, tmp_path)
+
+        assert obj.current_workspace == 'first-val'  # load cached value
+        assert not obj.terraform_workspace_select('name')
+        mock_gen_command.assert_called_once_with(['workspace', 'select'], ['name'])
+        mock_run_command.assert_called_once_with(
+            ['mock_gen_command'],
+            env_vars=obj.context.env.vars,
+            logger=obj.logger
+        )
+        # cache was cleared and a new value was obtained
+        assert obj.current_workspace == 'second-val'
+
+    @patch(MODULE + '.subprocess')
+    @patch.object(Terraform, 'gen_command')
+    def test_terraform_workspace_show(self, mock_gen_command, mock_subprocess,
+                                      runway_context, tmp_path):
+        """Test terraform_workspace_show."""
+        mock_gen_command.return_value = ['mock_gen_command']
+        check_output_result = MagicMock(strip=MagicMock(
+            return_value=MagicMock(decode=MagicMock(return_value='decoded'))
+        ))
+        mock_subprocess.check_output.return_value = check_output_result
+
+        obj = Terraform(runway_context, tmp_path)
+        assert obj.terraform_workspace_show() == 'decoded'
+        mock_gen_command.assert_called_once_with(['workspace', 'show'])
+        mock_subprocess.check_output.assert_called_once_with(
+            ['mock_gen_command'], env=obj.context.env.vars
+        )
+        check_output_result.strip.assert_called_once_with()
+        check_output_result.strip.return_value.decode.assert_called_once_with()
+
+    @pytest.mark.parametrize('action', ['deploy', 'destroy', 'plan'])
+    def test_execute(self, action, caplog, monkeypatch, runway_context, tmp_path):
+        """Test executing a Runway action."""
+        caplog.set_level(LogLevels.DEBUG, logger=MODULE)
+        monkeypatch.setattr(Terraform, 'handle_backend', MagicMock())
+        monkeypatch.setattr(Terraform, 'skip', True)
+        monkeypatch.setattr(Terraform, 'handle_parameters', MagicMock())
+        monkeypatch.setattr(Terraform, 'terraform_init', MagicMock())
+        monkeypatch.setattr(Terraform, 'current_workspace', 'test')
+        monkeypatch.setattr(
+            Terraform, 'terraform_workspace_list', MagicMock(return_value='* test')
+        )
+        monkeypatch.setattr(Terraform, 'terraform_workspace_select', MagicMock())
+        monkeypatch.setattr(Terraform, 'terraform_workspace_new', MagicMock())
+        monkeypatch.setattr(Terraform, 'terraform_get', MagicMock())
+        monkeypatch.setattr(Terraform, 'terraform_apply', MagicMock())
+        monkeypatch.setattr(Terraform, 'terraform_destroy', MagicMock())
+        monkeypatch.setattr(Terraform, 'terraform_plan', MagicMock())
+        monkeypatch.setattr(
+            Terraform, 'auto_tfvars', MagicMock(
+                exists=MagicMock(
+                    return_value=True
+                ),
+                unlink=MagicMock()
+            )
+        )
+        command = 'apply' if action == 'deploy' else action
+
+        # pylint: disable=no-member
+        # module is skipped
+        obj = Terraform(runway_context, tmp_path)
+        assert not obj[action]()
+        obj.handle_backend.assert_called_once_with()
+        obj.handle_parameters.assert_not_called()
+        obj.auto_tfvars.exists.assert_called_once_with()
+        obj.auto_tfvars.unlink.assert_called_once_with()
+        caplog.clear()
+
+        # module is run; workspace matches
+        obj.auto_tfvars.exists.return_value = False
+        monkeypatch.setattr(obj, 'skip', False)
+        assert not obj[action]()
+        obj.handle_parameters.assert_called_once_with()
+        obj.terraform_init.assert_called_once_with()
+        obj.terraform_workspace_list.assert_not_called()
+        obj.terraform_workspace_select.assert_not_called()
+        obj.terraform_workspace_new.assert_not_called()
+        obj.terraform_get.assert_called_once_with()
+        obj['terraform_' + command].assert_called_once_with()
+        assert obj.auto_tfvars.exists.call_count == 2
+        assert obj.auto_tfvars.unlink.call_count == 1
+        logs = '\n'.join(caplog.messages)
+        assert 'init (in progress)' in logs
+        assert 'init (complete)' in logs
+        assert 're-running init after workspace change...' not in logs
+        assert '{} (in progress)'.format(command) in logs
+        assert '{} (complete)'.format(command) in logs
+        caplog.clear()
+
+        # module is run; switch to workspace
+        monkeypatch.setattr(Terraform, 'current_workspace', 'default')
+        assert not obj[action]()
+        obj.terraform_workspace_list.assert_called_once_with()
+        obj.terraform_workspace_select.assert_called_once_with('test')
+        obj.terraform_workspace_new.assert_not_called()
+        logs = '\n'.join(caplog.messages)
+        assert 're-running init after workspace change...' in logs
+
+        # module is run; create workspace
+        monkeypatch.setattr(
+            Terraform, 'terraform_workspace_list', MagicMock(return_value='')
+        )
+        assert not obj[action]()
+        obj.terraform_workspace_new.assert_called_once_with('test')
 
 
 class TestTerraformOptions(object):
@@ -143,9 +849,20 @@ class TestTerraformOptions(object):
 class TestTerraformBackendConfig(object):
     """Test runway.module.terraform.TerraformBackendConfig."""
 
+    def test_get_full_configuration(self, runway_context, tmp_path):
+        """Test get_full_configuration."""
+        config_file = tmp_path / 'backend.hcl'
+        config_file.write_text(six.u('key2 = "val2"'))
+        backend = TerraformBackendConfig(
+            runway_context, **{'key1': 'val1'}
+        )
+        assert backend.get_full_configuration() == {'key1': 'val1'}
+        backend.config_file = config_file
+        assert backend.get_full_configuration() == {'key1': 'val1', 'key2': 'val2'}
+
     @pytest.mark.parametrize('input_data, expected_items', [
         ({}, []),
-        ({'bucket': 'test-bucket'}, ['bucket=test-bucket']),
+        ({'some-key': 'anything'}, ['some-key=anything']),
         ({'dynamodb_table': 'test-table'}, ['dynamodb_table=test-table']),
         ({'region': 'us-east-1'}, ['region=us-east-1']),
         ({'bucket': 'test-bucket', 'dynamodb_table': 'test-table'},
@@ -155,16 +872,27 @@ class TestTerraformBackendConfig(object):
          ['bucket=test-bucket', 'dynamodb_table=test-table',
           'region=us-east-1']),
         ({'bucket': 'test-bucket', 'dynamodb_table': 'test-table',
-          'region': 'us-east-1', 'filename': 'anything'},
+          'region': 'us-east-1', 'config_file': MagicMock()},
          ['bucket=test-bucket', 'dynamodb_table=test-table',
-          'region=us-east-1', 'filename=anything'])
+          'region=us-east-1'])
     ])
-    def test_init_args(self, input_data, expected_items):
+    def test_init_args(self, input_data, expected_items, runway_context):
         """Test init_args."""
         expected = []
         for i in expected_items:
             expected.extend(['-backend-config', i])
-        assert TerraformBackendConfig(**input_data).init_args == expected
+        assert TerraformBackendConfig(
+            runway_context, **input_data
+        ).init_args == expected
+
+    def test_init_args_file(self, caplog, runway_context, tmp_path):
+        """Test init_args with backend file."""
+        caplog.set_level(LogLevels.VERBOSE, logger=MODULE)
+        config_file = tmp_path / 'backend.hcl'
+        assert TerraformBackendConfig(
+            runway_context, config_file=config_file
+        ).init_args == ['-backend-config=backend.hcl']
+        assert 'using backend config file: backend.hcl' in caplog.messages
 
     @pytest.mark.parametrize('kwargs, stack_info,expected', [
         ({'bucket': 'tf-state::BucketName',
@@ -237,14 +965,18 @@ class TestTerraformBackendConfig(object):
         stubber.assert_no_pending_responses()
         assert 'deprecated' in '\n'.join(caplog.messages)
 
-    def test_gen_backend_tfvars_filenames(self):
-        """Test gen_backend_tfvars_filenames."""
-        expected = ['backend-test-us-east-1.tfvars',
+    def test_gen_backend_filenames(self):
+        """Test gen_backend_filenames."""
+        expected = ['backend-test-us-east-1.hcl',
+                    'backend-test-us-east-1.tfvars',
+                    'backend-test.hcl',
                     'backend-test.tfvars',
+                    'backend-us-east-1.hcl',
                     'backend-us-east-1.tfvars',
+                    'backend.hcl',
                     'backend.tfvars']
 
-        assert TerraformBackendConfig.gen_backend_tfvars_filenames(
+        assert TerraformBackendConfig.gen_backend_filenames(
             'test', 'us-east-1'
         ) == expected
 
@@ -257,17 +989,20 @@ class TestTerraformBackendConfig(object):
         (['backend-test-us-east-1.tfvars', 'backend.tfvars'],
          'backend-test-us-east-1.tfvars')
     ])
-    def test_get_backend_tfvars_file(self, tmp_path, filename, expected):
-        """Test get_backend_tfvars_file."""
+    def test_get_backend_file(self, tmp_path, filename, expected):
+        """Test get_backend_file."""
         if isinstance(filename, list):
             for name in filename:
                 (tmp_path / name).touch()
         else:
             (tmp_path / filename).touch()
-        # TODO remove conversion of path to str when dripping python 2
-        assert TerraformBackendConfig.get_backend_tfvars_file(
-            str(tmp_path), 'test', 'us-east-1'
-        ) == expected
+        result = TerraformBackendConfig.get_backend_file(
+            tmp_path, 'test', 'us-east-1'
+        )
+        if expected:
+            assert result == tmp_path / expected
+        else:
+            assert not result
 
     @pytest.mark.parametrize('config, expected_region', [
         ({'terraform_backend_config': {'bucket': 'foo',
@@ -341,7 +1076,7 @@ class TestTerraformBackendConfig(object):
                 return kwargs
 
             @classmethod
-            def assert_get_backend_tfvars_file_args(_, path, env_name, env_region):
+            def assert_get_backend_file_args(_, path, env_name, env_region):
                 """Assert args passed to the method during parse."""
                 assert path == './'
                 assert env_name == 'test'
@@ -358,7 +1093,7 @@ class TestTerraformBackendConfig(object):
                 assert kwargs == config.get('terraform_backend_ssm_params')
                 return kwargs
 
-            def assert_get_backend_tfvars_file_args(path, env_name, env_region):
+            def assert_get_backend_file_args(path, env_name, env_region):
                 """Assert args passed to the method during parse."""
                 assert path == './'
                 assert env_name == 'test'
@@ -370,12 +1105,12 @@ class TestTerraformBackendConfig(object):
         monkeypatch.setattr(TerraformBackendConfig,
                             'resolve_ssm_params',
                             assert_ssm_kwargs)
-        monkeypatch.setattr(TerraformBackendConfig, 'get_backend_tfvars_file',
-                            assert_get_backend_tfvars_file_args)
+        monkeypatch.setattr(TerraformBackendConfig, 'get_backend_file',
+                            assert_get_backend_file_args)
 
         result = TerraformBackendConfig.parse(runway_context, './', **config)
 
         assert result._raw_config['bucket'] == 'foo'
         assert result._raw_config['dynamodb_table'] == 'bar'
         assert result._raw_config['region'] == expected_region
-        assert result._raw_config['filename'] == 'success'
+        assert result.config_file == 'success'


### PR DESCRIPTION

## Summary

Refactor the Terraform module class the environment manager to be more easily tested and support additional backends.

## Why This Is Needed

resolves #379 

## What Changed

### Added

- custom per-backend handling is now supported
- Terraform remote backend has custom handling around pre-selecting a workspace, not switching workspace, and dumping parameters to a `runway-parameters.auto.tfvars.json` file (only option of variables with remote backend)
- Terraform workspaces can be specified with the `terraform_workspace` option (mainly needed for remote backend support)
- Terraform module parameters can now be dumped to a `auto.tfvars` using the `terraform_write_auto_tfvars` option (mainly needed for remote backend support)

### Changed

- the Terraform environment manager is now responsible for finding a version file instead of the Terraform module class
- all Terraform files in a module are searched to compile a `terraform` configuration block with is available on the Terraform environment manager object
- Terraform backend configuration is now collected and parsed into a dict
- split the `run_terraform` method of the Terraform module class into multiple methods to be more easily tested
