### PR TITLE
fix missing hcl2.lark in binary releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixed an issue preventing binary releases of Runway from functioning because `hcl2.lark` did not exist
 
 ## [1.11.1] - 2020-08-14
 ### Added

--- a/runway.file.spec
+++ b/runway.file.spec
@@ -74,6 +74,7 @@ data_files.append(('{}/awscli/data'.format(get_distribution('awscli').location),
                    'awscli/data/'))
 data_files.extend(collect_data_files('cfnlint'))
 data_files.extend(collect_data_files('distutils'))
+data_files.extend(collect_data_files('hcl2'))
 data_files.extend(collect_data_files('pip'))
 data_files.extend(collect_data_files('wheel'))
 data_files.append(copy_metadata('runway')[0])  # support scm version

--- a/runway.folder.spec
+++ b/runway.folder.spec
@@ -74,6 +74,7 @@ data_files.append(('{}/awscli/data'.format(get_distribution('awscli').location),
                    'awscli/data/'))
 data_files.extend(collect_data_files('cfnlint'))
 data_files.extend(collect_data_files('distutils'))
+data_files.extend(collect_data_files('hcl2'))
 data_files.extend(collect_data_files('pip'))
 data_files.extend(collect_data_files('wheel'))
 data_files.append(copy_metadata('runway')[0])  # support scm version


### PR DESCRIPTION

## Why This Is Needed

resolves #414 

## What Changed

### Fixed

- fixed an issue preventing binary releases of Runway from functioning because `hcl2.lark` did not exist

