### PR TITLE
fix `npx runway <command>` (npm) not recognized on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - fixed a python 3 compatibility issue in `runway.cfngin.blueprints.testutil.YamlDirTestGenerator`
 - fixed an issue causing static sites to be inaccessible when deployed to regions other than us-east-1
+- fixed an issue where `npx runway <command>` (installed from npm) would not work on Windows
 
 ## [1.12.0] - 2020-09-11
 ### Changed

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -94,7 +94,7 @@ fs.mkdir(`${moduleDir}/runway`, { recursive: true }, (err, data) => {
       }
       // symlink does not work for windows so we need to use a bat file
       // this will overwrite the file if it already exists so no fancy error handling needed
-      fs.writeFile(binPath, `@"${moduleDir}/runway/runway-cli.exe %*"`, (err, data) => {
+      fs.writeFile(binPath, `@"${moduleDir}/runway/runway-cli.exe" %*`, (err, data) => {
         if (err) throw err;
       })
     }


### PR DESCRIPTION
## Why This Is Needed

resolves #447 

## What Changed

### Changed

- moved double quote from after args to before args in windows npm `runway.bat`

### Fixed

- fixed an issue where `npx runway <command>` (installed from npm) would not work on Windows
