### PR TITLE
staticsite: add additional_redirect_domains option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Static Site Auth@Edge: when domain aliases are specified, the CloudFront domain will no longer be added to the list of callback URLs
+  - E.g. if `site.example.com` is provided as the site alias, logins will only work from `site.example.com` and not `d111111abcdef8.cloudfront.net`
+  - This should better match expected behavior, and has the advantage of being deterministic: the Cognito AppClient no longer has to be updated after creating the CloudFront distribution
+  - Old behavior can be preserved via the new `staticsite_additional_redirect_domains` option
+
+### Added
+- Static Site Auth@Edge: `staticsite_additional_redirect_domains` option.
 
 ## [1.13.1] - 2020-09-21
 ### Fixed

--- a/docs/source/staticsite/configuration.rst
+++ b/docs/source/staticsite/configuration.rst
@@ -370,7 +370,7 @@ Parameters
   Additional domains (beyond the `staticsite_aliases` domains or the CloudFront URL if no
   aliases are provided) that will be authorized by the :ref:`Auth@Edge` UserPool AppClient.
   This parameter typically won't be needed in production environments, but can be useful in
-  development environments to bypass Runway Auth@Edge.
+  development environments to allow bypassing Runway Auth@Edge.
 
   This should be represented as a comma delimited list of domains with protocols. Requires
   staticsite_auth_at_edge_.

--- a/docs/source/staticsite/configuration.rst
+++ b/docs/source/staticsite/configuration.rst
@@ -369,14 +369,16 @@ Parameters
 **staticsite_additional_redirect_domains (Optional[str])**
   Additional domains (beyond the `staticsite_aliases` domains or the CloudFront URL if no
   aliases are provided) that will be authorized by the :ref:`Auth@Edge` UserPool AppClient.
-  This should be represented as a comma delimited list of domains with protocols.
+  This parameter typically won't be needed in production environments, but can be useful in
+  development environments to bypass Runway Auth@Edge.
 
-  Requires staticsite_auth_at_edge_.
+  This should be represented as a comma delimited list of domains with protocols. Requires
+  staticsite_auth_at_edge_.
 
   .. rubric:: Example
   .. code-block:: yaml
 
-    parameters
+    parameters:
       staticsite_additional_redirect_domains: http://localhost:3000
 
 **staticsite_web_acl (Optional[str])**

--- a/docs/source/staticsite/configuration.rst
+++ b/docs/source/staticsite/configuration.rst
@@ -366,6 +366,19 @@ Parameters
     parameters
       staticsite_user_pool_arn: arn:aws:cognito-idp:<region>:<account-id>:userpool/<pool>
 
+**staticsite_additional_redirect_domains (Optional[str])**
+  Additional domains (beyond the `staticsite_aliases` domains or the CloudFront URL if no
+  aliases are provided) that will be authorized by the :ref:`Auth@Edge` UserPool AppClient.
+  This should be represented as a comma delimited list of domains with protocols.
+
+  Requires staticsite_auth_at_edge_.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    parameters
+      staticsite_additional_redirect_domains: http://localhost:3000
+
 **staticsite_web_acl (Optional[str])**
   The ARN of a `web access control list (web ACL) <https://docs.aws.amazon.com/waf/latest/developerguide/web-acl.html>`__ to associate with the CloudFront Distribution.
 

--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -9,6 +9,7 @@ from awacs.aws import Allow, AWSPrincipal, Policy, Statement
 from troposphere import AccountId, Join, Output, cognito, s3
 
 from runway.cfngin.blueprints.base import Blueprint
+from runway.module.staticsite import add_url_scheme
 
 LOGGER = logging.getLogger(__name__)
 
@@ -17,6 +18,17 @@ class Dependencies(Blueprint):
     """Stacker blueprint for creating static website buckets."""
 
     VARIABLES = {
+        "Aliases": {
+            "type": list,
+            "default": [],
+            "description": "(Optional) Domain aliases for the distribution",
+        },
+        "AdditionalRedirectDomains": {
+            "type": list,
+            "default": [],
+            "description": "(Optional) AppClient callback/logout domains (in "
+            "addition to the Aliases)",
+        },
         "AuthAtEdge": {
             "type": bool,
             "default": False,
@@ -26,6 +38,10 @@ class Dependencies(Blueprint):
             "type": bool,
             "default": False,
             "description": "Whether a User Pool should be created for the project",
+        },
+        "SupportedIdentityProviders": {
+            "type": list,
+            "description": "Auth@Edge AppClient Identity Providers",
         },
         "OAuthScopes": {
             "type": list,
@@ -37,6 +53,16 @@ class Dependencies(Blueprint):
                 "aws.cognito.signin.user.admin",
             ],
             "description": "The allowed scopes for OAuth validation",
+        },
+        "RedirectPathSignIn": {
+            "type": str,
+            "default": "/parseauth",
+            "description": "Auth@Edge redirect sign in path",
+        },
+        "RedirectPathSignOut": {
+            "type": str,
+            "default": "/",
+            "description": "Auth@Edge redirect sign out path",
         },
     }
 
@@ -107,9 +133,32 @@ class Dependencies(Blueprint):
         )
 
         if variables["AuthAtEdge"]:
