### PR TITLE
update workflow to not install dev dependencies when building artifacts

### DIFF
--- a/.github/requirements/build-pyinstaller.txt
+++ b/.github/requirements/build-pyinstaller.txt
@@ -1,3 +1,3 @@
 -i https://pypi.org/simple
 pyinstaller==3.5  # stuck till this is resolved https://github.com/pyinstaller/pyinstaller/issues/4674
-setuptools<50.0.0  # replaces stdlib.distutils with it's own breaking ^ version of pyinstaller
+setuptools<49.2 # replaces stdlib.distutils with it's own breaking ^ version of pyinstaller

--- a/.github/requirements/build-pyinstaller.txt
+++ b/.github/requirements/build-pyinstaller.txt
@@ -1,4 +1,3 @@
 -i https://pypi.org/simple
-virtualenv==16.7.9  # stuck due to pyinstaller
-pipenv==2018.11.26  # stuck due to pyinstaller
 pyinstaller==3.5  # stuck till this is resolved https://github.com/pyinstaller/pyinstaller/issues/4674
+setuptools<50.0.0  # replaces stdlib.distutils with it's own breaking ^ version of pyinstaller

--- a/.github/requirements/build-pyinstaller.txt
+++ b/.github/requirements/build-pyinstaller.txt
@@ -1,0 +1,4 @@
+-i https://pypi.org/simple
+virtualenv==16.7.9  # stuck due to pyinstaller
+pipenv==2018.11.26  # stuck due to pyinstaller
+pyinstaller==3.5  # stuck till this is resolved https://github.com/pyinstaller/pyinstaller/issues/4674

--- a/.github/requirements/requirements.txt
+++ b/.github/requirements/requirements.txt
@@ -1,0 +1,6 @@
+# global requirements that can apply to all steps
+-i https://pypi.org/simple
+setuptools_scm~=4.1.2
+virtualenv==16.7.9  # stuck due to pyinstaller
+pipenv==2018.11.26  # stuck due to pyinstaller
+wheel

