### PR TITLE
xref lookup will now only log that its deprecated once per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - support for HCL2 using `python-hcl2` (requires Python >= 3.6)
 
+### Changes
+
+- xref CFNgin lookup now only logs once per run that it is deprecated
+
 ## [1.11.0] - 2020-08-11
 ### Added
 - custom per-backend (Terraform) handling is now supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - support for HCL2 using `python-hcl2` (requires Python >= 3.6)
 
-### Changes
+### Changed
 
 - xref CFNgin lookup now only logs once per run that it is deprecated
 

--- a/runway/cfngin/lookups/handlers/xref.py
+++ b/runway/cfngin/lookups/handlers/xref.py
@@ -9,6 +9,10 @@ from .output import deconstruct
 LOGGER = logging.getLogger(__name__)
 TYPE_NAME = "xref"
 
+XREF_PRESISTENT_STATE = {
+    'has_warned': False
+}
+
 
 class XrefLookup(LookupHandler):
     """Xref lookup."""
@@ -42,7 +46,9 @@ class XrefLookup(LookupHandler):
                 conf_value: ${xref fully-qualified-stack-name::SomeOutputName}
 
         """
-        LOGGER.warning(cls.DEPRECATION_MSG)
+        if not XREF_PRESISTENT_STATE.get('has_warned'):
+            LOGGER.warning(cls.DEPRECATION_MSG)
+            XREF_PRESISTENT_STATE['has_warned'] = True
         if provider is None:
             raise ValueError('Provider is required')
 


### PR DESCRIPTION

## Why This Is Needed

resolves #411 

## What Changed

### Changed

- xref CFNgin lookup now only logs once per run that it is deprecated
