### PR TITLE
add HCL2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- support for HCL2 using `python-hcl2` (requires Python >= 3.6)
 
 ## [1.11.0] - 2020-08-11
 ### Added

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "43a907f9356dd27805e828995417fecf2074d5d193d1517aa4711d80f193906f"
+            "sha256": "dcd675df0afc3e359113ed5d64878aa6addb71f016329f0924363e0db631e176"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -37,24 +37,22 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:05895eca96bba40bf223776e9647e5e07069c495c03296b64ccd0751fd13612d",
-                "sha256:3078c4fe738814a4191f02bfd2fdd28279cdafdd8f80039249f42389d3e73078"
+                "sha256:b0ad0823e24da4a48243d41ea3cb984407cfb20883d266c014886ab5e9c22a8b"
             ],
-            "version": "==1.18.117"
+            "version": "==1.18.118"
         },
         "boto3": {
             "hashes": [
-                "sha256:a88d486dcbc80c3e180d811707b366f7b178cf293e0746ae3c00c24a07deac92",
-                "sha256:c9cab4e0ce77a8c54724eadff047adc976e541f912ca15e35bb475f42b344e0c"
+                "sha256:26f76c7780470de54dfe816bcbeed57a05f53a0bec7c9ae9e8ad7b61ac4c74cc"
             ],
-            "version": "==1.14.40"
+            "version": "==1.14.41"
         },
         "botocore": {
             "hashes": [
-                "sha256:c3fad73aefabc89c918687a0f207772925530017ce1ca58e2a47b459a1060cb0",
-                "sha256:feb71e0d2e73fed3c35f1ebfc6b9ff6e499dc9c66db60b63c787fffea3b360a5"
+                "sha256:329ca6d6d5e91e97569ecd7f328cd3d627e918ce0703943f93d0b9de6af9aab2",
+                "sha256:519fcccf9c41634d2aba9dc769b0ac6aa14034f20a60882b0e098ae2e07cab55"
             ],
-            "version": "==1.17.40"
+            "version": "==1.17.41"
         },
         "certifi": {
             "hashes": [
@@ -128,7 +126,6 @@
                 "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
                 "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
             ],
-            "markers": "python_version != '3.4'",
             "version": "==0.4.3"
         },
         "coloredlogs": {
@@ -285,6 +282,12 @@
             ],
             "version": "==1.9"
         },
+        "lark-parser": {
+            "hashes": [
+                "sha256:26215ebb157e6fb2ee74319aa4445b9f3b7e456e26be215ce19fdaaa901c20a4"
+            ],
+            "version": "==0.7.8"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
@@ -408,6 +411,12 @@
             ],
             "version": "==2.8.1"
         },
