### PR TITLE
add overlay_path for k8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Terraform files are now able to be parsed by `python-hcl2` (eks-base.tf was failing both parsers)
   - replace the custom script with tls provider to get EKS cluster `sha1_fingerprint`
 
+### Added
+- `overlay_path` option for k8s modules
+
 ## [1.11.3] - 2020-08-19
 ### Fixed
 - fixed an issue where `npx runway` (installed from npm) would not work on Windows if there was a space in the path

--- a/docs/source/kubernetes/configuration.rst
+++ b/docs/source/kubernetes/configuration.rst
@@ -19,6 +19,15 @@ Options
     options:
       kubectl_version: 1.14.5
 
+**overlay_path (Optional[str])**
+  Specify the directory containing the kustomize overlay to use.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    options:
+      overlay_path: overlays/${env DEPLOY_ENVIRONMENT}-blue
+
 
 **********
 Parameters

--- a/runway/module/k8s.py
+++ b/runway/module/k8s.py
@@ -83,15 +83,21 @@ class K8s(RunwayModule):
 
     def run_kubectl(self, command="plan"):
         """Run kubectl."""
-        kustomize_config_path = os.path.join(
-            self.path,
-            "overlays",
-            get_overlay_dir(
-                os.path.join(self.path, "overlays"),
-                self.context.env.name,
-                self.context.env.aws_region,
-            ),
-        )
+        if self.options.get("options", {}).get("overlay_path"):
+            # config path is overriden from runway
+            kustomize_config_path = os.path.join(
+                self.path, self.options.get("options", {}).get("overlay_path"),
+            )
+        else:
+            kustomize_config_path = os.path.join(
+                self.path,
+                "overlays",
+                get_overlay_dir(
+                    os.path.join(self.path, "overlays"),
+                    self.context.env.name,
+                    self.context.env.aws_region,
+                ),
+            )
         response = generate_response(
             kustomize_config_path,
             self.path,


### PR DESCRIPTION
Because there is no way to pass Runway parameters into kustomize, this provides an alternative option for changing the overlay used in a given environment.