### PR TITLE
remove relocated stacker shim

### DIFF
--- a/runway/module/cloudformation.py
+++ b/runway/module/cloudformation.py
@@ -1,18 +1,11 @@
 """Cloudformation module."""
 import logging
-import sys
 
-from .. import cfngin as cfngin_module
-from .. import variables
 from .._logging import PrefixAdaptor
 from ..cfngin.cfngin import CFNgin
 from . import RunwayModule
 
 LOGGER = logging.getLogger(__name__)
-
-# TODO remove - https://github.com/onicagroup/runway/issues/293
-sys.modules["stacker"] = cfngin_module  # shim to remove stacker dependency
-sys.modules["stacker.variables"] = variables  # shim to support standard variables
 
 
 class CloudFormation(RunwayModule):

--- a/runway/path.py
+++ b/runway/path.py
@@ -109,7 +109,7 @@ class Path:  # pylint: disable=too-many-instance-attributes
     """
 
     def __init__(self, module, env_root, cache_dir=None, git_source_class=Git):
-        # type: (Union(str, Dict[str, str]), str, Optional[str], Optional[Git]) -> None
+        # type: (Union[str, Dict[str, str]], str, Optional[str], Optional[Git]) -> None
         """Path Configuration.
 
         Keyword Args:
@@ -153,7 +153,7 @@ class Path:  # pylint: disable=too-many-instance-attributes
         return os.path.join(self.env_root, self.location)
 
     def __fetch_remote_source(self):
-        # type: () -> Union(Git, None)
+        # type: () -> Optional[Git]
         """Switch based on the retrieved source of the path.
 
         Determine which remote Source type to fetch based on the source

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,10 +8,8 @@ from typing import Dict
 import pytest
 import yaml
 
-# TODO fix runway import issues caused when importing config - will req v2 changes
-# from runway.config import Config
-# from runway.core.components import DeployEnvironment
-import runway
+from runway.config import Config
+from runway.core.components import DeployEnvironment
 
 from .factories import (
     MockCFNginContext,
@@ -76,7 +74,7 @@ def fx_config():
     """Return YAML loader for config fixtures."""
     return YamlLoader(
         TEST_ROOT.parent / "fixtures" / "configs",
-        load_class=runway.config.Config,
+        load_class=Config,
         load_type="kwargs",
     )
 
@@ -164,7 +162,5 @@ def runway_context(request):
     env_vars.update(getattr(request.module, "ENV_VARS", {}))
     return MockRunwayContext(
         command="test",
-        deploy_environment=runway.core.components.DeployEnvironment(
-            environ=env_vars, explicit_name="test"
-        ),
+        deploy_environment=DeployEnvironment(environ=env_vars, explicit_name="test"),
     )


### PR DESCRIPTION
## Why This Is Needed

resolves #293 

a portion of the shim was removed when rebasing the `v2` branch as there was a conflict

## What Changed

### Changed

- reverted change to `tests/unit/conftest.py` to avoid import issue uncovered after moving the shim

### Removed

- removed relocated stacker shim