+        "python-hcl2": {
+            "hashes": [
+                "sha256:21e051155e8a48c8dafcbc9b35c9affeea5cdc3ae171a8910169d7c1877f151b"
+            ],
+            "version": "==0.3.0"
+        },
         "pyyaml": {
             "hashes": [
                 "sha256:0e7f69397d53155e55d10ff68fdfb2cf630a35e6daf65cf0bdeaf04f127c09dc",
@@ -437,7 +446,6 @@
                 "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
                 "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "markers": "python_version != '3.4'",
             "version": "==4.5"
         },
         "runway": {
@@ -583,17 +591,16 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:a88d486dcbc80c3e180d811707b366f7b178cf293e0746ae3c00c24a07deac92",
-                "sha256:c9cab4e0ce77a8c54724eadff047adc976e541f912ca15e35bb475f42b344e0c"
+                "sha256:26f76c7780470de54dfe816bcbeed57a05f53a0bec7c9ae9e8ad7b61ac4c74cc"
             ],
-            "version": "==1.14.40"
+            "version": "==1.14.41"
         },
         "botocore": {
             "hashes": [
-                "sha256:c3fad73aefabc89c918687a0f207772925530017ce1ca58e2a47b459a1060cb0",
-                "sha256:feb71e0d2e73fed3c35f1ebfc6b9ff6e499dc9c66db60b63c787fffea3b360a5"
+                "sha256:329ca6d6d5e91e97569ecd7f328cd3d627e918ce0703943f93d0b9de6af9aab2",
+                "sha256:519fcccf9c41634d2aba9dc769b0ac6aa14034f20a60882b0e098ae2e07cab55"
             ],
-            "version": "==1.17.40"
+            "version": "==1.17.41"
         },
         "certifi": {
             "hashes": [
@@ -1202,7 +1209,6 @@
                 "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
                 "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "markers": "python_version != '3.4'",
             "version": "==4.5"
         },
         "s3transfer": {

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -36,18 +36,17 @@
         },
         "aws-sam-translator": {
             "hashes": [
-                "sha256:33c5e9a04584a88b2dc730991f7aea52acc4a077a194444e16728dd2be997dc0",
-                "sha256:5b31769d271fa6c7e87cde076ce819f9f9c7da324b3880f2cd0f5f5aa837e520",
-                "sha256:f2d0585fc7dd071f136b543e9a614945cb80bbd3113a25f260797c126456dd25"
+                "sha256:1a3fd8e48a745967e8457b9cefdc3ad0f139ac4a25af4db9c13a9e1c19ea6910",
+                "sha256:3a200e6475f11726732b9b9c070ca4d58d2fe5ecc40e8fb629b09a053fba5640",
+                "sha256:de2f1b4efd83347639eb19fea37989e9da9a3c59da277320cf1e58a2f0ff6dd0"
             ],
-            "version": "==1.25.0"
+            "version": "==1.26.0"
         },
         "awscli": {
             "hashes": [
-                "sha256:2606cda0ebda43b5a8aa33577a8842338b0fac3d8ed8250ea494efeb355b824d",
-                "sha256:6cc7a7a092757989cd74e130f0b382d64d6b5918dce286183ac80a646443c058"
+                "sha256:b0ad0823e24da4a48243d41ea3cb984407cfb20883d266c014886ab5e9c22a8b"
             ],
-            "version": "==1.18.116"
+            "version": "==1.18.118"
         },
         "babel": {
             "hashes": [
@@ -58,16 +57,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b81e5f672ba66e85a0037baae8c73fcc8fca90b94a0bd591cc9e6dc25a1364fe"
+                "sha256:26f76c7780470de54dfe816bcbeed57a05f53a0bec7c9ae9e8ad7b61ac4c74cc",
+                "sha256:e9a5efddf7492719ec3d4024e67170fc71a874125d37eb5211b242f23c242dac"
             ],
-            "version": "==1.14.39"
+            "version": "==1.14.41"
         },
         "botocore": {
             "hashes": [
-                "sha256:b869be5ca327bdf64d4e203f3bb6036cc9700e1cb55c8633779f74e0658d5d06",
-                "sha256:fd1c42436a4271fbcc8bc53357171ff01d9a1bea8efc4c8a00e58a531efdcb31"
+                "sha256:329ca6d6d5e91e97569ecd7f328cd3d627e918ce0703943f93d0b9de6af9aab2",
+                "sha256:519fcccf9c41634d2aba9dc769b0ac6aa14034f20a60882b0e098ae2e07cab55"
             ],
-            "version": "==1.17.39"
+            "version": "==1.17.41"
         },
         "certifi": {
             "hashes": [
@@ -141,7 +141,6 @@
                 "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
                 "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
             ],
-            "markers": "python_version != '3.4'",
             "version": "==0.4.3"
         },
         "coloredlogs": {
@@ -305,6 +304,12 @@
             ],
             "version": "==1.9"
         },
+        "lark-parser": {
+            "hashes": [
+                "sha256:26215ebb157e6fb2ee74319aa4445b9f3b7e456e26be215ce19fdaaa901c20a4"
+            ],
+            "version": "==0.7.8"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
@@ -433,6 +438,12 @@
             ],
             "version": "==2.8.1"
         },