-            callbacks = self.context.hook_data["aae_callback_url_retriever"][
-                "callback_urls"
-            ]
+            userpool_client_params = {
+                "AllowedOAuthFlows": ["code"],
+                "AllowedOAuthScopes": variables["OAuthScopes"],
+            }
+            if variables["Aliases"]:
+                userpool_client_params["AllowedOAuthFlowsUserPoolClient"] = True
+                userpool_client_params["SupportedIdentityProviders"] = variables[
+                    "SupportedIdentityProviders"
+                ]
+                redirect_domains = [add_url_scheme(x) for x in variables["Aliases"]] + [
+                    add_url_scheme(x) for x in variables["AdditionalRedirectDomains"]
+                ]
+
+                # Create a list of all domains with their redirect paths
+                userpool_client_params["CallbackURLs"] = [
+                    "%s%s" % (domain, variables["RedirectPathSignIn"])
+                    for domain in redirect_domains
+                ]
+                userpool_client_params["LogoutURLs"] = [
+                    "%s%s" % (domain, variables["RedirectPathSignOut"])
+                    for domain in redirect_domains
+                ]
+            else:
+                userpool_client_params["CallbackURLs"] = self.context.hook_data[
+                    "aae_callback_url_retriever"
+                ]["callback_urls"]
 
             if variables["CreateUserPool"]:
                 user_pool = template.add_resource(
@@ -129,15 +178,10 @@ class Dependencies(Blueprint):
                 user_pool_id = self.context.hook_data["aae_user_pool_id_retriever"][
                     "id"
                 ]
+            userpool_client_params["UserPoolId"] = user_pool_id
 
             client = template.add_resource(
-                cognito.UserPoolClient(
-                    "AuthAtEdgeClient",
-                    AllowedOAuthFlows=["code"],
-                    CallbackURLs=callbacks,
-                    UserPoolId=user_pool_id,
-                    AllowedOAuthScopes=variables["OAuthScopes"],
-                )
+                cognito.UserPoolClient("AuthAtEdgeClient", **userpool_client_params)
             )
 
             template.add_output(

--- a/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
+++ b/runway/hooks/staticsite/auth_at_edge/callback_url_retriever.py
@@ -41,7 +41,7 @@ def get(context, provider, **kwargs):
     cognito_client = session.client("cognito-idp")
 
     context_dict = {}
-    context_dict["callback_urls"] = ["https://example.tmp"]
+    context_dict["callback_urls"] = ["https://example.org"]
 
     try:
         # Return the current stack if one exists

--- a/runway/module/staticsite.py
+++ b/runway/module/staticsite.py
@@ -519,8 +519,12 @@ class StaticSite(RunwayModule):
                 {
                     "AuthAtEdge": self.parameters.get("staticsite_auth_at_edge", False),
                     "SupportedIdentityProviders": self._get_supported_identity_providers(),
-                    "RedirectPathSignIn": "${default staticsite_redirect_path_sign_in::/parseauth}",
-                    "RedirectPathSignOut": "${default staticsite_redirect_path_sign_out::/}",
+                    "RedirectPathSignIn": (
+                        "${default staticsite_redirect_path_sign_in::/parseauth}"
+                    ),
+                    "RedirectPathSignOut": (
+                        "${default staticsite_redirect_path_sign_out::/}"
+                    ),
                 }
             )
 


### PR DESCRIPTION
~WIP - there's still some DRYing and cleanup to be done, but the broad elements are ready for discussion before buttoning it up.~

The main change at play here is solving the local development issue when using Auth@Edge, by way of conditionally allowing `localhost` callback URLs to be used with Cognito in development environments. Preliminary name for this new option is `staticsite_additional_redirect_domains`.

In adding the option, I've made one other change that's _technically_ breaking, but I believe it's more intuitive & solves a timing issue for the majority of uses: now, if an alias for the Auth@Edge domain is specified (e.g. myapp.example.com, instead of just relying on accessing the site via `https://dkldhy3d8df.cloudfront.net`), then the CloudFront domain will not be included in the callback URLs. I don't believe there's a single existing user that will be negatively affected by this change, and if anyone desires the old behavior it can be achieved via the new `staticsite_additional_redirect_domains` option.

Example of using the new option to define a serverless app that only allows localhost redirects in dev:
```
variables:
  qa: &variables
    namespace: internalapptest-qa
    cert_domain: internalapptest-qa.example.com
    user_pool_arn: arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_kodf83dfD
    user_pool_supported_identity_providers: Auth0
    user_pool_additional_redirect_domains: ""
  prod:
    <<: *variables
    namespace: internalapptest-prod
    cert_domain: internalapptest-prod.example.com
  dev:
    <<: *variables
    namespace: internalapptest-dev
    cert_domain: internalapptest.example.com
    user_pool_additional_redirect_domains: http://localhost:3000

deployments:
  - regions:
      - us-east-1
    parameters:
      namespace: ${var ${env DEPLOY_ENVIRONMENT}.namespace}
      region: ${env AWS_REGION}
      cert_domain: ${var ${env DEPLOY_ENVIRONMENT}.cert_domain}
    modules:
      - path: backend.sls
      - name: frontend
        path: frontend
        type: static
        parameters:
          staticsite_acmcert_arn: ${ssm /${var ${env DEPLOY_ENVIRONMENT}.namespace}/acm_cert_arn}
          staticsite_aliases: ${var ${env DEPLOY_ENVIRONMENT}.cert_domain}
          staticsite_auth_at_edge: true
          staticsite_user_pool_arn: ${var ${env DEPLOY_ENVIRONMENT}.user_pool_arn}
          staticsite_supported_identity_providers: ${var ${env DEPLOY_ENVIRONMENT}.user_pool_supported_identity_providers}
          staticsite_additional_redirect_domains: ${var ${env DEPLOY_ENVIRONMENT}.user_pool_additional_redirect_domains}
        options:
          build_output: build
          pre_build_steps:
            - command: npm ci
              cwd: ../backend.sls
            - command: npx sls exportEndpoints --stage ${env DEPLOY_ENVIRONMENT} --region ${env AWS_REGION}
              cwd: ../backend.sls
          build_steps:
            - npm run build
          source_hashing:
            enabled: true
            directories:
              - path: src
              - path: public
```