### PR TITLE
fixed TypeError when stack template from AWS contains non-JSON data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `terraform_backend_cfn_outputs` option is now deprecated
 - `xref` Lookup is now deprecated
 
+### Fixed
+- fixed TypeError when stack template from AWS contains non-JSON data type
+
 ## [1.10.1] - 2020-07-20
 ### Fixed
 - fixed an issue where AWS account alias/id validation was not using the context object with assumed credentials when running in parallel

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ lint-pylint: ## run pylint
 # linting for python 2, requires additional disables
 lint_two: ## run all linters (python 2 only)
 	pipenv run flake8 --exclude=runway/embedded,runway/templates --ignore=D101,D403,E124,W504 runway
-	find runway -name '*.py' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run pylint --rcfile=.pylintrc --disable=bad-option-value,duplicate-code,relative-import
+	find runway -name '*.py' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run pylint --rcfile=.pylintrc --disable=bad-option-value,duplicate-code,method-hidden,relative-import
 
 test: ## run integration and unit tests
 	@echo "Running integration & unit tests..."

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -12,7 +12,7 @@ import yaml
 from botocore.config import Config
 from six.moves import urllib
 
-from runway.util import DOC_SITE
+from runway.util import DOC_SITE, JsonEncoder
 
 from ... import exceptions
 from ...actions.diff import DictValue, diff_parameters
@@ -1277,7 +1277,7 @@ class Provider(BaseProvider):
         if isinstance(template, str):  # handle yaml templates
             template = parse_cloudformation_template(template)
 
-        return json.dumps(template), parameters
+        return json.dumps(template, cls=JsonEncoder), parameters
 
     def get_stack_changes(self, stack, template, parameters, tags):
         """Get the changes from a ChangeSet.

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,15 +1,24 @@
 """Test Runway utils."""
 # pylint: disable=no-self-use
+import datetime
 import json
 import logging
 import os
 import string
 import sys
+from decimal import Decimal
 
 import pytest
 from mock import MagicMock, patch
 
-from runway.util import MutableMap, SafeHaven, argv, environ, load_object_from_string
+from runway.util import (
+    JsonEncoder,
+    MutableMap,
+    SafeHaven,
+    argv,
+    environ,
+    load_object_from_string,
+)
 
 MODULE = 'runway.util'
 VALUE = {
@@ -21,6 +30,26 @@ VALUE = {
     },
     'str_val': 'test'
 }
+
+
+class TestJsonEncoder(object):
+    """Test runway.util.JsonEncoder."""
+
+    @pytest.mark.parametrize('provided, expected', [
+        (datetime.datetime.now(), str),
+        (Decimal('1.1'), float)
+    ])
+    def test_supported_types(self, provided, expected):
+        """Test encoding of supported data types."""
+        assert isinstance(JsonEncoder().default(provided), expected)
+
+    @pytest.mark.parametrize('provided', [
+        (None)
+    ])
+    def test_unsupported_types(self, provided):
+        """Test encoding of unsupported data types."""
+        with pytest.raises(TypeError):
+            assert not JsonEncoder().default(provided)
 
 
 class TestMutableMap:


### PR DESCRIPTION
## Summary

If the template uploaded to AWS contains a date that is not quoted, it will be returned as a datetime object which cannot be handled by `json.dumps`.

The json encoder being added supports datetime as well as another data type that can appear in some AWS responses, Decimal, since I had the snippet that handles both laying around.

resolves #400 

## What Changed

### Added

- added `runway.util.JsonEncoder` that can be passed to `json.dumps` for handling `datetime.datetime`, `datetime.date` and `decimal.Decimal` objects

### Fixed

- fixed TypeError when stack template from AWS contains non-JSON data type