+        "python-hcl2": {
+            "hashes": [
+                "sha256:21e051155e8a48c8dafcbc9b35c9affeea5cdc3ae171a8910169d7c1877f151b"
+            ],
+            "version": "==0.3.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
@@ -469,7 +480,6 @@
                 "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
                 "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "markers": "python_version != '3.4'",
             "version": "==4.5"
         },
         "runway": {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,18 +2,18 @@
 alabaster==0.7.12
 attrs==19.3.0
 awacs==0.9.8
-aws-sam-translator==1.25.0
-awscli==1.18.116
+aws-sam-translator==1.26.0
+awscli==1.18.118
 babel==2.8.0
-boto3==1.14.39
-botocore==1.17.39
+boto3==1.14.41
+botocore==1.17.41
 certifi==2020.6.20
 cffi==1.14.1
 cfn-flip==1.2.3
 cfn-lint==0.34.1
 chardet==3.0.4
 click==7.1.2
-colorama==0.4.3 ; python_version != '3.4'
+colorama==0.4.3
 coloredlogs==14.0
 cryptography==3.0
 decorator==4.4.2
@@ -34,6 +34,7 @@ jsonpointer==2.0
 jsonschema==3.2.0
 jsx-lexer==0.0.8
 junit-xml==1.9
+lark-parser==0.7.8
 markupsafe==1.1.1
 more-itertools==8.4.0
 networkx==2.4 ; python_version >= '3.5'
@@ -48,10 +49,11 @@ pyopenssl==19.1.0
 pyparsing==2.4.7
 pyrsistent==0.16.0
 python-dateutil==2.8.1
+python-hcl2==0.3.0
 pytz==2020.1
 pyyaml==5.2 ; python_version != '3.4'
 requests==2.24.0
-rsa==4.5 ; python_version != '3.4'
+rsa==4.5
 s3transfer==0.3.3
 schematics==2.0.1
 send2trash==1.5.0

--- a/integration_test_infrastructure/Pipfile.lock
+++ b/integration_test_infrastructure/Pipfile.lock
@@ -29,31 +29,31 @@
         },
         "aws-sam-translator": {
             "hashes": [
-                "sha256:33c5e9a04584a88b2dc730991f7aea52acc4a077a194444e16728dd2be997dc0",
-                "sha256:5b31769d271fa6c7e87cde076ce819f9f9c7da324b3880f2cd0f5f5aa837e520",
-                "sha256:f2d0585fc7dd071f136b543e9a614945cb80bbd3113a25f260797c126456dd25"
+                "sha256:1a3fd8e48a745967e8457b9cefdc3ad0f139ac4a25af4db9c13a9e1c19ea6910",
+                "sha256:3a200e6475f11726732b9b9c070ca4d58d2fe5ecc40e8fb629b09a053fba5640",
+                "sha256:de2f1b4efd83347639eb19fea37989e9da9a3c59da277320cf1e58a2f0ff6dd0"
             ],
-            "version": "==1.25.0"
+            "version": "==1.26.0"
         },
         "awscli": {
             "hashes": [
-                "sha256:2606cda0ebda43b5a8aa33577a8842338b0fac3d8ed8250ea494efeb355b824d",
-                "sha256:6cc7a7a092757989cd74e130f0b382d64d6b5918dce286183ac80a646443c058"
+                "sha256:b0ad0823e24da4a48243d41ea3cb984407cfb20883d266c014886ab5e9c22a8b"
             ],
-            "version": "==1.18.116"
+            "version": "==1.18.118"
         },
         "boto3": {
             "hashes": [
-                "sha256:b81e5f672ba66e85a0037baae8c73fcc8fca90b94a0bd591cc9e6dc25a1364fe"
+                "sha256:26f76c7780470de54dfe816bcbeed57a05f53a0bec7c9ae9e8ad7b61ac4c74cc",
+                "sha256:e9a5efddf7492719ec3d4024e67170fc71a874125d37eb5211b242f23c242dac"
             ],
-            "version": "==1.14.39"
+            "version": "==1.14.41"
         },
         "botocore": {
             "hashes": [
-                "sha256:b869be5ca327bdf64d4e203f3bb6036cc9700e1cb55c8633779f74e0658d5d06",
-                "sha256:fd1c42436a4271fbcc8bc53357171ff01d9a1bea8efc4c8a00e58a531efdcb31"
+                "sha256:329ca6d6d5e91e97569ecd7f328cd3d627e918ce0703943f93d0b9de6af9aab2",
+                "sha256:519fcccf9c41634d2aba9dc769b0ac6aa14034f20a60882b0e098ae2e07cab55"
             ],
-            "version": "==1.17.39"
+            "version": "==1.17.41"
         },
         "certifi": {
             "hashes": [
@@ -275,6 +275,12 @@
             ],
             "version": "==1.9"
         },
