### PR TITLE
update pylint & isort

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -150,13 +150,15 @@ disable=useless-object-inheritance,
         missing-class-docstring,
         # flake8 (pydocstyle) overlap
         missing-function-docstring,
-        # needed for black formatting
-        bad-continuation,
         # with black formatting, it is difficult to avoide this with inherited
         # code or code that needs to be duplicated.
         similarities,
         # flake8 overlap
-        line-too-long
+        line-too-long,
+        # TODO remove & resolve when dropping python 2
+        super-with-arguments,
+        # TODO remove & resolve when dropping python 2
+        raise-missing-from
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -469,13 +471,6 @@ max-line-length=100
 
 # Maximum number of lines in a module
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ lint-pylint: ## run pylint
 # linting for python 2, requires additional disables
 lint_two: ## run all linters (python 2 only)
 	pipenv run flake8 --config=setup.cfg --exclude=runway/embedded,runway/templates --extend-ignore=D101,D202,D403,E124,E203,W504 runway
-	find runway -name '*.py' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run pylint --rcfile=.pylintrc --disable=bad-option-value,method-hidden,relative-import
+	find runway -name '*.py' -not -path 'runway/embedded*' -not -path 'runway/templates/stacker/*' -not -path 'runway/templates/cdk-py/*' -not -path 'runway/blueprints/*' | xargs pipenv run pylint --rcfile=.pylintrc --disable=bad-continuation,bad-option-value,bad-whitespace,method-hidden,relative-import
 
 test: ## run integration and unit tests
 	@echo "Running integration & unit tests..."

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ lint-flake8: ## run flake8
 
 lint-isort: ## run isort
 	@echo "Running isort... If this fails, run 'make fix-isort' to resolve."
-	@pipenv run isort . --recursive --check-only
+	@pipenv run isort . --check-only
 	@echo ""
 
 lint-pylint: ## run pylint

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ fix-isort: ## automatically fix all isort errors
 lint: lint-isort lint-black lint-flake8 lint-pylint ## run all linters
 
 lint-black: ## run black
-	@echo "Running black... If this failes, run 'make fix-black' to resolve."
+	@echo "Running black... If this fails, run 'make fix-black' to resolve."
 	@pipenv run black . --check
 	@echo ""
 

--- a/Pipfile
+++ b/Pipfile
@@ -13,15 +13,13 @@ importlib-resources = {version = ">=1.4", python_version = '<"3.7"'}
 # Format
 black = {version = "==19.10b0",python_version = '>="3.6"'}  # since its pre-release, it has to be pinned this way for pipenv to install it
 # Lint
-isort = "<5.0.0"  # v5 drops python 2 support
+isort = "~=5.4.2"  # v5 drops python 2 support
+pylint = "~=2.6.0"
 ## flake8
 flake8 = "~=3.8.2"
 flake8-docstrings = "~=1.5.0"
 pep8-naming = "~=0.11"
 pydocstyle = "~=5.0.2"
-## Pylint
-pylint = ">=2.5.0"  # pinned to avoid "Instance of '' has no 'Bucket' member"
-astroid = ">=2.4.0"  # https://github.com/PyCQA/pylint/issues/3134
 # Test
 coverage = {extras = ["toml"], version = "~=5.2.1"}
 pytest = "<5.0"  # last version that supports 2.7 - allows install with 2/3

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dccc706c886a7680c4f078717a4a37956170e4b2fd6e985d94802c6f1dda4630"
+            "sha256": "b4ba3aaafc7d511e4128d005e45b9541cf4b08d6e190f33048851807514e327f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,10 +16,10 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a",
+                "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"
             ],
