### PR TITLE
fix `YamlDirTestGenerator` python 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixed a python 3 compatibility issue in `runway.cfngin.blueprints.testutil.YamlDirTestGenerator`
 
 ## [1.12.0] - 2020-09-11
 ### Changed

--- a/runway/cfngin/blueprints/testutil.py
+++ b/runway/cfngin/blueprints/testutil.py
@@ -150,7 +150,7 @@ class YamlDirTestGenerator(object):
 
                 configvars = self.stack.variables or {}
                 variables = [
-                    Variable(k, v, "cfngin") for k, v in configvars.iteritems()
+                    Variable(k, v, "cfngin") for k, v in configvars.items()
                 ]
 
                 blueprint_class = load_object_from_string(self.stack.class_path)

--- a/runway/cfngin/blueprints/testutil.py
+++ b/runway/cfngin/blueprints/testutil.py
@@ -149,9 +149,7 @@ class YamlDirTestGenerator(object):
                     )
 
                 configvars = self.stack.variables or {}
-                variables = [
-                    Variable(k, v, "cfngin") for k, v in configvars.items()
-                ]
+                variables = [Variable(k, v, "cfngin") for k, v in configvars.items()]
 
                 blueprint_class = load_object_from_string(self.stack.class_path)
                 blueprint = blueprint_class(self.stack.name, ctx)


### PR DESCRIPTION
## Summary

Use of `dict.iteritems()` was removed in Python 3. This change updates the reference to use `dict.items()` instead.

## Why This Is Needed

Class `YamlDirTestGenerator` is broken in Python 3 due to legacy `dict.iteritems()` use.

## What Changed

### Fixed

- fixed Python 3 compatibility issue in `YamlDirTestGenerator` when iterating a `dict`