### PR TITLE
static site CF origin will now use the s3 regional endpoint to avoid temporary redirect for new deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixed an issues causing static sites in regions other than us-east-1 to redirect to the s3 object until CloudFront was able to use the global endpoint of the bucket
 
 ## [1.13.0] - 2020-09-14
 ### Added

--- a/runway/blueprints/staticsite/staticsite.py
+++ b/runway/blueprints/staticsite/staticsite.py
@@ -229,7 +229,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         """
         variables = self.get_variables()
 
-        if os.environ.get("AWS_REGION") == "us-east-1":
+        if os.getenv("AWS_REGION") == "us-east-1":
             # use global endpoint for us-east-1
             origin = Join(".", [bucket.ref(), "s3.amazonaws.com"])
         else:


### PR DESCRIPTION

## Why This Is Needed

resolves #445 ([second problem raised in the issue](https://github.com/onicagroup/runway/issues/445#issuecomment-692826339))

## What Changed

### Changed

- static site CloudFront distribution now uses regional endpoints for the S3 bucket
	- us-east-1 still uses the global endpoint 

### Fixed

- fixed an issues causing static sites in regions other than us-east-1 to redirect to the s3 object until CloudFront was able to use the global endpoint of the bucket
