### PR TITLE
auth@edge: fix refreshauth error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - fixed an issues causing static sites in regions other than us-east-1 to redirect to the s3 object until CloudFront was able to use the global endpoint of the bucket
+- fixed uncaught static site auth@edge errors in refresh token handling
 
 ## [1.13.0] - 2020-09-14
 ### Added

--- a/runway/hooks/staticsite/auth_at_edge/templates/shared.py
+++ b/runway/hooks/staticsite/auth_at_edge/templates/shared.py
@@ -4,7 +4,6 @@ import json
 import logging
 import re
 import time
-import traceback
 from datetime import datetime
 from random import random
 from urllib import request  # pylint: disable=no-name-in-module
@@ -304,9 +303,8 @@ def http_post_with_retry(url, data, headers):
         except Exception as err:
             LOGGER.error("HTTP POST to %s failed (attempt %s)", url, attempts)
             LOGGER.error(err)
-            LOGGER.error(traceback.print_exc())
             if attempts >= 5:
-                break
+                raise
             if attempts >= 2:
                 # After attempting twice do some exponential backoff with jitter
                 time.sleep((25 * (pow(2, attempts) + random() * attempts)) / 1000)


### PR DESCRIPTION
Previous "break" statement would cause None to be returned by the function (after the 5 attempts failed), which refreshauth did not expect. Changing it to `raise` pushes the error into refresh auth so it can invalidate the token as expected.

parseauth also uses this shared function, and this should also help avoid unexpected error handling in it.

Cosmetically, removed the traceback logging from the http method because it didn't show anything farther up the stack than the
http_post_with_retry method (just request/urllib spam).

Cloudwatch Logs showing the error occurring:
![image](https://user-images.githubusercontent.com/1806418/93830270-99592580-fc24-11ea-8761-84c4c148345c.png)