+        "lark-parser": {
+            "hashes": [
+                "sha256:26215ebb157e6fb2ee74319aa4445b9f3b7e456e26be215ce19fdaaa901c20a4"
+            ],
+            "version": "==0.7.8"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
@@ -398,6 +404,12 @@
             ],
             "version": "==2.8.1"
         },
+        "python-hcl2": {
+            "hashes": [
+                "sha256:21e051155e8a48c8dafcbc9b35c9affeea5cdc3ae171a8910169d7c1877f151b"
+            ],
+            "version": "==0.3.0"
+        },
         "pyyaml": {
             "hashes": [
                 "sha256:0e7f69397d53155e55d10ff68fdfb2cf630a35e6daf65cf0bdeaf04f127c09dc",
@@ -427,7 +439,6 @@
                 "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
                 "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "markers": "python_version != '3.4'",
             "version": "==4.5"
         },
         "runway": {

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -31,31 +31,30 @@
         },
         "aws-sam-translator": {
             "hashes": [
-                "sha256:33c5e9a04584a88b2dc730991f7aea52acc4a077a194444e16728dd2be997dc0",
-                "sha256:5b31769d271fa6c7e87cde076ce819f9f9c7da324b3880f2cd0f5f5aa837e520",
-                "sha256:f2d0585fc7dd071f136b543e9a614945cb80bbd3113a25f260797c126456dd25"
+                "sha256:1a3fd8e48a745967e8457b9cefdc3ad0f139ac4a25af4db9c13a9e1c19ea6910",
+                "sha256:3a200e6475f11726732b9b9c070ca4d58d2fe5ecc40e8fb629b09a053fba5640",
+                "sha256:de2f1b4efd83347639eb19fea37989e9da9a3c59da277320cf1e58a2f0ff6dd0"
             ],
-            "version": "==1.25.0"
+            "version": "==1.26.0"
         },
         "awscli": {
             "hashes": [
-                "sha256:2606cda0ebda43b5a8aa33577a8842338b0fac3d8ed8250ea494efeb355b824d",
-                "sha256:6cc7a7a092757989cd74e130f0b382d64d6b5918dce286183ac80a646443c058"
+                "sha256:b0ad0823e24da4a48243d41ea3cb984407cfb20883d266c014886ab5e9c22a8b"
             ],
-            "version": "==1.18.116"
+            "version": "==1.18.118"
         },
         "boto3": {
             "hashes": [
-                "sha256:b81e5f672ba66e85a0037baae8c73fcc8fca90b94a0bd591cc9e6dc25a1364fe"
+                "sha256:26f76c7780470de54dfe816bcbeed57a05f53a0bec7c9ae9e8ad7b61ac4c74cc"
             ],
-            "version": "==1.14.39"
+            "version": "==1.14.41"
         },
         "botocore": {
             "hashes": [
-                "sha256:b869be5ca327bdf64d4e203f3bb6036cc9700e1cb55c8633779f74e0658d5d06",
-                "sha256:fd1c42436a4271fbcc8bc53357171ff01d9a1bea8efc4c8a00e58a531efdcb31"
+                "sha256:329ca6d6d5e91e97569ecd7f328cd3d627e918ce0703943f93d0b9de6af9aab2",
+                "sha256:519fcccf9c41634d2aba9dc769b0ac6aa14034f20a60882b0e098ae2e07cab55"
             ],
-            "version": "==1.17.39"
+            "version": "==1.17.41"
         },
         "certifi": {
             "hashes": [
@@ -277,6 +276,12 @@
             ],
             "version": "==1.9"
         },
+        "lark-parser": {
+            "hashes": [
+                "sha256:26215ebb157e6fb2ee74319aa4445b9f3b7e456e26be215ce19fdaaa901c20a4"
+            ],
+            "version": "==0.7.8"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
@@ -415,6 +420,12 @@
             ],
             "version": "==2.8.1"
         },
