### PR TITLE
add v1 & v2 branch names to cicd trigger and allow branch names

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -17,7 +17,7 @@ jobs:
           # All branches should start with the given prefix
           allowed_prefixes: 'bugfix,chore,dependabot,docs,enhancement,feat,feature,fix,hotfix,maint,maintain,maintenance,release'
           # Ignore exactly matching branch names from convention
-          ignore: master,release,develop,v0_47_fixes
+          ignore: master,release,develop,v0_47_fixes,v1,v2
           # Min length of the branch name
           min_length: 5
           # Max length of the branch name

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+      - v1
+      - v2
 
 env:
   AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION

## Why This Is Needed

Allow workflows to run/pass checks for branches that will be used leading up to Runway v2.

## What Changed

### Changed

- CI/CD workflow will now run on push to v1 & v2 branches
- "Enforce Branch Name" check will pass for branches v1 & v2
