### PR TITLE
fix `npx runway` on Windows when path contains a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixed an issue where `npx runway` (installed from npm) would not work on Windows if there was a space in the path
 
 ## [1.11.2] - 2020-08-17
 ### Fixed

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -94,7 +94,7 @@ fs.mkdir(`${moduleDir}/runway`, { recursive: true }, (err, data) => {
       }
       // symlink does not work for windows so we need to use a bat file
       // this will overwrite the file if it already exists so no fancy error handling needed
-      fs.writeFile(binPath, `@${moduleDir}/runway/runway-cli.exe %*`, (err, data) => {
+      fs.writeFile(binPath, `@"${moduleDir}/runway/runway-cli.exe %*"`, (err, data) => {
         if (err) throw err;
       })
     }


### PR DESCRIPTION
## Summary

Wraps the path to unzipped Runway executable with quotes when creating the `runway.bat` file on Windows.

## Why This Is Needed

resolves #418 

## What Changed

### Changed

- the path written to `runway.bat` when installing from npm on Windows is now wrapped in quotes

### Fixed

- fixed an issue where `npx runway` (installed from npm) would not work on Windows if there was a space in the path
