### PR TITLE
update quickstart dockerfile to show use of binary release, remove mention of published docker image

### DIFF
--- a/docs/source/quickstart/other_ways_to_use.rst
+++ b/docs/source/quickstart/other_ways_to_use.rst
@@ -1,9 +1,9 @@
 .. _CloudFormation template: https://github.com/onicagroup/runway/blob/master/quickstarts/runway/runway-quickstart.yml
 .. _Dockerfile: https://github.com/onicagroup/runway/blob/master/quickstarts/runway/Dockerfile
-.. _Docker hub: https://hub.docker.com
 
+########################
 Other Ways to Use Runway
-========================
+########################
 
 While we recommend using one of the install methods outlined in the
 :ref:`Installation<install>` section, we realize that these may not be an
@@ -12,8 +12,9 @@ up a deploy environment in AWS and a `Docker`_ image/Dockerfile that can be
 used to run Runway.
 
 
+**************
 CloudFormation
-^^^^^^^^^^^^^^
+**************
 
 This `CloudFormation template`_ is probably the easiest and quickest way to go
 from "zero to Runway" as it allows for using an IAM Role eliminate the need to
@@ -22,15 +23,13 @@ Windows Runway host. Windows Runway host includes vsCode, which some users may
 find easier for manipulating Runway config files.
 
 
+******
 Docker
-^^^^^^
+******
 
 Docker users can build their own Docker image to run a local Runway
 container or modify this `Dockerfile`_ to build a Runway image to suit specific
 needs.
-
-We have also provide a pre-build Docker image on `Docker Hub`_ that can be
-used with the following command.
 
 .. code-block:: shell
 

--- a/quickstarts/runway/Dockerfile
+++ b/quickstarts/runway/Dockerfile
@@ -15,10 +15,8 @@ RUN set -xe && \
   rm -rf /var/lib/apt/lists/* && \
   update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10 && \
   npm install npm@latest -g && \
-  curl -o tf.zip https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip && \
-  unzip tf.zip && \
-  mv terraform /usr/local/bin/ && \
-  pip install ply && \
-  pip install pipenv runway
+  curl -L oni.ca/runway/latest/linux -o runway && \
+  chmod +x runway && \
+  mv runway /usr/local/bin
 
 CMD ["bash"]


### PR DESCRIPTION
## Why This Is Needed

resolves #421 

## What Changed

### Changed

- quick start Dockerfile now downloads and uses Runway's binary release

### Removed

- quick start Dockerfile no longer installs Terraform as its now handled by Runway per-module
- docs no longer reference an image on Docker Hub as its no longer maintained

