### PR TITLE
fix cfngin kms lookup on py3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `overlay_path` option for k8s modules
 
+### Fixed
+- CFN: ensure kms lookup returns a non-binary value on all python versions
+
 ## [1.11.3] - 2020-08-19
 ### Fixed
 - fixed an issue where `npx runway` (installed from npm) would not work on Windows if there was a space in the path

--- a/runway/cfngin/lookups/handlers/kms.py
+++ b/runway/cfngin/lookups/handlers/kms.py
@@ -1,6 +1,7 @@
 """AWS KMS lookup."""
 # pylint: disable=arguments-differ,unused-argument
 import codecs
+import sys
 
 from runway.lookups.handlers.base import LookupHandler
 
@@ -73,4 +74,7 @@ class KmsLookup(LookupHandler):
         decoded = codecs.decode(value, "base64")
 
         # decrypt and return the plain text raw value.
-        return kms.decrypt(CiphertextBlob=decoded)["Plaintext"]
+        decrypted = kms.decrypt(CiphertextBlob=decoded)["Plaintext"]
+        if sys.version_info[0] > 2:  # TODO remove after droping python 2
+            return decrypted.decode("UTF-8")
+        return decrypted

--- a/runway/cfngin/lookups/handlers/kms.py
+++ b/runway/cfngin/lookups/handlers/kms.py
@@ -75,6 +75,6 @@ class KmsLookup(LookupHandler):
 
         # decrypt and return the plain text raw value.
         decrypted = kms.decrypt(CiphertextBlob=decoded)["Plaintext"]
-        if sys.version_info[0] > 2:  # TODO remove after droping python 2
-            return decrypted.decode("UTF-8")
+        if sys.version_info[0] > 2:  # TODO remove condition after droping py2
+            return decrypted.decode()
         return decrypted

--- a/tests/unit/cfngin/lookups/handlers/test_kms.py
+++ b/tests/unit/cfngin/lookups/handlers/test_kms.py
@@ -1,5 +1,6 @@
 """Tests for runway.cfngin.lookups.handlers.kms."""
 import codecs
+import sys
 import unittest
 
 import boto3
@@ -28,7 +29,7 @@ class TestKMSHandler(unittest.TestCase):
         """Run before tests."""
         self.stubber = Stubber(self.client)
         self.provider = mock_provider(region=REGION)
-        self.secret = b"my secret"
+        self.secret = "my secret"
 
     @patch(
         "runway.cfngin.lookups.handlers.kms.get_session",
@@ -38,14 +39,19 @@ class TestKMSHandler(unittest.TestCase):
         """Test kms handler."""
         self.stubber.add_response(
             "decrypt",
-            {"Plaintext": self.secret},
-            {"CiphertextBlob": codecs.decode(self.secret, "base64")},
+            # TODO: drop ternary when dropping python 2 support
+            {
+                "Plaintext": self.secret.encode()
+                if sys.version_info[0] > 2
+                else self.secret
+            },
+            {"CiphertextBlob": codecs.decode(self.secret.encode(), "base64")},
         )
 
         with self.stubber:
             self.assertEqual(
                 self.secret,
-                KmsLookup.handle(value=self.secret.decode(), provider=self.provider),
+                KmsLookup.handle(value=self.secret, provider=self.provider),
             )
             self.stubber.assert_no_pending_responses()
 
@@ -55,12 +61,17 @@ class TestKMSHandler(unittest.TestCase):
     )
     def test_kms_handler_with_region(self, _mock_client):
         """Test kms handler with region."""
-        value = "{}@{}".format(REGION, self.secret.decode())
+        value = "{}@{}".format(REGION, self.secret)
 
         self.stubber.add_response(
             "decrypt",
-            {"Plaintext": self.secret},
-            {"CiphertextBlob": codecs.decode(self.secret, "base64")},
+            # TODO: drop ternary when dropping python 2 support
+            {
+                "Plaintext": self.secret.encode()
+                if sys.version_info[0] > 2
+                else self.secret
+            },
+            {"CiphertextBlob": codecs.decode(self.secret.encode(), "base64")},
         )
 
         with self.stubber:


### PR DESCRIPTION
This should avoid returning a binary value unexpectedly.

