### PR TITLE
adjust workflow to skip npm build if commit is tagged

### DIFF
--- a/.github/scripts/cicd/check_distance_from_tag.sh
+++ b/.github/scripts/cicd/check_distance_from_tag.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Checks for this distance from the last tag.
+# If there is no distence, return a non-zero exit code.
+#
+# This can be used in GitHub actions with the following steps using conditionals to handle either case.
+#
+# Example:
+#
+#   - id: check_distance
+#     continue-on-error: true
+#     run: bash ./check_distance_from_tag.sh
+#     working-directory: .github/scripts/cicd
+#   - if: steps.check_distance.outcome == 'failure'
+#     run: echo "No distance"
+#   - if: steps.check_distance.outcome == 'success'
+#     run: echo "There is distance"
+
+DESCRIBE=`git describe --tags --match "v*.*.*"`
+echo "Result from 'git describe': ${DESCRIBE}"
+DISTANCE=`echo ${DESCRIBE} | grep -P '\-(\d)*\-g(\d)*'`
+if [ -n "${DISTANCE}" ]; then
+    echo "Distance from last tag detected: ${DISTANCE}"
+    echo "It is safe to proceed with a pre-production release."
+    exit 0
+else
+    echo "No distance from last tag; skipping pre-production release."
+    exit 1
+fi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -249,7 +249,7 @@ jobs:
       NODE_VERSION: 12
       NPM_PACKAGE_NAME: '@onica/runway'
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7]
@@ -325,10 +325,9 @@ jobs:
           find . -name 'onica-runway-*.*.*.tgz' -exec mv {} artifacts/ \;
       - name: Skipped Publishing
         if: steps.check_distance.outcome == 'failure'
-        run: |
-          mkdir -p artifacts
-          echo "A pre-production version was not published because the current commit is tagged for release."
+        run: echo "A pre-production version was not published because the current commit is tagged for release."
       - name: Upload Artifacts
+        if: steps.check_distance.outcome == 'success'
         uses: actions/upload-artifact@v1.0.0
         with:
           name: npm-pack
@@ -345,7 +344,7 @@ jobs:
       NPM_PACKAGE_NAME: '@onica/runway'
       NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7]
@@ -357,15 +356,21 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org/
       - name: Download Artifact
+        id: download-npm-pack
+        continue-on-error: true
         uses: actions/download-artifact@v1.0.0
         with:
           name: npm-pack
           path: artifacts
       - name: Publish Distribution 📦 to npm (dev)
+        if: steps.download-npm-pack.outcome == 'success'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
         run: |
           find ./artifacts -name 'onica-runway-*.*.*-*.tgz' -exec npm publish --access public --tag dev {} +
+      - name: Artifact Does Not Exist
+        if: steps.download-npm-pack.outcome == 'failure'
+        run: echo "Artifact npm-pack was not produced from the build step"
 
   build-pypi:
     name: Build PyPi 📦

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -257,17 +257,22 @@ jobs:
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
-      # - *install_python
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
+      - id: check_distance
+        name: Ensure Commit Is Not Tagged
+        continue-on-error: true
+        run: bash ./check_distance_from_tag.sh
+        working-directory: .github/scripts/cicd
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        if: steps.check_distance.outcome == 'success'
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Node ${{ env.NODE_VERSION }} on ${{ matrix.os }}
+        if: steps.check_distance.outcome == 'success'
         uses: actions/setup-node@v1.4.1
         with:
           always-auth: true
@@ -275,8 +280,8 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: '@onica'
       - name: Install Dependencies (ubuntu)
+        if: steps.check_distance.outcome == 'success'
         run: sudo apt-get update && sudo apt-get install sed tree -y
-      # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
         if: matrix.os == 'ubuntu-latest'
@@ -286,33 +291,45 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-pip-${{ matrix.python-version }}
       - name: Install Global Python Packages
+        if: steps.check_distance.outcome == 'success'
         run: |
           python -m pip install --upgrade pip setuptools
           pip install "setuptools-scm~=3.5.0" wheel
       - name: Download Artifacts (macOS)
+        if: steps.check_distance.outcome == 'success'
         uses: actions/download-artifact@v1.0.0
         with:
           name: pyinstaller-onefolder-macos-latest
           path: artifacts
       - name: Download Artifacts (ubuntu)
+        if: steps.check_distance.outcome == 'success'
         uses: actions/download-artifact@v1.0.0
         with:
           name: pyinstaller-onefolder-ubuntu-latest
           path: artifacts
       - name: Download Artifacts (windows)
+        if: steps.check_distance.outcome == 'success'
         uses: actions/download-artifact@v1.0.0
         with:
           name: pyinstaller-onefolder-windows-latest
           path: artifacts
       - name: List Artifacts
+        if: steps.check_distance.outcome == 'success'
         run: tree artifacts/
       - name: npm Prep
+        if: steps.check_distance.outcome == 'success'
         run: make npm_prep
       - name: npm pack
+        if: steps.check_distance.outcome == 'success'
         run: |
           npm pack
           rm -rf artifacts && mkdir -p artifacts
           find . -name 'onica-runway-*.*.*.tgz' -exec mv {} artifacts/ \;
+      - name: Skipped Publishing
+        if: steps.check_distance.outcome == 'failure'
+        run: |
+          mkdir -p artifacts
+          echo "A pre-production version was not published because the current commit is tagged for release."
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1.0.0
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - # &checkout
         name: Checkout Repo
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v2.3.2
       - # &install_python
         name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
@@ -106,11 +106,10 @@ jobs:
     env:
       OS_NAME: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
       # - *install_python
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
@@ -179,11 +178,10 @@ jobs:
     env:
       OS_NAME: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
       # - *install_python
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
@@ -381,11 +379,10 @@ jobs:
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
       # - *install_python
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -23,11 +23,10 @@ jobs:
     env:
       OS_NAME: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
       # - *install_python
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
@@ -96,11 +95,10 @@ jobs:
     env:
       OS_NAME: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
       # - *install_python
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
@@ -172,11 +170,10 @@ jobs:
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
       # - *install_python
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
@@ -275,11 +272,10 @@ jobs:
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
-      # - *checkout
-      - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
-      - name: git unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout Repo (complete)
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
       # - *install_python
       - name: Install Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
@@ -379,7 +375,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v2.3.2
       - name: Install Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
## Why This Is Needed

resolves #405 

## What Changed

### Added

- added script that checks for distance from the last tag

### Changed

- the npm deployment package is now only built if commit is not tagged

## Examples

- [untagged commit to master](https://github.com/ITProKyle/gh-actions-tag-test/actions/runs/215900239)
- [tagged commit to master pushed with its tag](https://github.com/ITProKyle/gh-actions-tag-test/actions/runs/215898300) (shows erroneous annotations on the workflow run but, still registers as passing since the errors are _handled_)