### PR TITLE
move prod release to it's own workflow triggered on github release

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,10 +1,9 @@
-name: CI/CD
+name: Publish Release
 
 on:
-  pull_request:  # any pull request
-  push:
-    branches:
-      - master
+  release:
+    types:
+      - published
 
 env:
   AWS_DEFAULT_REGION: us-east-1
@@ -12,89 +11,7 @@ env:
   PIPENV_VENV_IN_PROJECT: true
   PIPENV_YES: true
 
-# YAML anchors are not currently supported but are included here, commented out for support is added
-# https://github.community/t5/GitHub-Actions/Support-for-YAML-anchors/td-p/30336
-
 jobs:
-  test-python:
-    name: Python Linting & Tests
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: [2.7, 3.6, 3.7]
-    runs-on: ${{ matrix.os }}
-    env:
-      # populating AWS creds with fake values
-      AWS_ACCESS_KEY_ID: test
-      AWS_SECRET_ACCESS_KEY: test
-    steps:
-      - # &checkout
-        name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - # &install_python
-        name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - # &dependencies_ubuntu
-        name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install sed -y
-      - # &dependencies_windows
-        name: Install Dependencies (windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install make sed
-      - # &cache_pip_ubuntu
-        name: Pip Cache (ubuntu)
-        uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          path:  ~/.cache/pip
-          key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
-          restore-keys: |
-            ${{ matrix.os }}-pip-${{ matrix.python-version }}
-      - # &cache_pip_windows
-        name: Pip Cache (windows)
-        uses: actions/cache@v1
-        if: matrix.os == 'windows-latest'
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
-          restore-keys: |
-            ${{ matrix.os }}-pip-${{ matrix.python-version }}
-      - # &install_pip
-        name: Install Global Python Packages
-        run: |
-          python -m pip install --upgrade pip setuptools
-          pip install "virtualenv==16.7.9" "pipenv==2018.11.26"
-      - # &pipenv_sync_27
-        name: Setup Python Virtual Environment (2.7)
-        if: matrix.python-version == '2.7' && matrix.os != 'windows-latest'
-        run: |
-          rm -rf Pipfile.lock
-          make sync_two
-      - # &pipenv_sync_27_windows
-        name: Setup Python Virtual Environment (2.7) (windows)
-        if: matrix.python-version == '2.7' && matrix.os == 'windows-latest'
-        run: |
-          Remove-Item -Path $Env:GITHUB_WORKSPACE\Pipfile.lock -Force
-          make sync_two
-      - # &pipenv_sync
-        name: Setup Python Virtual Environment (3.x)
-        if: matrix.python-version != '2.7'
-        run: pipenv sync --dev
-      - name: Run Linters (2.7)
-        if: matrix.python-version == '2.7'
-        run: make lint_two
-      - name: Run Linters (3.x)
-        if: matrix.python-version != '2.7'
-        run: make lint
-      - name: Run Integration & Unit Tests
-        if: matrix.os != 'windows-latest'
-        # assertions assume linux so some fail when run on windows
-        run: make test
-
   build-pyinstaller-onefile:
     name: Pyinstaller "One File" Build
     strategy:
@@ -243,7 +160,6 @@ jobs:
 
   build-npm:
     name: Build npm 📦
-    if: github.ref == 'refs/heads/master'
     needs:
       - test-python
       - build-pyinstaller-onefolder
@@ -321,7 +237,6 @@ jobs:
 
   publish-npm:
     name: Publish 📦 To npm
-    if: github.ref == 'refs/heads/master'
     needs:
       - build-npm
     env:
@@ -346,15 +261,14 @@ jobs:
         with:
           name: npm-pack
           path: artifacts
-      - name: Publish Distribution 📦 to npm (dev)
+      - name: Publish Distribution 📦 to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
         run: |
-          find ./artifacts -name 'onica-runway-*.*.*-*.tgz' -exec npm publish --access public --tag dev {} +
+          find ./artifacts -name 'onica-runway-*.*.*.tgz' -exec npm publish --access public {} +
 
   build-pypi:
     name: Build PyPi 📦
-    if: github.ref == 'refs/heads/master'
     needs:
       - test-python
     strategy:
@@ -404,7 +318,6 @@ jobs:
 
   publish-pypi:
     name: Publish 📦 To PyPI
-    if: github.ref == 'refs/heads/master'
     needs:
       - build-pypi
     runs-on: ubuntu-latest
@@ -414,15 +327,13 @@ jobs:
         with:
           name: pypi-dist
           path: dist
-      - name: Publish Distribution 📦 to Test PyPI
+      - name: Publish Distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:
-          password: ${{ secrets.test_pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.pypi_password }}
 
   publish-s3:
     name: Publish 📦 To S3
-    if: github.ref == 'refs/heads/master'
     needs:
       - test-python
       - build-pyinstaller-onefile
@@ -456,3 +367,36 @@ jobs:
         run: |
           pip install "awscli~=1.18.19"
           aws s3 cp artifacts s3://$AWS_S3_BUCKET/runway/ --recursive --acl public-read
+
+  update-urlshortener:
+    name: Update URL Shortener
+    needs:
+      - publish-s3
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key }}
+      BUCKET_NAME: common-runway-assets-bucket83908e77-u2xp1bj1tuhp
+      BUCKET_REGION: us-west-2
+      TABLE: onica-urlshortener-prod
+      TABLE_REGION: us-east-1
+      VERSION: ${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.0.0
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Dependencies & Run Script
+        working-directory: .github/scripts/urlshortener
+        run: |
+          pip install wheel
+          pip install -r requirements.txt
+          python update_urls.py \
+            --bucket-name $BUCKET_NAME \
+            --bucket-region $BUCKET_REGION \
+            --table $TABLE \
+            --table-region $TABLE_REGION \
+            --version $VERSION \
+            --latest

--- a/docs/source/developers/github_actions.rst
+++ b/docs/source/developers/github_actions.rst
@@ -47,14 +47,6 @@ Based on the execution environment, this workflow will run different steps.
 - build & upload PyPi_ & npm_ artifacts
 - publish a development version to `Test PyPi`_ and npm_
 
-.. rubric:: Tag
-
-- Lint & test
-- build & upload Pyinstaller_ artifacts
-- build & upload PyPi_ & npm_ artifacts
-- publish a development version to `Test PyPi`_
-- publish a release to AWS S3, PyPi_, & npm_
-
 .. _npm: https://www.npmjs.com/package/@onica/runway
 .. _Pyinstaller: https://pypi.org/project/PyInstaller/
 .. _PyPi: https://pypi.org/project/runway/
@@ -106,3 +98,10 @@ Release Management
 ******************
 
 When a commit is pushed to **release** (tag is pushed, PR is merged) a release draft is created (if one does not exist) and PRs since the last tag are added following the included template. Changes are categorized based on PR labels.
+
+
+***************
+Publish Release
+***************
+
+When a GitHub **Release** is published, the final artifacts are created and published to AWS S3, PyPi_, & npm_.

--- a/docs/source/maintainers/release_process.rst
+++ b/docs/source/maintainers/release_process.rst
@@ -60,18 +60,39 @@ Execution
 5. Push the changes to the **onicagroup/runway** remote.
    (e.g. ``git push <remote> release``)
 
-6. Create a signed tag on the *release* branch for the new version.
-   (e.g. ``git tag --sign v0.0.0``)
+6. Create a tag on the *release* branch for the new version.
+   This can be done one of two ways:
 
-7. Push the new tag to the **onicagroup/runway** remote.
-   (e.g. ``git push <remote> v0.0.0``)
+- Navigate to the **Releases** section of the repository on GitHub.
+  The should be a *Draft Release* already started that was automatically generated from PRs that were merged since the last release.
+  Editing the draft will give provide the option to create a new tag for the release.
 
-At this point, GitHub Action will begin final linting & testing before building the deployment packages & automatically publishing them to npm, PyPi, and AWS S3.
-The **CI/CD** workflow can be monitored for progress.
+- Create a signed tag on the *release* branch for the new version and push it to the **onicagroup/runway** remote
+
+.. code-block:: shell
+
+  git tag --sign v0.0.0
+  git push <remote> v0.0.0
+
+7. Navigate to the **Releases** section of the repository on GitHub and edit the *Draft Release* if you have not done so already.
+
+8. Rename the release to match the version tag and associate it with the tag that was just created.
+
+9. Edit the description of the release as needed but, there should be little to no changes required if all PRs were properly labeled.
+
+10. Mark the release as a *pre-release* if applicable (alpha, beta, release candidate, etc).
+
+11. Publish the release on GitHub.
+
+
+At this point, GitHub Action will begin building the deployment packages & automatically publishing them to npm, PyPi, and AWS S3.
+The **Publish Release** workflow can be monitored for progress.
+
+.. This is kind of optional since it has yet to be done but, it would be great to have this automated before 2.0 if possible
 
 After all the publishing steps have completed:
 
-8. Download the following artifacts from the **CI/CD** workflow:
+12. Download the following artifacts from the **Publish Release** workflow:
 
 - npm-pack
 - pyinstaller-onefile-macos-latest
@@ -79,16 +100,4 @@ After all the publishing steps have completed:
 - pyinstaller-onefile-windows-latest
 - pypi-dist
 
-9. Navigate to the **Releases** tag of the repository on GitHub.
-   The should be a *Draft Release* already started that was automatically generated from PRs that were merged since the last release.
-   Edit the draft.
-
-10. Rename the release to match the version tag and associate it with the tag that was just created.
-
-11. Edit the description of the release as needed but, there should be little to no changes required if all PRs were properly labeled.
-
-12. Attach all artifacts to the release that were previously downloaded.
-
-13. Mark the release as a *pre-release* if applicable (alpha, beta, release candidate, etc).
-
-14. Publish the release on GitHub.
+13. Attach all artifacts to the release that were previously downloaded.


### PR DESCRIPTION
## Summary

resolves #327

Final artifact building and publishing has been moved out of the `CI/CD` workflow and moved into the `Publish Release` workflow.

Previously, it relied on conditions to determine if the steps should be run or skipped and those that were skipped still always appears in the checks of each PR. This removes that.

Moving the trigger from `tag` to `release.published` better restricts when these steps are run and forces the use of GitHub releases which notifies users of new versions and can be used to track change instead of keeping a changelog.

## What Changed

### Changed

- copied build steps to a new workflow
- moved production publishing steps from `CI/CD` workflow to a new workflow
