### PR TITLE
fix issue causing static sites to be inaccessible when not us-east-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - fixed a python 3 compatibility issue in `runway.cfngin.blueprints.testutil.YamlDirTestGenerator`
-
-### Fixed
 - fixed an issue causing static sites to be inaccessible when deployed to regions other than us-east-1
 
 ## [1.12.0] - 2020-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- fixed an issue causing static sites to be inaccessible when deployed to regions other than us-east-1
+
 ## [1.12.0] - 2020-09-11
 ### Changed
 - updated the `k8s-tf-repo` sample

--- a/runway/blueprints/staticsite/staticsite.py
+++ b/runway/blueprints/staticsite/staticsite.py
@@ -15,21 +15,17 @@ import awacs.states
 import awacs.sts
 from awacs.aws import Action, Allow, Policy, PolicyDocument, Principal, Statement
 from awacs.helpers.trust import make_simple_assume_policy
-from troposphere import (  # noqa pylint: disable=unused-import
+from troposphere import (
     AccountId,
     Join,
     NoValue,
     Output,
     Partition,
-    Region,
     StackName,
-    Sub,
     awslambda,
     cloudfront,
     iam,
-    logs,
     s3,
-    stepfunctions,
 )
 
 from runway.cfngin.blueprints.base import Blueprint


### PR DESCRIPTION

## Why This Is Needed

resolves #445 

[![image](https://user-images.githubusercontent.com/23145462/93118014-781c9600-f674-11ea-8477-72b3331ef68d.png)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html)

According to the [AWS docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html) screenshot above, our current implementation of configuring the S3 bucket for hosting a static website conflicts with the use of an OAI to grant access.

By removing the `WebsiteConfiguration`, we can use the OAI correctly.

To continue using `WebsiteConfiguration` with CloudFront, we would need to make the bucket private and/or use custom headers to restrict access - configuring the Bucket as a custom origin rather than an S3 origin.

## What Changed

### Changed

- the static site S3 Bucket is now only configured for static website hosting if not using CloudFront

### Fixed

- fixed an issue causing static sites to be inaccessible when deployed to regions other than us-east-1
