### PR TITLE
relocate, update, and rename variable & lookup exceptions

### DIFF
--- a/runway/cfngin/blueprints/base.py
+++ b/runway/cfngin/blueprints/base.py
@@ -11,8 +11,8 @@ from runway.variables import Variable
 from ..exceptions import (
     InvalidUserdataPlaceholder,
     MissingVariable,
-    UnresolvedVariable,
-    UnresolvedVariables,
+    UnresolvedBlueprintVariable,
+    UnresolvedBlueprintVariables,
     ValidatorError,
     VariableTypeRequired,
 )
@@ -188,8 +188,8 @@ def resolve_variable(var_name, var_def, provided_variable, blueprint_name):
     Raises:
         MissingVariable: Raised when a variable with no default is not
             provided a value.
-        UnresolvedVariable: Raised when the provided variable is not already
-            resolved.
+        UnresolvedBlueprintVariable: Raised when the provided variable is
+            not already resolved.
         ValueError: Raised when the value is not the right type and cannot be
             cast as the correct type. Raised by
             :func:`runway.cfngin.blueprints.base.validate_variable_type`
@@ -204,7 +204,7 @@ def resolve_variable(var_name, var_def, provided_variable, blueprint_name):
 
     if provided_variable:
         if not provided_variable.resolved:
-            raise UnresolvedVariable(blueprint_name, provided_variable)
+            raise UnresolvedBlueprintVariable(blueprint_name, provided_variable)
 
         value = provided_variable.value
     else:
@@ -425,11 +425,11 @@ class Blueprint:
             Dict[str, Variable]: Variables available to the template.
 
         Raises:
-            UnresolvedVariables: If variables are unresolved.
+            UnresolvedBlueprintVariables: If variables are unresolved.
 
         """
         if self.resolved_variables is None:
-            raise UnresolvedVariables(self.name)
+            raise UnresolvedBlueprintVariables(self.name)
         return self.resolved_variables
 
     def get_cfn_parameters(self):

--- a/runway/cfngin/blueprints/raw.py
+++ b/runway/cfngin/blueprints/raw.py
@@ -6,7 +6,7 @@ import sys
 
 from jinja2 import Template
 
-from ..exceptions import InvalidConfig, UnresolvedVariable
+from ..exceptions import InvalidConfig, UnresolvedBlueprintVariable
 from ..util import parse_cloudformation_template
 from .base import Blueprint
 
@@ -67,14 +67,14 @@ def resolve_variable(provided_variable, blueprint_name):
         object: The resolved variable string value.
 
     Raises:
-        UnresolvedVariable: Raised when the provided variable is not already
-            resolved.
+        UnresolvedBlueprintVariable: Raised when the provided variable is
+            not already resolved.
 
     """
     value = None
     if provided_variable:
         if not provided_variable.resolved:
-            raise UnresolvedVariable(blueprint_name, provided_variable)
+            raise UnresolvedBlueprintVariable(blueprint_name, provided_variable)
 
         value = provided_variable.value
 

--- a/runway/cfngin/exceptions.py
+++ b/runway/cfngin/exceptions.py
@@ -21,55 +21,6 @@ class ChangesetDidNotStabilize(Exception):
         super().__init__(message)
 
 
-class FailedLookup(Exception):
-    """Intermediary Exception to be converted to FailedVariableLookup.
-
-    Should be caught by error handling and
-    :class:`runway.cfngin.exceptions.FailedVariableLookup` raised instead to
-    construct a propper error message.
-
-    """
-
-    def __init__(self, lookup, error, *args, **kwargs):
-        """Instantiate class.
-
-        Args:
-            lookup (:class:`runway.cfngin.variables.VariableValueLookup`):
-                Attempted lookup and resulted in an exception being raised.
-            error (Exception): The exception that was raised.
-
-        """
-        self.lookup = lookup
-        self.error = error
-        super().__init__("Failed lookup", *args, **kwargs)
-
-
-class FailedVariableLookup(Exception):
-    """Lookup could not be resolved.
-
-    Raised when an exception is raised when trying to resolve a lookup.
-
-    """
-
-    def __init__(self, variable_name, lookup, error, *args, **kwargs):
-        """Instantiate class.
-
-        Args:
-            variable_name (str): Name of the variable that failed to be
-                resolved.
-            lookup (:class:`runway.cfngin.variables.VariableValueLookup`):
-                Attempted lookup and resulted in an exception being raised.
-            error (Exception): The exception that was raised.
-
-        """
-        self.lookup = lookup
-        self.error = error
-        message = "Couldn't resolve lookup in variable `%s`, " % variable_name
-        message += "lookup: ${%s}: " % repr(lookup)
-        message += "(%s) %s" % (error.__class__, error)
-        super().__init__(message, *args, **kwargs)
-
-
 class GraphError(Exception):
     """Raised when the graph is invalid (e.g. acyclic dependencies)."""
 