-            "version": "==19.3.0"
+            "version": "==20.1.0"
         },
         "awacs": {
             "hashes": [
@@ -37,23 +37,24 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:4fa6d2cdf11c03e6130b33ac05e99b4c595b0ed51b2c6889bc0cd5f4b4f11fab"
+                "sha256:1716fb9a608e63cb8c8943b5012d7df51f87639a46c1761e37ee57157b903021",
+                "sha256:f4f740740764dec66a44eb65ba3fe575eafe909ad73d98d39e17a6b743e7e99a"
             ],
-            "version": "==1.18.122"
+            "version": "==1.18.124"
         },
         "boto3": {
             "hashes": [
-                "sha256:02ad765927bb46b9f45c3bce65e763960733919eee7883217995c5df5d096695",
-                "sha256:4421aad9a9740ce95199460f3262859e1c3594cc6c86cbe552745f4bbff34300"
+                "sha256:0d9cbeb5c8ca67650cc963c77e2e3b3ab5dffeeee16e03d61d740755f8fc7c44",
+                "sha256:df73edf3bd6f191870212e04ae9a8bc6245fd6749f464e9fb950392a8d15bd8c"
             ],
-            "version": "==1.14.45"
+            "version": "==1.14.47"
         },
         "botocore": {
             "hashes": [
-                "sha256:17470c97435891cf40e147f533069de0109cda24c208c918f28997274bbac399",
-                "sha256:bc8b1c83ccc0d77963849b66a94bbb20a666ff0225aff84de7ed0175db1fd6f7"
+                "sha256:42b320b449df22cdb1232913e4a066919d127feb8e58ad98898831e6255ccfe0",
+                "sha256:eca25f01c503c2b86b394497f875a0eb0d3fe367dbc032f3a02851ba7e827109"
             ],
-            "version": "==1.17.45"
+            "version": "==1.17.47"
         },
         "certifi": {
             "hashes": [
@@ -127,6 +128,7 @@
                 "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
                 "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==0.4.3"
         },
         "coloredlogs": {
@@ -169,10 +171,10 @@
         },
         "docker": {
             "hashes": [
-                "sha256:431a268f2caf85aa30613f9642da274c62f6ee8bae7d70d968e01529f7d6af93",
-                "sha256:ba118607b0ba6bfc1b236ec32019a355c47b5d012d01d976467d4692ef443929"
+                "sha256:13966471e8bc23b36bfb3a6fb4ab75043a5ef1dac86516274777576bed3b9828",
+                "sha256:bad94b8dd001a8a4af19ce4becc17f41b09f228173ffe6a4e0355389eef142f2"
             ],
-            "version": "==4.3.0"
+            "version": "==4.3.1"
         },
         "docutils": {
             "hashes": [
@@ -447,6 +449,7 @@
                 "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
                 "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==4.5"
         },
         "runway": {
@@ -551,7 +554,6 @@
                 "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
                 "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
             ],
-            "index": "pypi",
             "version": "==2.4.2"
         },
         "atomicwrites": {
@@ -563,10 +565,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a",
+                "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"
             ],
-            "version": "==19.3.0"
+            "version": "==20.1.0"
         },
         "aws-sam-translator": {
             "hashes": [
@@ -601,17 +603,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:02ad765927bb46b9f45c3bce65e763960733919eee7883217995c5df5d096695",
-                "sha256:4421aad9a9740ce95199460f3262859e1c3594cc6c86cbe552745f4bbff34300"
+                "sha256:0d9cbeb5c8ca67650cc963c77e2e3b3ab5dffeeee16e03d61d740755f8fc7c44",
+                "sha256:df73edf3bd6f191870212e04ae9a8bc6245fd6749f464e9fb950392a8d15bd8c"
             ],
-            "version": "==1.14.45"
+            "version": "==1.14.47"
         },
         "botocore": {
             "hashes": [
-                "sha256:17470c97435891cf40e147f533069de0109cda24c208c918f28997274bbac399",
-                "sha256:bc8b1c83ccc0d77963849b66a94bbb20a666ff0225aff84de7ed0175db1fd6f7"
+                "sha256:42b320b449df22cdb1232913e4a066919d127feb8e58ad98898831e6255ccfe0",
+                "sha256:eca25f01c503c2b86b394497f875a0eb0d3fe367dbc032f3a02851ba7e827109"
             ],
-            "version": "==1.17.45"
+            "version": "==1.17.47"
         },
         "certifi": {
             "hashes": [
@@ -764,10 +766,10 @@
         },
         "docker": {
             "hashes": [
-                "sha256:431a268f2caf85aa30613f9642da274c62f6ee8bae7d70d968e01529f7d6af93",
-                "sha256:ba118607b0ba6bfc1b236ec32019a355c47b5d012d01d976467d4692ef443929"
+                "sha256:13966471e8bc23b36bfb3a6fb4ab75043a5ef1dac86516274777576bed3b9828",
+                "sha256:bad94b8dd001a8a4af19ce4becc17f41b09f228173ffe6a4e0355389eef142f2"
             ],
-            "version": "==4.3.0"
+            "version": "==4.3.1"
         },
         "docutils": {
             "hashes": [
@@ -844,11 +846,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:60a1b97e33f61243d12647aaaa3e6cc6778f5eb9f42997650f1cc975b6008750",
+                "sha256:d488ba1c5a2db721669cc180180d5acf84ebdc5af7827f7aaeaa75f73cf0e2b8"
             ],
             "index": "pypi",
-            "version": "==4.3.21"
+            "version": "==5.4.2"
         },
         "jinja2": {
             "hashes": [
@@ -1119,11 +1121,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc",
-                "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"
+                "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210",
+                "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"
             ],
             "index": "pypi",
-            "version": "==2.5.3"
+            "version": "==2.6.0"
         },
         "pyparsing": {
             "hashes": [
@@ -1265,6 +1267,7 @@
                 "sha256:35c5b5f6675ac02120036d97cf96f1fde4d49670543db2822ba5015e21a18032",
                 "sha256:4d409f5a7d78530a4a2062574c7bd80311bc3af29b364e293aa9b03eea77714f"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==4.5"
         },
         "s3transfer": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,25 +44,12 @@ omit = ["*/runway/aws_sso_botocore/*"]  # TODO remove native support is added to
 
 
 [tool.isort]
-force_grid_wrap = 0
-include_trailing_comma = true
-# TODO remove runway from known first party when isort>=5 can be used in the repo
-known_first_party = ["runway"]
+profile = "black"
 known_local_folder = [
     "jwks_rsa",
     "shared",
     "update_urls",
 ]
-known_third_party = [  # most of these exist in integration_tests/ only
-    "jose",  # not correctly identified by isort<5
-    "pexpect",
-    "prettytable",
-    "mypy_boto3_dynamodb",  # not correctly identified by isort<5
-    "semver",  # not correctly identified by isort<5
-    "send2trash",
-]
-line_length = 88
-multi_line_output = 3
 skip = [
     ".demo",
     ".eggs",
@@ -78,4 +65,3 @@ skip = [
     "node_modules",
     "venv",
 ]
-use_parentheses = true


### PR DESCRIPTION

## Why This Is Needed

resolves #425 

previous versions of pylint required isort<5 preventing use of the vast improvements made in isort v5

## What Changed

### Changed

- updated pylint to `~=2.6.0`
	- updated .pylintrc accordingly
	- updated `lint_two` cli options to be compatible with the new config
- updated isort to `~=5.4.2`
	- update cli options for v5