--- a/.github/scripts/cicd/build_pyinstaller.sh
+++ b/.github/scripts/cicd/build_pyinstaller.sh
@@ -32,15 +32,15 @@ pipenv run pyinstaller --noconfirm --clean runway.$1.spec
 if [ "$1" == 'file' ]; then
     mv dist/* artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
     chmod +x artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway
-    # quick functionality test
+    # quick functional test
     ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway --version
 else
     if [ "$OS_NAME" == "windows-latest" ]; then
         7z a -ttar -so ./runway.tar ./dist/runway/* | 7z a -si ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway.tar.gz
     else
         chmod +x dist/runway/runway-cli
-        # quick functionality test
-        .dist/runway/runway-cli --version
+        # quick functional test
+        ./dist/runway/runway-cli --version
         tar -C dist/runway/ -czvf ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway.tar.gz .
     fi
 fi

--- a/.github/scripts/cicd/build_pyinstaller.sh
+++ b/.github/scripts/cicd/build_pyinstaller.sh
@@ -26,6 +26,7 @@ pipenv run python setup.py sdist
 pipenv run pip install .
 rm -rf dist/runway-$RUNWAY_VERSION.tar.gz
 mkdir -p artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
+pipenv run pip show setuptools
 pipenv run pyinstaller --noconfirm --clean runway.$1.spec
 
 if [ "$1" == 'file' ]; then

--- a/.github/scripts/cicd/build_pyinstaller.sh
+++ b/.github/scripts/cicd/build_pyinstaller.sh
@@ -31,10 +31,16 @@ pipenv run pyinstaller --noconfirm --clean runway.$1.spec
 
 if [ "$1" == 'file' ]; then
     mv dist/* artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME
+    chmod +x artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway
+    # quick functionality test
+    ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway --version
 else
     if [ "$OS_NAME" == "windows-latest" ]; then
         7z a -ttar -so ./runway.tar ./dist/runway/* | 7z a -si ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway.tar.gz
     else
+        chmod +x dist/runway/runway-cli
+        # quick functionality test
+        .dist/runway/runway-cli --version
         tar -C dist/runway/ -czvf ./artifacts/$RUNWAY_VERSION/$LOCAL_OS_NAME/runway.tar.gz .
     fi
 fi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -152,15 +152,13 @@ jobs:
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
           restore-keys: |
             ${{ matrix.os }}-pip-${{ matrix.python-version }}
-      # - *install_pip
       - name: Install Global Python Packages
+        working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install "virtualenv==16.7.9" "pipenv==2018.11.26"
-      # - *pipenv_sync
-      - name: Setup Python Virtual Environment (3.x)
-        if: matrix.python-version != '2.7'
-        run: pipenv sync --dev
+          pip install -r build-pyinstaller.txt
+      - name: Setup Python Virtual Environment (no dev)
+        run: pipenv sync
       - name: Run Build
         run: make build_pyinstaller_file
       - name: Upload Artifacts
@@ -224,15 +222,13 @@ jobs:
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
           restore-keys: |
             ${{ matrix.os }}-pip-${{ matrix.python-version }}
-      # - *install_pip
       - name: Install Global Python Packages
+        working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install "virtualenv==16.7.9" "pipenv==2018.11.26"
-      # - *pipenv_sync
-      - name: Setup Python Virtual Environment (3.x)
-        if: matrix.python-version != '2.7'
-        run: pipenv sync --dev
+          pip install -r build-pyinstaller.txt
+      - name: Setup Python Virtual Environment (no dev)
+        run: pipenv sync
       - name: Run Build
         run: make build_pyinstaller_folder
       - name: Upload Artifacts

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -156,9 +156,11 @@ jobs:
         working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install -r build-pyinstaller.txt
-      - name: Setup Python Virtual Environment (no dev)
-        run: pipenv sync
+          pip install -r requirements.txt
+      - name: Setup Python Virtual Environment
+        # our version of pipenv does not respect versions in a requirements file
+        # to we have to use pip within a venv to process it correctly
+        run: pipenv run pip install -r .github/requirements/build-pyinstaller.txt
       - name: Run Build
         run: make build_pyinstaller_file
       - name: Upload Artifacts
@@ -226,9 +228,11 @@ jobs:
         working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install -r build-pyinstaller.txt
-      - name: Setup Python Virtual Environment (no dev)
-        run: pipenv sync
+          pip install -r requirements.txt
+      - name: Setup Python Virtual Environment
+        # our version of pipenv does not respect versions in a requirements file
+        # to we have to use pip within a venv to process it correctly
+        run: pipenv run pip install -r .github/requirements/build-pyinstaller.txt
       - name: Run Build
         run: make build_pyinstaller_folder
       - name: Upload Artifacts

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -71,9 +71,11 @@ jobs:
         working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install -r build-pyinstaller.txt
-      - name: Setup Python Virtual Environment (no dev)
-        run: pipenv sync
+          pip install -r requirements.txt
+      - name: Setup Python Virtual Environment
+        # our version of pipenv does not respect versions in a requirements file
+        # to we have to use pip within a venv to process it correctly
+        run: pipenv run pip install -r .github/requirements/build-pyinstaller.txt
       - name: Run Build
         run: make build_pyinstaller_file
       - name: Upload Artifacts
@@ -141,9 +143,11 @@ jobs:
         working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install -r build-pyinstaller.txt
-      - name: Setup Python Virtual Environment (no dev)
-        run: pipenv sync
+          pip install -r requirements.txt
+      - name: Setup Python Virtual Environment
+        # our version of pipenv does not respect versions in a requirements file
+        # to we have to use pip within a venv to process it correctly
+        run: pipenv run pip install -r .github/requirements/build-pyinstaller.txt
       - name: Run Build
         run: make build_pyinstaller_folder
       - name: Upload Artifacts

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -67,15 +67,13 @@ jobs:
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
           restore-keys: |
             ${{ matrix.os }}-pip-${{ matrix.python-version }}
-      # - *install_pip
       - name: Install Global Python Packages
+        working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install "virtualenv==16.7.9" "pipenv==2018.11.26"
-      # - *pipenv_sync
-      - name: Setup Python Virtual Environment (3.x)
-        if: matrix.python-version != '2.7'
-        run: pipenv sync --dev
+          pip install -r build-pyinstaller.txt
+      - name: Setup Python Virtual Environment (no dev)
+        run: pipenv sync
       - name: Run Build
         run: make build_pyinstaller_file
       - name: Upload Artifacts
@@ -139,15 +137,13 @@ jobs:
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
           restore-keys: |
             ${{ matrix.os }}-pip-${{ matrix.python-version }}
-      # - *install_pip
       - name: Install Global Python Packages
+        working-directory: .github/requirements
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install "virtualenv==16.7.9" "pipenv==2018.11.26"
-      # - *pipenv_sync
-      - name: Setup Python Virtual Environment (3.x)
-        if: matrix.python-version != '2.7'
-        run: pipenv sync --dev
+          pip install -r build-pyinstaller.txt
+      - name: Setup Python Virtual Environment (no dev)
+        run: pipenv sync
       - name: Run Build
         run: make build_pyinstaller_folder
       - name: Upload Artifacts

--- a/Pipfile
+++ b/Pipfile
@@ -30,8 +30,6 @@ moto = "~=1.3"
 testfixtures = "~=4.10.0"
 # Build
 setuptools-scm = "~=3.5.0"
-## pyinstaller is installed globally when building artifacts (.github/requirements/)
-pyinstaller = "==3.5"  # stuck till this is resolved https://github.com/pyinstaller/pyinstaller/issues/4674
 # Utilities
 pre-commit = {version = "~=2.6.0", python_version = '>="3.6"'}
 setuptools = "<49.2"  # https://github.com/microsoft/vscode-python/issues/12949

--- a/Pipfile
+++ b/Pipfile
@@ -30,6 +30,7 @@ moto = "~=1.3"
 testfixtures = "~=4.10.0"
 # Build
 setuptools-scm = "~=3.5.0"
+## pyinstaller is installed globally when building artifacts (.github/requirements/)
 pyinstaller = "==3.5"  # stuck till this is resolved https://github.com/pyinstaller/pyinstaller/issues/4674
 # Utilities
 pre-commit = {version = "~=2.6.0", python_version = '>="3.6"'}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b4ba3aaafc7d511e4128d005e45b9541cf4b08d6e190f33048851807514e327f"
+            "sha256": "b180f136568bf023fca437cbe091061f62de4eaf4bfa1f1da40afaf3388e25e4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -37,24 +37,24 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:1716fb9a608e63cb8c8943b5012d7df51f87639a46c1761e37ee57157b903021",
-                "sha256:f4f740740764dec66a44eb65ba3fe575eafe909ad73d98d39e17a6b743e7e99a"
+                "sha256:c146c1634edbedc32564c536afcaaaeedc3ecc5aa9db3cf64fe5870c1c1a2a32",
+                "sha256:e094505f698981417612d8204d55631e741b5ae8c3f81762ef5197737b286a5a"
             ],
-            "version": "==1.18.124"
+            "version": "==1.18.128"
         },
         "boto3": {
             "hashes": [
-                "sha256:0d9cbeb5c8ca67650cc963c77e2e3b3ab5dffeeee16e03d61d740755f8fc7c44",
-                "sha256:df73edf3bd6f191870212e04ae9a8bc6245fd6749f464e9fb950392a8d15bd8c"
+                "sha256:a6bdb808e948bd264af135af50efb76253e85732c451fa605b7a287faf022432",
+                "sha256:f9dbccbcec916051c6588adbccae86547308ac4cd154f1eb7cf6422f0e391a71"
             ],
-            "version": "==1.14.47"
+            "version": "==1.14.51"
         },
         "botocore": {
             "hashes": [
-                "sha256:42b320b449df22cdb1232913e4a066919d127feb8e58ad98898831e6255ccfe0",
-                "sha256:eca25f01c503c2b86b394497f875a0eb0d3fe367dbc032f3a02851ba7e827109"
+                "sha256:198a62d387eb64b4c1dde33a9c41e96b07884c68c1442dd7c7d38123592aae7c",
+                "sha256:5f984def778b0000a12cf28ec727d64634ca46ab0dcdb5ce8b654bfb2a1fb99c"
             ],
-            "version": "==1.17.47"
+            "version": "==1.17.51"
         },
         "certifi": {
             "hashes": [
@@ -140,27 +140,30 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0c608ff4d4adad9e39b5057de43657515c7da1ccb1807c3a27d4cf31fc923b4b",
-                "sha256:0cbfed8ea74631fe4de00630f4bb592dad564d57f73150d6f6796a24e76c76cd",
-                "sha256:124af7255ffc8e964d9ff26971b3a6153e1a8a220b9a685dc407976ecb27a06a",
-                "sha256:384d7c681b1ab904fff3400a6909261cae1d0939cc483a68bdedab282fb89a07",
-                "sha256:45741f5499150593178fc98d2c1a9c6722df88b99c821ad6ae298eff0ba1ae71",
-                "sha256:4b9303507254ccb1181d1803a2080a798910ba89b1a3c9f53639885c90f7a756",
-                "sha256:4d355f2aee4a29063c10164b032d9fa8a82e2c30768737a2fd56d256146ad559",
-                "sha256:51e40123083d2f946794f9fe4adeeee2922b581fa3602128ce85ff813d85b81f",
-                "sha256:8713ddb888119b0d2a1462357d5946b8911be01ddbf31451e1d07eaa5077a261",
-                "sha256:8e924dbc025206e97756e8903039662aa58aa9ba357d8e1d8fc29e3092322053",
-                "sha256:8ecef21ac982aa78309bb6f092d1677812927e8b5ef204a10c326fc29f1367e2",
-                "sha256:8ecf9400d0893836ff41b6f977a33972145a855b6efeb605b49ee273c5e6469f",
-                "sha256:9367d00e14dee8d02134c6c9524bb4bd39d4c162456343d07191e2a0b5ec8b3b",
-                "sha256:a09fd9c1cca9a46b6ad4bea0a1f86ab1de3c0c932364dbcf9a6c2a5eeb44fa77",
-                "sha256:ab49edd5bea8d8b39a44b3db618e4783ef84c19c8b47286bf05dfdb3efb01c83",
-                "sha256:bea0b0468f89cdea625bb3f692cd7a4222d80a6bdafd6fb923963f2b9da0e15f",
-                "sha256:bec7568c6970b865f2bcebbe84d547c52bb2abadf74cefce396ba07571109c67",
-                "sha256:ce82cc06588e5cbc2a7df3c8a9c778f2cb722f56835a23a68b5a7264726bb00c",
-                "sha256:dea0ba7fe6f9461d244679efa968d215ea1f989b9c1957d7f10c21e5c7c09ad6"
+                "sha256:10c9775a3f31610cf6b694d1fe598f2183441de81cedcf1814451ae53d71b13a",
+                "sha256:180c9f855a8ea280e72a5d61cf05681b230c2dce804c48e9b2983f491ecc44ed",
+                "sha256:247df238bc05c7d2e934a761243bfdc67db03f339948b1e2e80c75d41fc7cc36",
+                "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08",
+                "sha256:2a27615c965173c4c88f2961cf18115c08fedfb8bdc121347f26e8458dc6d237",
+                "sha256:2e26223ac636ca216e855748e7d435a1bf846809ed12ed898179587d0cf74618",
+                "sha256:321761d55fb7cb256b771ee4ed78e69486a7336be9143b90c52be59d7657f50f",
+                "sha256:4005b38cd86fc51c955db40b0f0e52ff65340874495af72efabb1bb8ca881695",
+                "sha256:4b9e96543d0784acebb70991ebc2dbd99aa287f6217546bb993df22dd361d41c",
+                "sha256:548b0818e88792318dc137d8b1ec82a0ab0af96c7f0603a00bb94f896fbf5e10",
+                "sha256:725875681afe50b41aee7fdd629cedbc4720bab350142b12c55c0a4d17c7416c",
+                "sha256:7a63e97355f3cd77c94bd98c59cb85fe0efd76ea7ef904c9b0316b5bbfde6ed1",
+                "sha256:94191501e4b4009642be21dde2a78bd3c2701a81ee57d3d3d02f1d99f8b64a9e",
+                "sha256:969ae512a250f869c1738ca63be843488ff5cc031987d302c1f59c7dbe1b225f",
+                "sha256:9f734423eb9c2ea85000aa2476e0d7a58e021bc34f0a373ac52a5454cd52f791",
+                "sha256:b45ab1c6ece7c471f01c56f5d19818ca797c34541f0b2351635a5c9fe09ac2e0",
+                "sha256:cc6096c86ec0de26e2263c228fb25ee01c3ff1346d3cfc219d67d49f303585af",
+                "sha256:dc3f437ca6353979aace181f1b790f0fc79e446235b14306241633ab7d61b8f8",
+                "sha256:e7563eb7bc5c7e75a213281715155248cceba88b11cb4b22957ad45b85903761",
+                "sha256:e7dad66a9e5684a40f270bd4aee1906878193ae50a4831922e454a2a457f1716",
+                "sha256:eb80a288e3cfc08f679f95da72d2ef90cb74f6d8a8ba69d2f215c5e110b2ca32",
+                "sha256:fa7fbcc40e2210aca26c7ac8a39467eae444d90a2c346cbcffd9133a166bcc67"
             ],
-            "version": "==3.0"
+            "version": "==3.1"
         },
         "decorator": {
             "hashes": [
@@ -331,18 +334,18 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
-                "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
+                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
+                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
             ],
-            "version": "==8.4.0"
+            "version": "==8.5.0"
         },
         "networkx": {
             "hashes": [
-                "sha256:cdfbf698749a5014bf2ed9db4a07a5295df1d3a53bf80bf3cbd61edf9df05fa1",
-                "sha256:f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64"
+                "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602",
+                "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.4"
+            "version": "==2.5"
         },
         "packaging": {
             "hashes": [
@@ -535,13 +538,6 @@
         }
     },
     "develop": {
-        "altgraph": {
-            "hashes": [
-                "sha256:1f05a47122542f97028caf78775a095fbe6a2699b5089de8477eb583167d69aa",
-                "sha256:c623e5f3408ca61d4016f23a681b9adb100802ca3e3da5e718915a9e4052cebe"
-            ],
-            "version": "==0.17"
-        },
         "appdirs": {
             "hashes": [
                 "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
@@ -603,17 +599,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0d9cbeb5c8ca67650cc963c77e2e3b3ab5dffeeee16e03d61d740755f8fc7c44",
-                "sha256:df73edf3bd6f191870212e04ae9a8bc6245fd6749f464e9fb950392a8d15bd8c"
+                "sha256:a6bdb808e948bd264af135af50efb76253e85732c451fa605b7a287faf022432",
+                "sha256:f9dbccbcec916051c6588adbccae86547308ac4cd154f1eb7cf6422f0e391a71"
             ],
-            "version": "==1.14.47"
+            "version": "==1.14.51"
         },
         "botocore": {
             "hashes": [
-                "sha256:42b320b449df22cdb1232913e4a066919d127feb8e58ad98898831e6255ccfe0",
-                "sha256:eca25f01c503c2b86b394497f875a0eb0d3fe367dbc032f3a02851ba7e827109"
+                "sha256:198a62d387eb64b4c1dde33a9c41e96b07884c68c1442dd7c7d38123592aae7c",
+                "sha256:5f984def778b0000a12cf28ec727d64634ca46ab0dcdb5ce8b654bfb2a1fb99c"
             ],
-            "version": "==1.17.47"
+            "version": "==1.17.51"
         },
         "certifi": {
             "hashes": [
@@ -728,27 +724,30 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0c608ff4d4adad9e39b5057de43657515c7da1ccb1807c3a27d4cf31fc923b4b",
-                "sha256:0cbfed8ea74631fe4de00630f4bb592dad564d57f73150d6f6796a24e76c76cd",
-                "sha256:124af7255ffc8e964d9ff26971b3a6153e1a8a220b9a685dc407976ecb27a06a",
-                "sha256:384d7c681b1ab904fff3400a6909261cae1d0939cc483a68bdedab282fb89a07",
-                "sha256:45741f5499150593178fc98d2c1a9c6722df88b99c821ad6ae298eff0ba1ae71",
-                "sha256:4b9303507254ccb1181d1803a2080a798910ba89b1a3c9f53639885c90f7a756",
-                "sha256:4d355f2aee4a29063c10164b032d9fa8a82e2c30768737a2fd56d256146ad559",
-                "sha256:51e40123083d2f946794f9fe4adeeee2922b581fa3602128ce85ff813d85b81f",
-                "sha256:8713ddb888119b0d2a1462357d5946b8911be01ddbf31451e1d07eaa5077a261",
-                "sha256:8e924dbc025206e97756e8903039662aa58aa9ba357d8e1d8fc29e3092322053",
-                "sha256:8ecef21ac982aa78309bb6f092d1677812927e8b5ef204a10c326fc29f1367e2",
-                "sha256:8ecf9400d0893836ff41b6f977a33972145a855b6efeb605b49ee273c5e6469f",
-                "sha256:9367d00e14dee8d02134c6c9524bb4bd39d4c162456343d07191e2a0b5ec8b3b",
-                "sha256:a09fd9c1cca9a46b6ad4bea0a1f86ab1de3c0c932364dbcf9a6c2a5eeb44fa77",
-                "sha256:ab49edd5bea8d8b39a44b3db618e4783ef84c19c8b47286bf05dfdb3efb01c83",
-                "sha256:bea0b0468f89cdea625bb3f692cd7a4222d80a6bdafd6fb923963f2b9da0e15f",
-                "sha256:bec7568c6970b865f2bcebbe84d547c52bb2abadf74cefce396ba07571109c67",
-                "sha256:ce82cc06588e5cbc2a7df3c8a9c778f2cb722f56835a23a68b5a7264726bb00c",
-                "sha256:dea0ba7fe6f9461d244679efa968d215ea1f989b9c1957d7f10c21e5c7c09ad6"
+                "sha256:10c9775a3f31610cf6b694d1fe598f2183441de81cedcf1814451ae53d71b13a",
+                "sha256:180c9f855a8ea280e72a5d61cf05681b230c2dce804c48e9b2983f491ecc44ed",
+                "sha256:247df238bc05c7d2e934a761243bfdc67db03f339948b1e2e80c75d41fc7cc36",
+                "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08",
+                "sha256:2a27615c965173c4c88f2961cf18115c08fedfb8bdc121347f26e8458dc6d237",
+                "sha256:2e26223ac636ca216e855748e7d435a1bf846809ed12ed898179587d0cf74618",
+                "sha256:321761d55fb7cb256b771ee4ed78e69486a7336be9143b90c52be59d7657f50f",
+                "sha256:4005b38cd86fc51c955db40b0f0e52ff65340874495af72efabb1bb8ca881695",
+                "sha256:4b9e96543d0784acebb70991ebc2dbd99aa287f6217546bb993df22dd361d41c",
+                "sha256:548b0818e88792318dc137d8b1ec82a0ab0af96c7f0603a00bb94f896fbf5e10",
+                "sha256:725875681afe50b41aee7fdd629cedbc4720bab350142b12c55c0a4d17c7416c",
+                "sha256:7a63e97355f3cd77c94bd98c59cb85fe0efd76ea7ef904c9b0316b5bbfde6ed1",
+                "sha256:94191501e4b4009642be21dde2a78bd3c2701a81ee57d3d3d02f1d99f8b64a9e",
+                "sha256:969ae512a250f869c1738ca63be843488ff5cc031987d302c1f59c7dbe1b225f",
+                "sha256:9f734423eb9c2ea85000aa2476e0d7a58e021bc34f0a373ac52a5454cd52f791",
+                "sha256:b45ab1c6ece7c471f01c56f5d19818ca797c34541f0b2351635a5c9fe09ac2e0",
+                "sha256:cc6096c86ec0de26e2263c228fb25ee01c3ff1346d3cfc219d67d49f303585af",
+                "sha256:dc3f437ca6353979aace181f1b790f0fc79e446235b14306241633ab7d61b8f8",
+                "sha256:e7563eb7bc5c7e75a213281715155248cceba88b11cb4b22957ad45b85903761",
+                "sha256:e7dad66a9e5684a40f270bd4aee1906878193ae50a4831922e454a2a457f1716",
+                "sha256:eb80a288e3cfc08f679f95da72d2ef90cb74f6d8a8ba69d2f215c5e110b2ca32",
+                "sha256:fa7fbcc40e2210aca26c7ac8a39467eae444d90a2c346cbcffd9133a166bcc67"
             ],
-            "version": "==3.0"
+            "version": "==3.1"
         },
         "decorator": {
             "hashes": [
@@ -824,10 +823,10 @@
         },
         "identify": {
             "hashes": [
-                "sha256:69c4769f085badafd0e04b1763e847258cbbf6d898e8678ebffc91abdb86f6c6",
-                "sha256:d6ae6daee50ba1b493e9ca4d36a5edd55905d2cf43548fdc20b2a14edef102e7"
+                "sha256:9f5fcf22b665eaece583bd395b103c2769772a0f646ffabb5b1f155901b07de2",
+                "sha256:b1aa2e05863dc80242610d46a7b49105e2eafe00ef0c8ff311c1828680760c76"
             ],
-            "version": "==1.4.28"
+            "version": "==1.4.29"
         },
         "idna": {
             "hashes": [
@@ -933,13 +932,6 @@
             ],
             "version": "==1.4.3"
         },
-        "macholib": {
-            "hashes": [
-                "sha256:0c436bc847e7b1d9bda0560351bf76d7caf930fb585a828d13608839ef42c432",
-                "sha256:c500f02867515e6c60a27875b408920d18332ddf96b4035ef03beddd782d4281"
-            ],
-            "version": "==1.14"
-        },
         "markupsafe": {
             "hashes": [
                 "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
@@ -995,10 +987,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
-                "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
+                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
+                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
             ],
-            "version": "==8.4.0"
+            "version": "==8.5.0"
         },
         "moto": {
             "hashes": [
@@ -1010,17 +1002,18 @@
         },
         "networkx": {
             "hashes": [
-                "sha256:cdfbf698749a5014bf2ed9db4a07a5295df1d3a53bf80bf3cbd61edf9df05fa1",
-                "sha256:f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64"
+                "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602",
+                "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.4"
+            "version": "==2.5"
         },
         "nodeenv": {
             "hashes": [
-                "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"
+                "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9",
+                "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"
             ],
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "packaging": {
             "hashes": [
@@ -1111,13 +1104,6 @@
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
             "version": "==2.2.0"
-        },
-        "pyinstaller": {
-            "hashes": [
-                "sha256:ee7504022d1332a3324250faf2135ea56ac71fdb6309cff8cd235de26b1d0a96"
-            ],
-            "index": "pypi",
-            "version": "==3.5"
         },
         "pylint": {
             "hashes": [
@@ -1257,10 +1243,10 @@
         },
         "responses": {
             "hashes": [
-                "sha256:cf55b7c89fc77b9ebbc5e5924210b6d0ef437061b80f1273d7e202069e43493c",
-                "sha256:fa125311607ab3e57d8fcc4da20587f041b4485bdfb06dd6bdf19d8b66f870c1"
+                "sha256:0de50fbf600adf5ef9f0821b85cc537acca98d66bc7776755924476775c1989c",
+                "sha256:e80d5276011a4b79ecb62c5f82ba07aa23fb31ecbc95ee7cad6de250a3c97444"
             ],
-            "version": "==0.10.16"
+            "version": "==0.12.0"
         },
         "rsa": {
             "hashes": [

--- a/runway.file.spec
+++ b/runway.file.spec
@@ -15,9 +15,7 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 # can be removed once we can upgrade virtualenv and pyinstaller
 import distutils
 
-if hasattr(distutils, "distutils_path") and distutils.distutils_path.endswith(
-    "__init__.py"
-):
+if distutils.distutils_path.endswith("__init__.py"):
     distutils.distutils_path = os.path.dirname(distutils.distutils_path)
 
 CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)), "runway")  # noqa

--- a/runway.file.spec
+++ b/runway.file.spec
@@ -5,7 +5,6 @@ This file should be considered a python file and linted as such.
 """
 # pylint: disable=undefined-variable,wrong-import-order,invalid-name
 # pylint: disable=wrong-import-position,import-self
-import inspect
 import os
 import pkgutil
 from pkg_resources import get_distribution, get_entry_info
@@ -16,11 +15,7 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 # can be removed once we can upgrade virtualenv and pyinstaller
 import distutils
 
-print(inspect.getfile(distutils))
-print(inspect.getsourcefile(distutils))
-print(distutils.__dict__)
-
-if distutils.distutils_path.endswith("__init__.py"):
+if getattr(distutils, "distutils_path", "").endswith("__init__.py"):
     distutils.distutils_path = os.path.dirname(distutils.distutils_path)
 
 CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)), "runway")  # noqa

--- a/runway.file.spec
+++ b/runway.file.spec
@@ -5,6 +5,7 @@ This file should be considered a python file and linted as such.
 """
 # pylint: disable=undefined-variable,wrong-import-order,invalid-name
 # pylint: disable=wrong-import-position,import-self
+import inspect
 import os
 import pkgutil
 from pkg_resources import get_distribution, get_entry_info
@@ -14,6 +15,10 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 # distutils not included with virtualenv < 20 so we have to import it here
 # can be removed once we can upgrade virtualenv and pyinstaller
 import distutils
+
+print(inspect.getfile(distutils))
+print(inspect.getsourcefile(distutils))
+print(distutils.__dict__)
 
 if distutils.distutils_path.endswith("__init__.py"):
     distutils.distutils_path = os.path.dirname(distutils.distutils_path)

--- a/runway.file.spec
+++ b/runway.file.spec
@@ -15,11 +15,12 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 # can be removed once we can upgrade virtualenv and pyinstaller
 import distutils
 
-if distutils.distutils_path.endswith('__init__.py'):
+if hasattr(distutils, "distutils_path") and distutils.distutils_path.endswith(
+    "__init__.py"
+):
     distutils.distutils_path = os.path.dirname(distutils.distutils_path)
 
-CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)),  # noqa
-                        'runway')
+CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)), "runway")  # noqa
 
 
 def get_submodules(package):
@@ -38,46 +39,52 @@ def get_submodules(package):
         List of submodules.
 
     """
-    return [name for _, name, _ in
-            pkgutil.walk_packages(path=package.__path__,
-                                  prefix=package.__name__ + '.',
-                                  onerror=lambda x: None)]
+    return [
+        name
+        for _, name, _ in pkgutil.walk_packages(
+            path=package.__path__, prefix=package.__name__ + ".", onerror=lambda x: None
+        )
+    ]
 
 
 def Entrypoint(dist, group, name, **kwargs):  # noqa
     """Get entrypoint info for packages using setuptools."""
     ep = get_entry_info(dist, group, name)
     # script name must not be a valid module name to avoid name clashes on import
-    script_path = os.path.join(workpath, name + '-script.py')  # noqa: F821
+    script_path = os.path.join(workpath, name + "-script.py")  # noqa: F821
     print("creating script for entry point", dist, group, name)
-    with open(script_path, 'w') as fh:
+    with open(script_path, "w") as fh:
         print("import", ep.module_name, file=fh)
-        print("%s.%s()" % (ep.module_name, '.'.join(ep.attrs)), file=fh)
+        print("%s.%s()" % (ep.module_name, ".".join(ep.attrs)), file=fh)
 
-    return Analysis([script_path] + kwargs.get('scripts', []), **kwargs)  # noqa: F821
+    return Analysis([script_path] + kwargs.get("scripts", []), **kwargs)  # noqa: F821
 
 
 # files that are not explicitly imported but consumed at runtime
 # need to be included as data_files.
 data_files = [
-    (os.path.join(CLI_PATH, 'templates'), './runway/templates'),
-    (os.path.join(CLI_PATH, 'blueprints'), './runway/blueprints'),
-    (os.path.join(CLI_PATH, 'hooks'), './runway/hooks')
+    (os.path.join(CLI_PATH, "templates"), "./runway/templates"),
+    (os.path.join(CLI_PATH, "blueprints"), "./runway/blueprints"),
+    (os.path.join(CLI_PATH, "hooks"), "./runway/hooks"),
 ]
-data_files.append(('{}/yamllint/conf'.format(get_distribution('yamllint').location),
-                   'yamllint/conf/'))
-data_files.append(('{}/cfnlint/rules'.format(get_distribution('cfn-lint').location),
-                   'cfnlint/rules/'))
-data_files.append(('{}/botocore/data'.format(get_distribution('botocore').location),
-                   'botocore/data/'))
-data_files.append(('{}/awscli/data'.format(get_distribution('awscli').location),
-                   'awscli/data/'))
-data_files.extend(collect_data_files('cfnlint'))
-data_files.extend(collect_data_files('distutils'))
-data_files.extend(collect_data_files('hcl2'))
-data_files.extend(collect_data_files('pip'))
-data_files.extend(collect_data_files('wheel'))
-data_files.append(copy_metadata('runway')[0])  # support scm version
+data_files.append(
+    ("{}/yamllint/conf".format(get_distribution("yamllint").location), "yamllint/conf/")
+)
+data_files.append(
+    ("{}/cfnlint/rules".format(get_distribution("cfn-lint").location), "cfnlint/rules/")
+)
+data_files.append(
+    ("{}/botocore/data".format(get_distribution("botocore").location), "botocore/data/")
+)
+data_files.append(
+    ("{}/awscli/data".format(get_distribution("awscli").location), "awscli/data/")
+)
+data_files.extend(collect_data_files("cfnlint"))
+data_files.extend(collect_data_files("distutils"))
+data_files.extend(collect_data_files("hcl2"))
+data_files.extend(collect_data_files("pip"))
+data_files.extend(collect_data_files("wheel"))
+data_files.append(copy_metadata("runway")[0])  # support scm version
 
 # pyinstaller is not able to find dependencies of dependencies
 # unless a hook already exists for pyinstaller so we have to
@@ -94,6 +101,7 @@ import pip  # noqa
 import wheel  # noqa
 import yamllint  # noqa
 import cfnlint  # noqa
+
 hiddenimports.extend(get_submodules(runway))
 hiddenimports.extend(get_submodules(troposphere))
 hiddenimports.extend(get_submodules(awacs))
@@ -107,29 +115,32 @@ hiddenimports.extend(get_submodules(cfnlint))
 # needed due to pkg_resources dropping python2 support
 # can be removed on the next pyinstaller release
 # https://github.com/pypa/setuptools/issues/1963#issuecomment-582084099
-hiddenimports.append('pkg_resources.py2_warn')
+hiddenimports.append("pkg_resources.py2_warn")
 
-a = Entrypoint('runway',
-               'console_scripts',
-               'runway',
-               pathex=[CLI_PATH],
-               datas=data_files,
-               hiddenimports=hiddenimports,
-               win_no_prefer_redirects=False,
-               win_private_assemblies=False,
-               cipher=None,
-               noarchive=False,
-               binaries=[])
-pyz = PYZ(a.pure, a.zipped_data,  # noqa: F821
-          cipher=None)
-exe = EXE(pyz,  # noqa: F821
-          a.scripts,
-          a.binaries,
-          a.zipfiles,
-          a.datas,
-          [],
-          name='runway',
-          strip=False,
-          upx=True,
-          runtime_tmpdir=None,
-          console=True)
+a = Entrypoint(
+    "runway",
+    "console_scripts",
+    "runway",
+    pathex=[CLI_PATH],
+    datas=data_files,
+    hiddenimports=hiddenimports,
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=None,
+    noarchive=False,
+    binaries=[],
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=None)  # noqa: F821
+exe = EXE(
+    pyz,  # noqa: F821
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="runway",
+    strip=False,
+    upx=True,
+    runtime_tmpdir=None,
+    console=True,
+)

--- a/runway.folder.spec
+++ b/runway.folder.spec
@@ -15,9 +15,7 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 # can be removed once we can upgrade virtualenv and pyinstaller
 import distutils
 
-if hasattr(distutils, "distutils_path") and distutils.distutils_path.endswith(
-    "__init__.py"
-):
+if distutils.distutils_path.endswith("__init__.py"):
     distutils.distutils_path = os.path.dirname(distutils.distutils_path)
 
 CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)), "runway")  # noqa

--- a/runway.folder.spec
+++ b/runway.folder.spec
@@ -15,11 +15,12 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 # can be removed once we can upgrade virtualenv and pyinstaller
 import distutils
 
-if distutils.distutils_path.endswith('__init__.py'):
+if hasattr(distutils, "distutils_path") and distutils.distutils_path.endswith(
+    "__init__.py"
+):
     distutils.distutils_path = os.path.dirname(distutils.distutils_path)
 
-CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)),  # noqa
-                        'runway')
+CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)), "runway")  # noqa
 
 
 def get_submodules(package):
@@ -38,46 +39,52 @@ def get_submodules(package):
         List of submodules.
 
     """
-    return [name for _, name, _ in
-            pkgutil.walk_packages(path=package.__path__,
-                                  prefix=package.__name__ + '.',
-                                  onerror=lambda x: None)]
+    return [
+        name
+        for _, name, _ in pkgutil.walk_packages(
+            path=package.__path__, prefix=package.__name__ + ".", onerror=lambda x: None
+        )
+    ]
 
 
 def Entrypoint(dist, group, name, **kwargs):  # noqa
     """Get entrypoint info for packages using setuptools."""
     ep = get_entry_info(dist, group, name)
     # script name must not be a valid module name to avoid name clashes on import
-    script_path = os.path.join(workpath, name + '-script.py')  # noqa: F821
+    script_path = os.path.join(workpath, name + "-script.py")  # noqa: F821
     print("creating script for entry point", dist, group, name)
-    with open(script_path, 'w') as fh:
+    with open(script_path, "w") as fh:
         print("import", ep.module_name, file=fh)
-        print("%s.%s()" % (ep.module_name, '.'.join(ep.attrs)), file=fh)
+        print("%s.%s()" % (ep.module_name, ".".join(ep.attrs)), file=fh)
 
-    return Analysis([script_path] + kwargs.get('scripts', []), **kwargs)  # noqa: F821
+    return Analysis([script_path] + kwargs.get("scripts", []), **kwargs)  # noqa: F821
 
 
 # files that are not explicitly imported but consumed at runtime
 # need to be included as data_files.
 data_files = [
-    (os.path.join(CLI_PATH, 'templates'), './runway/templates'),
-    (os.path.join(CLI_PATH, 'blueprints'), './runway/blueprints'),
-    (os.path.join(CLI_PATH, 'hooks'), './runway/hooks')
+    (os.path.join(CLI_PATH, "templates"), "./runway/templates"),
+    (os.path.join(CLI_PATH, "blueprints"), "./runway/blueprints"),
+    (os.path.join(CLI_PATH, "hooks"), "./runway/hooks"),
 ]
-data_files.append(('{}/yamllint/conf'.format(get_distribution('yamllint').location),
-                   'yamllint/conf/'))
-data_files.append(('{}/cfnlint/rules'.format(get_distribution('cfn-lint').location),
-                   'cfnlint/rules/'))
-data_files.append(('{}/botocore/data'.format(get_distribution('botocore').location),
-                   'botocore/data/'))
-data_files.append(('{}/awscli/data'.format(get_distribution('awscli').location),
-                   'awscli/data/'))
-data_files.extend(collect_data_files('cfnlint'))
-data_files.extend(collect_data_files('distutils'))
-data_files.extend(collect_data_files('hcl2'))
-data_files.extend(collect_data_files('pip'))
-data_files.extend(collect_data_files('wheel'))
-data_files.append(copy_metadata('runway')[0])  # support scm version
+data_files.append(
+    ("{}/yamllint/conf".format(get_distribution("yamllint").location), "yamllint/conf/")
+)
+data_files.append(
+    ("{}/cfnlint/rules".format(get_distribution("cfn-lint").location), "cfnlint/rules/")
+)
+data_files.append(
+    ("{}/botocore/data".format(get_distribution("botocore").location), "botocore/data/")
+)
+data_files.append(
+    ("{}/awscli/data".format(get_distribution("awscli").location), "awscli/data/")
+)
+data_files.extend(collect_data_files("cfnlint"))
+data_files.extend(collect_data_files("distutils"))
+data_files.extend(collect_data_files("hcl2"))
+data_files.extend(collect_data_files("pip"))
+data_files.extend(collect_data_files("wheel"))
+data_files.append(copy_metadata("runway")[0])  # support scm version
 
 # pyinstaller is not able to find dependencies of dependencies
 # unless a hook already exists for pyinstaller so we have to
@@ -94,6 +101,7 @@ import pip  # noqa
 import wheel  # noqa
 import yamllint  # noqa
 import cfnlint  # noqa
+
 hiddenimports.extend(get_submodules(runway))
 hiddenimports.extend(get_submodules(troposphere))
 hiddenimports.extend(get_submodules(awacs))
@@ -107,35 +115,40 @@ hiddenimports.extend(get_submodules(cfnlint))
 # needed due to pkg_resources dropping python2 support
 # can be removed on the next pyinstaller release
 # https://github.com/pypa/setuptools/issues/1963#issuecomment-582084099
-hiddenimports.append('pkg_resources.py2_warn')
+hiddenimports.append("pkg_resources.py2_warn")
 
-a = Entrypoint('runway',
-               'console_scripts',
-               'runway',
-               pathex=[CLI_PATH],
-               datas=data_files,
-               hiddenimports=hiddenimports,
-               win_no_prefer_redirects=False,
-               win_private_assemblies=False,
-               cipher=None,
-               noarchive=False,
-               binaries=[])
-pyz = PYZ(a.pure, a.zipped_data,  # noqa: F821
-          cipher=None)
-exe = EXE(pyz,  # noqa: F821
-          a.scripts,
-          [],
-          exclude_binaries=True,
-          # for some reason pyinstaller won't create the correct dir
-          # structure if this is the same name as a dir used in datas
-          name='runway-cli',
-          strip=False,
-          upx=True,
-          console=True)
-coll = COLLECT(exe,  # noqa: F821
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               name='runway',
-               strip=False,
-               upx=True)
+a = Entrypoint(
+    "runway",
+    "console_scripts",
+    "runway",
+    pathex=[CLI_PATH],
+    datas=data_files,
+    hiddenimports=hiddenimports,
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=None,
+    noarchive=False,
+    binaries=[],
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=None)  # noqa: F821
+exe = EXE(
+    pyz,  # noqa: F821
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    # for some reason pyinstaller won't create the correct dir
+    # structure if this is the same name as a dir used in datas
+    name="runway-cli",
+    strip=False,
+    upx=True,
+    console=True,
+)
+coll = COLLECT(
+    exe,  # noqa: F821
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name="runway",
+    strip=False,
+    upx=True,
+)

--- a/runway.folder.spec
+++ b/runway.folder.spec
@@ -15,7 +15,7 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 # can be removed once we can upgrade virtualenv and pyinstaller
 import distutils
 
-if distutils.distutils_path.endswith("__init__.py"):
+if getattr(distutils, "distutils_path", "").endswith("__init__.py"):
     distutils.distutils_path = os.path.dirname(distutils.distutils_path)
 
 CLI_PATH = os.path.join(os.path.dirname(os.path.dirname(workpath)), "runway")  # noqa


### PR DESCRIPTION
## Why This Is Needed

The old version of pyinstaller we are stuck at does not work with the new versions of dev dependencies that we are able to use when dropping python 2 support. This is due to outdated hooks that are built-in to the tool and cannot be overridden.

This also has the potential to result in slightly smaller artifacts.

## What Changed

### Added

- added a functional test to the pyinstaller build process for basic validation fo the build artifact

### Changed

- github workflows no longer installs dev dependencies when building pyinstaller artifacts
- moved build & global python requirements to dedicated files