+        "python-hcl2": {
+            "hashes": [
+                "sha256:21e051155e8a48c8dafcbc9b35c9affeea5cdc3ae171a8910169d7c1877f151b"
+            ],
+            "version": "==0.3.0"
+        },
         "pyyaml": {
             "hashes": [
                 "sha256:0e7f69397d53155e55d10ff68fdfb2cf630a35e6daf65cf0bdeaf04f127c09dc",
@@ -444,7 +455,6 @@
                 "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
                 "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
-            "markers": "python_version != '3.4'",
             "version": "==4.5"
         },
         "runway": {

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -23,7 +23,7 @@ from . import EnvManager, handle_bin_download_error
 if sys.version_info >= (3, 6):
     import hcl2  # pylint: disable=import-error
 else:
-    hcl2 = None  # pylint: disable=invalid-name
+    hcl2 = hcl  # pylint: disable=invalid-name
 
 LOGGER = logging.getLogger(__name__)
 TF_VERSION_FILENAME = '.terraform-version'

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -163,7 +163,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         if hcl2:  # TODO remove condition when dropping python 2
             try:
                 return load_terrafrom_module(hcl2, self.path)
-            except ValueError:  # this may need adjusted
+            except (KeyError, ValueError):
                 LOGGER.warning(
                     'failed to parse as HCL2; trying HCL', exc_info=True
                 )

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -23,7 +23,7 @@ from . import EnvManager, handle_bin_download_error
 if sys.version_info >= (3, 6):
     import hcl2  # pylint: disable=import-error
 else:
-    hcl2 = hcl  # pylint: disable=invalid-name
+    hcl2 = None  # pylint: disable=invalid-name
 
 LOGGER = logging.getLogger(__name__)
 TF_VERSION_FILENAME = '.terraform-version'

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -19,10 +19,11 @@ from six.moves.urllib.request import urlretrieve  # pylint: disable=E
 from ..util import cached_property, get_hash_for_filename, merge_dicts, sha256sum
 from . import EnvManager, handle_bin_download_error
 
+# TODO remove condition and import-error when dropping python 2
 if sys.version_info >= (3, 6):
-    import hcl2
+    import hcl2  # pylint: disable=import-error
 else:
-    hcl2 = None
+    hcl2 = None  # pylint: disable=invalid-name
 
 LOGGER = logging.getLogger(__name__)
 TF_VERSION_FILENAME = '.terraform-version'
@@ -159,7 +160,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
             Dict[str, Any]
 
         """
-        if hcl2:
+        if hcl2:  # TODO remove condition when dropping python 2
             try:
                 return load_terrafrom_module(hcl2, self.path)
             except ValueError:  # this may need adjusted

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -178,6 +178,7 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
             for attr, val in copy_data.items():
                 if isinstance(val, list):
                     if len(val) == 1:
+                        # pull single values out of lists
                         data[attr] = _flatten_lists(val[0])
                     else:
                         data[attr] = [_flatten_lists(v) for v in val]

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -162,12 +162,14 @@ class TFEnvManager(EnvManager):  # pylint: disable=too-few-public-methods
         """
         if hcl2:  # TODO remove condition when dropping python 2
             try:
-                return load_terrafrom_module(hcl2, self.path)
-            except (KeyError, ValueError):
-                LOGGER.warning(
-                    'failed to parse as HCL2; trying HCL', exc_info=True
+                return load_terrafrom_module(hcl2, self.path).get('terraform', {})
+            except Exception:  # pylint: disable=broad-except
+                # could result in any number of lark exceptions
+                LOGGER.verbose(
+                    'failed to parse as HCL2; trying HCL',
+                    exc_info=True  # useful in troubleshooting
                 )
-        return load_terrafrom_module(hcl, self.path)
+        return load_terrafrom_module(hcl, self.path).get('terraform', {})
 
     @cached_property
     def version_file(self):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ INSTALL_REQUIRES = [
     'docker',
     'requests',
     'future',
-    'pyhcl~=0.4',
+    'pyhcl~=0.4',  # does not support HCL2, possibly move to extras_require in the future
+    'python-hcl2>=0.3.0,<1.0.0; python_version >= "3.6"',  # only support >=3.6
     'gitpython',
     'importlib-metadata; python_version < "3.8"',
     'packaging',  # component of setuptools needed for version compare

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -1,20 +1,55 @@
 """Test runway.env_mgr.tfenv."""
 # pylint: disable=no-self-use
 import json
+import sys
 
 import hcl
 import pytest
 import six
-from mock import MagicMock, patch
+from mock import MagicMock, call, patch
 
+from runway._logging import LogLevels
 from runway.env_mgr.tfenv import (
     TF_VERSION_FILENAME,
     TFEnvManager,
     get_available_tf_versions,
     get_latest_tf_version,
+    load_terrafrom_module,
 )
 
+# TODO remove condition and import-error when dropping python 2
+if sys.version_info >= (3, 6):
+    import hcl2  # pylint: disable=import-error
+else:
+    hcl2 = None  # pylint: disable=invalid-name
+
 MODULE = 'runway.env_mgr.tfenv'
+
+HCL_BACKEND_REMOTE = """
+terraform {
+  backend "remote" {
+    organization = "test"
+    workspaces {
+      prefix = "test-"
+    }
+  }
+}
+"""
+HCL_BACKEND_S3 = """
+terraform {
+  backend "s3" {
+    bucket = "name"
+  }
+}
+"""
+HCL_ATTR_LIST = """
+terraform {
+  some_attr = [
+    "val1",
+    "val2"
+  ]
+}
+"""
 
 
 @patch(MODULE + '.requests')
@@ -46,32 +81,58 @@ def test_get_latest_tf_version(mock_get_available_tf_versions):
     mock_get_available_tf_versions.assert_called_with(True)
 
 
-class TestTFEnvManager(object):
-    """Test runway.env_mgr.tfenv.TFEnvManager."""
-
-    def test_backend(self, monkeypatch, tmp_path):
-        """Test backend."""
-        monkeypatch.setattr(TFEnvManager, 'terraform_block', {
+@pytest.mark.skipif(sys.version_info < (3, 6),
+                    reason='dependency requires >=3.6')
+@pytest.mark.parametrize('parser, expected', [
+    (hcl, {
+        'terraform': {
             'backend': {
                 's3': {
                     'bucket': 'name'
                 }
             }
-        })
-        tfenv = TFEnvManager(tmp_path)
-        assert tfenv.backend == {
-            'type': 's3',
-            'config': {
-                'bucket': 'name'
-            }
         }
+    }),
+    (hcl2, {
+        'terraform': [{
+            'backend': [{
+                's3': {
+                    'bucket': ['name']
+                }
+            }]
+        }]
+    })
+])
+def test_load_terrafrom_module(parser, expected, tmp_path):
+    """Test runway.env_mgr.tfenv.load_terrafrom_module."""
+    tf_file = tmp_path / 'module.tf'
+    tf_file.write_text(six.u(HCL_BACKEND_S3))
 
-        del tfenv.backend
-        monkeypatch.setattr(tfenv, 'terraform_block', {})
-        assert tfenv.backend == {
-            'type': None,
-            'config': {}
-        }
+    assert load_terrafrom_module(parser, tmp_path) == expected
+
+
+class TestTFEnvManager(object):
+    """Test runway.env_mgr.tfenv.TFEnvManager."""
+
+    @pytest.mark.parametrize('response, expected', [
+        ({}, {'type': None, 'config': {}}),
+        (hcl.loads(HCL_BACKEND_S3),
+         {'type': 's3', 'config': {'bucket': 'name'}}),
+        (hcl2.loads(HCL_BACKEND_S3),
+         {'type': 's3', 'config': {'bucket': 'name'}}),
+        (hcl.loads(HCL_BACKEND_REMOTE),
+         {'type': 'remote', 'config': {'organization': 'test',
+                                       'workspaces': {'prefix': 'test-'}}}),
+        (hcl2.loads(HCL_BACKEND_REMOTE),
+         {'type': 'remote', 'config': {'organization': 'test',
+                                       'workspaces': {'prefix': 'test-'}}})
+    ])
+    @patch(MODULE + '.load_terrafrom_module')
+    def test_backend(self, mock_load_terrafrom_module, response, expected, tmp_path):
+        """Test backend."""
+        mock_load_terrafrom_module.return_value = response
+        tfenv = TFEnvManager(tmp_path)
+        assert tfenv.backend == expected
 
     def test_get_min_required(self, monkeypatch, tmp_path):
         """Test get_min_required."""
@@ -223,22 +284,45 @@ class TestTFEnvManager(object):
         mock_download.assert_not_called()
         assert not tfenv.current_version
 
-    def test_terraform_block(self, tmp_path):
+    @pytest.mark.wip
+    @pytest.mark.skipif(sys.version_info < (3, 6),
+                        reason='dependency requires >=3.6')
+    @pytest.mark.parametrize('response, expected', [
+        ([{}], {}),
+        ([hcl2.loads(HCL_BACKEND_S3)],
+         {'backend': {'s3': {'bucket': 'name'}}}),
+        ([Exception, hcl.loads(HCL_BACKEND_S3)],
+         {'backend': {'s3': {'bucket': 'name'}}}),
+        ([hcl2.loads(HCL_BACKEND_REMOTE)],
+         {'backend': {'remote': {'organization': 'test',
+                                 'workspaces': {'prefix': 'test-'}}}}),
+        ([Exception, hcl.loads(HCL_BACKEND_REMOTE)],
+         {'backend': {'remote': {'organization': 'test',
+                                 'workspaces': {'prefix': 'test-'}}}}),
+        ([hcl2.loads(HCL_ATTR_LIST)],
+         {'some_attr': ['val1', 'val2']}),
+        ([Exception, hcl.loads(HCL_ATTR_LIST)],
+         {'some_attr': ['val1', 'val2']})
+    ])
+    @patch(MODULE + '.load_terrafrom_module')
+    def test_terraform_block(self, mock_load_terrafrom_module,
+                             response, expected, caplog, tmp_path):
         """Test terraform_block."""
-        content = {
-            'terraform': {
-                'backend': {
-                    's3': {
-                        'bucket': 'name'
-                    }
-                }
-            }
-        }
-        tf_file = tmp_path / 'module.tf'
-        tf_file.write_text(six.u(hcl.dumps(content)))
+        caplog.set_level(LogLevels.VERBOSE, logger=MODULE)
+        mock_load_terrafrom_module.side_effect = response
         tfenv = TFEnvManager(tmp_path)
 
-        assert tfenv.terraform_block == content['terraform']
+        assert tfenv.terraform_block == expected
+
+        if not isinstance(response[0], dict):
+            assert 'failed to parse as HCL2; trying HCL' in '\n'.join(
+                caplog.messages
+            )
+            mock_load_terrafrom_module.assert_has_calls([
+                call(hcl2, tmp_path), call(hcl, tmp_path)
+            ])
+        else:
+            mock_load_terrafrom_module.assert_called_once_with(hcl2, tmp_path)
 
     def test_version_file(self, tmp_path):
         """Test version_file."""

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -21,7 +21,7 @@ from runway.env_mgr.tfenv import (
 if sys.version_info >= (3, 6):
     import hcl2  # pylint: disable=import-error
 else:
-    hcl2 = None  # pylint: disable=invalid-name
+    hcl2 = hcl  # pylint: disable=invalid-name
 
 MODULE = 'runway.env_mgr.tfenv'
 


### PR DESCRIPTION

## Why This Is Needed

Adds support for HCL2 syntax.

resolves #406 

## What Changed

### Added

- `python-hcl2` is now a Runway dependency when installed with Python >=3.6

### Changed

- Runway will now try to parse Terraform files using an HCL2 parser (if Python >=3.6) with an HCL parser (original functionality) as fallback