@@ -135,43 +86,6 @@ class InvalidDockerizePipConfiguration(Exception):
         """
         self.message = msg
         super().__init__(self.message)
-
-
-class InvalidLookupCombination(Exception):
-    """Improper use of lookups to result in a non-string return value."""
-
-    def __init__(self, lookup, lookups, value, *args, **kwargs):
-        """Instantiate class.
-
-        Args:
-            lookup (:class:`runway.cfngin.variables.VariableValueLookup`): The
-                variable lookup that was attempted but did not return a string.
-            lookups (:class:`runway.cfngin.variables.VariableValueConcatenation`):
-                The full variable concatenation the failing lookup is part of.
-            value (Any): The non-string value returned by lookup.
-
-        """
-        message = (
-            'Lookup: "{}" has non-string return value, must be only lookup '
-            'present (not {}) in "{}"'
-        ).format(str(lookup), len(lookups), value)
-        super().__init__(message, *args, **kwargs)
-
-
-class InvalidLookupConcatenation(Exception):
-    """Intermediary Exception to be converted to InvalidLookupCombination.
-
-    Should be caught by error handling and
-    :class:`runway.cfngin.exceptions.InvalidLookupCombination` raised instead
-    to construct a propper error message.
-
-    """
-
-    def __init__(self, lookup, lookups, *args, **kwargs):
-        """Instantiate class."""
-        self.lookup = lookup
-        self.lookups = lookups
-        super().__init__("", *args, **kwargs)
 
 
 class InvalidUserdataPlaceholder(Exception):
@@ -245,24 +159,6 @@ class MissingVariable(Exception):
             variable_name,
             blueprint_name,
         )
-        super().__init__(message, *args, **kwargs)
-
-
-class OutputDoesNotExist(Exception):
-    """Raised when a specific stack output does not exist."""
-
-    def __init__(self, stack_name, output, *args, **kwargs):
-        """Instantiate class.
-
-        Args:
-            stack_name (str): Name of the stack.
-            output (str): The output that does not exist.
-
-        """
-        self.stack_name = stack_name
-        self.output = output
-
-        message = "Output %s does not exist on stack %s" % (output, stack_name)
         super().__init__(message, *args, **kwargs)
 
 
@@ -500,27 +396,7 @@ class UnhandledChangeSetStatus(Exception):
         super().__init__(message)
 
 
-class UnknownLookupType(Exception):
-    """Lookup type provided does not match a registered lookup.
-
-    Example:
-        If a lookup of ``${<lookup_type> query}`` is used and ``<lookup_type>``
-        is not a registered lookup, this exception will be raised.
-
-    """
-
-    def __init__(self, lookup_type, *args, **kwargs):
-        """Instantiate class.
-
-        Args:
-            lookup_type (str): Lookup type that was used but not registered.
-
-        """
-        message = 'Unknown lookup type: "{}"'.format(lookup_type)
-        super().__init__(message, *args, **kwargs)
-
-
-class UnresolvedVariable(Exception):
+class UnresolvedBlueprintVariable(Exception):  # TODO rename for blueprints only
     """Raised when trying to use a variable before it has been resolved."""
 
     def __init__(self, blueprint_name, variable, *args, **kwargs):
@@ -539,28 +415,7 @@ class UnresolvedVariable(Exception):
         super().__init__(message, *args, **kwargs)
 
 
-class UnresolvedVariableValue(Exception):
-    """Intermediary Exception to be converted to UnresolvedVariable.
-
-    Should be caught by error handling and
-    :class:`runway.cfngin.exceptions.UnresolvedVariable` raised instead to
-    construct a propper error message.
-
-    """
-
-    def __init__(self, lookup, *args, **kwargs):
-        """Instantiate class.
-
-        Args:
-            lookup (:class:`runway.cfngin.variables.VariableValueLookup`): The
-                lookup that is not resolved.
-
-        """
-        self.lookup = lookup
-        super().__init__("Unresolved lookup", *args, **kwargs)
-
-
-class UnresolvedVariables(Exception):
+class UnresolvedBlueprintVariables(Exception):  # TODO rename for blueprints only
     """Raised when trying to use variables before they has been resolved."""
 
     def __init__(self, blueprint_name, *args, **kwargs):

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -8,8 +8,8 @@ from types import FunctionType
 from runway.util import load_object_from_string
 from runway.variables import Variable, resolve_variables
 
+from ...exceptions import FailedVariableLookup
 from ..blueprints.base import Blueprint
-from ..exceptions import FailedVariableLookup
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/cfngin/lookups/registry.py
+++ b/runway/cfngin/lookups/registry.py
@@ -4,7 +4,7 @@ import logging
 from runway.lookups.handlers import cfn, ssm
 from runway.util import DOC_SITE, load_object_from_string
 
-from ..exceptions import FailedVariableLookup, UnknownLookupType
+from ...exceptions import FailedVariableLookup, UnknownLookupType
 from .handlers import ami, default, dynamodb, envvar
 from .handlers import file as file_handler
 from .handlers import hook_data, kms, output, rxref, split, ssmstore, xref

--- a/runway/core/components/_deployment.py
+++ b/runway/core/components/_deployment.py
@@ -5,8 +5,8 @@ import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ..._logging import PrefixAdaptor
-from ...cfngin.exceptions import UnresolvedVariable
 from ...config import FutureDefinition, VariablesDefinition
+from ...exceptions import UnresolvedVariable
 from ...util import cached_property, merge_dicts, merge_nested_environment_dicts
 from ..providers import aws
 from ._module import Module

--- a/runway/exceptions.py
+++ b/runway/exceptions.py
@@ -1,0 +1,179 @@
+"""Runway exceptions."""
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .variables import (
+        Variable,
+        VariableValue,
+        VariableValueConcatenation,
+        VariableValueLookup,
+    )
+
+
+class FailedLookup(Exception):
+    """Intermediary Exception to be converted to FailedVariableLookup.
+
+    Should be caught by error handling and
+    :class:`runway.cfngin.exceptions.FailedVariableLookup` raised instead to
+    construct a propper error message.
+
+    """
+
+    lookup: "VariableValueLookup"
+    cause: Exception
+
+    def __init__(
+        self, lookup: "VariableValueLookup", cause: Exception, *args: Any, **kwargs: Any
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            lookup: The variable value lookup that was attempted and
+                resulted in an exception being raised.
+            cause: The exception that was raised.
+
+        """
+        self.lookup = lookup
+        self.cause = cause
+        super().__init__("Failed lookup", *args, **kwargs)
+
+
+class FailedVariableLookup(Exception):
+    """Lookup could not be resolved.
+
+    Raised when an exception is raised when trying to resolve a lookup.
+
+    """
+
+    lookup: "Variable"
+    cause: FailedLookup
+
+    def __init__(
+        self,
+        variable: "Variable",
+        lookup_error: FailedLookup,
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            variable: The variable containing the failed lookup.
+            lookup_error: The exception that was raised directly before this one.
+
+        """
+        self.variable = variable
+        self.cause = lookup_error
+        super().__init__(
+            f'Could not resolve lookup "{lookup_error.lookup}" for variable "{variable.name}"',
+            *args,
+            **kwargs
+        )
+
+
+class InvalidLookupConcatenation(Exception):
+    """Invalid return value for a concatinated (chained) lookup.
+
+    The return value must be a string when lookups are concatinated.
+
+    """
+
+    concatenated_lookups: "VariableValueConcatenation"
+    invalid_lookup: "VariableValue"
+
+    def __init__(
+        self,
+        invalid_lookup: "VariableValue",
+        concat_lookups: "VariableValueConcatenation",
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
+        """Instantiate class."""
+        self.concatenated_lookups = concat_lookups
+        self.invalid_lookup = invalid_lookup
+        message = (
+            f"expected return value of type {str} but received "
+            f'{type(invalid_lookup.value)} for lookup "{invalid_lookup}" '
+            f'in "{concat_lookups}"'
+        )
+        super().__init__(message, *args, **kwargs)
+
+
+class OutputDoesNotExist(Exception):
+    """Raised when a specific stack output does not exist."""
+
+    def __init__(self, stack_name, output, *args, **kwargs):
+        """Instantiate class.
+
+        Args:
+            stack_name (str): Name of the stack.
+            output (str): The output that does not exist.
+
+        """
+        self.stack_name = stack_name
+        self.output = output
+
+        message = "Output %s does not exist on stack %s" % (output, stack_name)
+        super().__init__(message, *args, **kwargs)
+
+
+class UnknownLookupType(Exception):
+    """Lookup type provided does not match a registered lookup.
+
+    Example:
+        If a lookup of ``${<lookup_type> query}`` is used and ``<lookup_type>``
+        is not a registered lookup, this exception will be raised.
+
+    """
+
+    def __init__(
+        self, lookup: "VariableValueLookup", *args: Any, **kwargs: Any
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            lookup: Variable value lookup that could not find a handler.
+
+        """
+        message = f'Unknown lookup type "{lookup.lookup_name.value}" in "{lookup}"'
+        super().__init__(message, *args, **kwargs)
+
+
+class UnresolvedVariable(Exception):
+    """Raised when trying to use a variable before it has been resolved."""
+
+    def __init__(self, variable: "Variable", *args: Any, **kwargs: Any) -> None:
+        """Instantiate class.
+
+        Args:
+            variable: The unresolved variable.
+
+        """
+        message = 'Attempted to use variable "{}" before it was resolved'.format(
+            variable.name
+        )
+        super().__init__(message, *args, **kwargs)
+
+
+class UnresolvedVariableValue(Exception):
+    """Intermediary Exception to be converted to UnresolvedVariable.
+
+    Should be caught by error handling and
+    :class:`runway.cfngin.exceptions.UnresolvedVariable` raised instead to
+    construct a propper error message.
+
+    """
+
+    lookup: "VariableValueLookup"
+
+    def __init__(
+        self, lookup: "VariableValueLookup", *args: Any, **kwargs: Any
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            lookup: The variable value lookup that is not resolved.
+
+        """
+        self.lookup = lookup
+        super().__init__("Unresolved lookup", *args, **kwargs)

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -49,7 +49,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from botocore.exceptions import ClientError
 
-from runway.cfngin.exceptions import OutputDoesNotExist, StackDoesNotExist
+from runway.cfngin.exceptions import StackDoesNotExist
+from runway.exceptions import OutputDoesNotExist
 
 from .base import LookupHandler
 

--- a/runway/module/cloudformation.py
+++ b/runway/module/cloudformation.py
@@ -2,7 +2,7 @@
 import logging
 
 from .._logging import PrefixAdaptor
-from ..cfngin import CFNgin
+from ..cfngin.cfngin import CFNgin
 from . import RunwayModule
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/unit/cfngin/blueprints/test_base.py
+++ b/tests/unit/cfngin/blueprints/test_base.py
@@ -23,15 +23,15 @@ from runway.cfngin.blueprints.variables.types import (
     TroposphereType,
 )
 from runway.cfngin.exceptions import (
-    InvalidLookupCombination,
     InvalidUserdataPlaceholder,
     MissingVariable,
-    UnresolvedVariable,
-    UnresolvedVariables,
+    UnresolvedBlueprintVariable,
+    UnresolvedBlueprintVariables,
     ValidatorError,
     VariableTypeRequired,
 )
 from runway.cfngin.lookups import register_lookup_handler
+from runway.exceptions import InvalidLookupConcatenation
 from runway.variables import Variable
 
 from ..factories import mock_context
@@ -176,7 +176,7 @@ class TestVariables(unittest.TestCase):  # pylint: disable=too-many-public-metho
             """Test blueprint."""
 
         blueprint = TestBlueprint(name="test", context=MagicMock())
-        with self.assertRaises(UnresolvedVariables):
+        with self.assertRaises(UnresolvedBlueprintVariables):
             blueprint.get_variables()
 
     def test_set_description(self):
@@ -278,7 +278,7 @@ class TestVariables(unittest.TestCase):  # pylint: disable=too-many-public-metho
         """Test resolve variable provided not resolved."""
         var_name = "testVar"
         provided_variable = Variable(var_name, "${mock abc}", "cfngin")
-        with self.assertRaises(UnresolvedVariable):
+        with self.assertRaises(UnresolvedBlueprintVariable):
             var_def = {"type": str}
             blueprint_name = "testBlueprint"
 
@@ -538,7 +538,7 @@ class TestVariables(unittest.TestCase):  # pylint: disable=too-many-public-metho
             "cfngin",
         )
         variable._value[0].resolve({}, {})
-        with self.assertRaises(InvalidLookupCombination):
+        with self.assertRaises(InvalidLookupConcatenation):
             variable.value()  # pylint: disable=not-callable
 
     def test_get_variables(self):

--- a/tests/unit/cfngin/lookups/handlers/test_hook_data.py
+++ b/tests/unit/cfngin/lookups/handlers/test_hook_data.py
@@ -1,9 +1,9 @@
 """Tests for runway.cfngin.lookups.handlers.hook_data."""
-# pylint: disable=no-self-use
+# pylint: disable=no-self-use,protected-access
 import pytest
 from troposphere.awslambda import Code
 
-from runway.cfngin.exceptions import FailedVariableLookup
+from runway.exceptions import FailedVariableLookup
 from runway.variables import Variable
 
 
@@ -48,8 +48,10 @@ class TestHookDataLookup:
         with pytest.raises(FailedVariableLookup) as err:
             variable.resolve(cfngin_context)
 
-        assert "ValueError" in str(err.value)
-        assert 'Could not find a value for "fake_hook.bad.result"' in str(err.value)
+        assert str(err.value) == (
+            f'Could not resolve lookup "{variable._raw_value}" for variable "{variable.name}"'
+        )
+        assert "Could not find a value for" in str(err.value.__cause__)
 
     def test_troposphere(self, cfngin_context):
         """Test with troposphere object like returned from lambda hook."""
@@ -93,7 +95,10 @@ class TestHookDataLookup:
         ):
             variable.resolve(cfngin_context)
 
-        assert "ValueError" in str(err.value)
+        assert str(err.value) == (
+            f'Could not resolve lookup "{variable._raw_value}" for variable "{variable.name}"'
+        )
+        assert "Could not find a value for" in str(err.value.__cause__)
 
     def test_legacy_bad_value_hook_data(self, cfngin_context):
         """Test bad value hook data."""
@@ -106,4 +111,7 @@ class TestHookDataLookup:
         ):
             variable.resolve(cfngin_context)
 
-        assert "ValueError" in str(err.value)
+        assert str(err.value) == (
+            f'Could not resolve lookup "{variable._raw_value}" for variable "{variable.name}"'
+        )
+        assert "Could not find a value for" in str(err.value.__cause__)

--- a/tests/unit/cfngin/lookups/test_registry.py
+++ b/tests/unit/cfngin/lookups/test_registry.py
@@ -4,8 +4,8 @@ import unittest
 
 from mock import MagicMock
 
-from runway.cfngin.exceptions import FailedVariableLookup, UnknownLookupType
 from runway.cfngin.lookups.registry import CFNGIN_LOOKUP_HANDLERS
+from runway.exceptions import FailedVariableLookup, UnknownLookupType
 from runway.variables import Variable, VariableValueLookup
 
 from ..factories import mock_context, mock_provider
@@ -69,7 +69,7 @@ class TestRegistry(unittest.TestCase):
         with self.assertRaises(FailedVariableLookup) as result:
             variable.resolve(self.ctx, self.provider)
 
-        self.assertIsInstance(result.exception.error, ValueError)
+        self.assertIsInstance(result.exception.cause.__cause__, ValueError)
 
     def test_resolve_lookups_string_failed_variable_lookup(self):
         """Test resolve lookups string failed variable lookup."""

--- a/tests/unit/cfngin/test_cfngin.py
+++ b/tests/unit/cfngin/test_cfngin.py
@@ -5,7 +5,7 @@ import shutil
 import pytest
 from mock import MagicMock, call, patch
 
-from runway.cfngin import CFNgin
+from runway.cfngin.cfngin import CFNgin
 from runway.core.components import DeployEnvironment
 
 from ..factories import MockRunwayContext

--- a/tests/unit/core/components/test_deployment.py
+++ b/tests/unit/core/components/test_deployment.py
@@ -5,9 +5,10 @@ import logging
 import pytest
 from mock import MagicMock, PropertyMock, call, patch
 
-from runway.cfngin.exceptions import UnresolvedVariable
 from runway.config import DeploymentDefinition, FutureDefinition, VariablesDefinition
 from runway.core.components import Deployment
+from runway.exceptions import UnresolvedVariable
+from runway.variables import Variable
 
 MODULE = "runway.core.components._deployment"
 
@@ -147,7 +148,13 @@ class TestDeployment:
             DeploymentDefinition,
             "env_vars",
             PropertyMock(
-                side_effect=[UnresolvedVariable("test", MagicMock()), expected]
+                side_effect=[
+                    UnresolvedVariable(
+                        Variable("test", "something", variable_type="runway"),
+                        MagicMock(),
+                    ),
+                    expected,
+                ]
             ),
         )
         monkeypatch.setattr(

--- a/tests/unit/lookups/handlers/test_cfn.py
+++ b/tests/unit/lookups/handlers/test_cfn.py
@@ -10,7 +10,8 @@ from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 from mock import MagicMock, patch
 
-from runway.cfngin.exceptions import OutputDoesNotExist, StackDoesNotExist
+from runway.cfngin.exceptions import StackDoesNotExist
+from runway.exceptions import OutputDoesNotExist
 from runway.lookups.handlers.cfn import TYPE_NAME, CfnLookup, OutputQuery
 
 

--- a/tests/unit/lookups/handlers/test_ssm.py
+++ b/tests/unit/lookups/handlers/test_ssm.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import pytest
 import yaml
 
-from runway.cfngin.exceptions import FailedVariableLookup
+from runway.exceptions import FailedVariableLookup
 from runway.variables import Variable
 
 
@@ -173,5 +173,5 @@ class TestSsmLookup:
         with stubber as stub, pytest.raises(FailedVariableLookup) as err:
             var.resolve(context=runway_context)
 
-        assert "ParameterNotFound" in str(err.value)
+        assert "ParameterNotFound" in str(err.value.__cause__)
         stub.assert_no_pending_responses()

--- a/tests/unit/module/test_cloudformation.py
+++ b/tests/unit/module/test_cloudformation.py
@@ -29,21 +29,21 @@ class TestCloudFormation:
         context.env.aws_region = region
         return context
 
-    @patch("runway.cfngin.CFNgin.deploy")
+    @patch("runway.cfngin.cfngin.CFNgin.deploy")
     def test_deploy(self, mock_action, tmp_path):
         """Test deploy."""
         module = CloudFormation(self.get_context(), str(tmp_path), self.generic_options)
         module.deploy()
         mock_action.assert_called_once()
 
-    @patch("runway.cfngin.CFNgin.destroy")
+    @patch("runway.cfngin.cfngin.CFNgin.destroy")
     def test_destroy(self, mock_action, tmp_path):
         """Test destroy."""
         module = CloudFormation(self.get_context(), str(tmp_path), self.generic_options)
         module.destroy()
         mock_action.assert_called_once()
 
-    @patch("runway.cfngin.CFNgin.plan")
+    @patch("runway.cfngin.cfngin.CFNgin.plan")
     def test_plan(self, mock_action, tmp_path):
         """Test plan."""
         module = CloudFormation(self.get_context(), str(tmp_path), self.generic_options)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,7 +10,6 @@ import yaml
 from mock import MagicMock, call, patch
 from packaging.specifiers import InvalidSpecifier
 
-from runway.cfngin.exceptions import UnresolvedVariable
 from runway.config import (  # tries to test the imported class unless using "as"
     Config,
     DeploymentDefinition,
@@ -19,6 +18,7 @@ from runway.config import (  # tries to test the imported class unless using "as
 )
 from runway.config import TestDefinition as ConfigTestDefinition
 from runway.config import VariablesDefinition
+from runway.exceptions import UnresolvedVariable
 from runway.util import MutableMap
 
 MODULE = "runway.config"

--- a/tests/unit/test_variables.py
+++ b/tests/unit/test_variables.py
@@ -6,9 +6,9 @@ from mock import MagicMock
 from troposphere import s3
 
 from runway.cfngin.blueprints.variables.types import TroposphereType
-from runway.cfngin.exceptions import UnresolvedVariable
 from runway.cfngin.lookups import register_lookup_handler
 from runway.cfngin.stack import Stack
+from runway.exceptions import UnresolvedVariable
 from runway.util import MutableMap
 from runway.variables import Variable
 


### PR DESCRIPTION

## Summary

Relocate exceptions related to variables and lookups to the top level of Runway.

## Why This Is Needed

resolves #430

## What Changed

### Changed

- variable and lookup exceptions are now located in `runway.exceptions`
	- reworded some of these exceptions and changed some of the parameters & attributes
- renamed some exceptions in `runway.cfngin.exceptions` to scope them to Blueprints for clarity
- updated some type hints and converted them to modern type hints (basic type checking was used to validate but they may not pass strict type checking)
- updated tests to use the new import locations

### Fixed

_Were any bugs fixed?_

### Removed

- removed a redundant exception that existed to re-raise another exception without adding meaningful information
