### PR TITLE
Update other_ways_to_use.rst

### DIFF
--- a/docs/source/quickstart/other_ways_to_use.rst
+++ b/docs/source/quickstart/other_ways_to_use.rst
@@ -29,7 +29,7 @@ Docker users can build their own Docker image to run a local Runway
 container or modify this `Dockerfile`_ to build a Runway image to suit specific
 needs.
 
-We have also provide a pre-build Docker image on `Docker Hub`_ that can be
+We have also provide a pre-built Docker image on `Docker Hub`_ that can be
 used with the following command.
 
 .. code-block:: shell

--- a/docs/source/quickstart/other_ways_to_use.rst
+++ b/docs/source/quickstart/other_ways_to_use.rst
@@ -28,10 +28,3 @@ Docker
 Docker users can build their own Docker image to run a local Runway
 container or modify this `Dockerfile`_ to build a Runway image to suit specific
 needs.
-
-We have also provide a pre-built Docker image on `Docker Hub`_ that can be
-used with the following command.
-
-.. code-block:: shell
-
-    $ docker run -it --rm onica/runway-quickstart


### PR DESCRIPTION
Removing mention of the public docker image, as it is out of date and not actively maintained. 

## Summary

There are no plans to upgrade the docker image with the latest runway versions, so we should not include it in the docs.

## Why This Is Needed

Improves overall quality of docs and does not encourage users to use an old version of runway.

## What Changed

Removed mention of publicly available container.