### PR TITLE
fix non-idempotent Auth@Edge function deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Static Site Auth@Edge: fix non-idempotent deploys when deploying from different systems
 
 ## [1.14.0] - 2020-09-23
 ### Changed

--- a/runway/hooks/staticsite/auth_at_edge/lambda_config.py
+++ b/runway/hooks/staticsite/auth_at_edge/lambda_config.py
@@ -112,7 +112,14 @@ def write(
                 context,
                 provider,
                 bucket=kwargs["bucket"],
-                functions={handler: {"path": dirpath}},
+                functions={
+                    handler: {
+                        "path": dirpath,
+                        "python_dontwritebytecode": True,
+                        "python_exclude_bin_dir": True,
+                        "python_exclude_setuptools_dirs": True,
+                    }
+                },
             )
 
             # Add the lambda code reference to our context_dict


### PR DESCRIPTION
pyrsa/pyjwt create scripts with a shebang specific to the build system. Removing them, and setuptools remnants containing various hash values, stops new functions from being built on different systems.

It's possible the `PYTHONDONTWRITEBYTECODE` option is safe to apply unconditionally to all function builds by default, but I'm not 100% certain of the implications of that so I've gated it to an explicit option for now.

All of the new options have been intentionally left off the docs for this first pass where we may revise the names.

Discrepancies in the packages looked like:
```
diff -ur old/ecdsa-0.15.dist-info/RECORD new/ecdsa-0.15.dist-info/RECORD
--- old/ecdsa-0.15.dist-info/RECORD	2020-09-24 18:52:58.000000000 -0700
+++ new/ecdsa-0.15.dist-info/RECORD	2020-09-24 11:38:08.000000000 -0700
@@ -2,33 +2,32 @@
 ecdsa-0.15.dist-info/LICENSE,sha256=PsqYRXc9LluMydjBGdNF8ApIBuS9Zg1KPWzfnA6di7I,1147
 ecdsa-0.15.dist-info/METADATA,sha256=Vipd5pI4sqqaWMjmDzRNRkZCQaq1YDHOHkAJPlI92tw,24899
 ecdsa-0.15.dist-info/RECORD,,
-ecdsa-0.15.dist-info/REQUESTED,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
 ecdsa-0.15.dist-info/WHEEL,sha256=8zNYZbwQSXoB9IfXOjPfeNwvAsALAjffgk27FqvCWbo,110
 ecdsa-0.15.dist-info/top_level.txt,sha256=7ovPHfAPyTou19f8gOSbHm6B9dGjTibWolcCB7Zjovs,6
 ecdsa/__init__.py,sha256=3wbqSX9mkjn_sjkbx2vU-MJbKg0uz8DYLAZE5Jk4iyc,1219
-ecdsa/__pycache__/__init__.cpython-37.pyc,,
-ecdsa/__pycache__/_compat.cpython-37.pyc,,
-ecdsa/__pycache__/_rwlock.cpython-37.pyc,,
-ecdsa/__pycache__/_version.cpython-37.pyc,,
-ecdsa/__pycache__/curves.cpython-37.pyc,,
-ecdsa/__pycache__/der.cpython-37.pyc,,
-ecdsa/__pycache__/ecdh.cpython-37.pyc,,
-ecdsa/__pycache__/ecdsa.cpython-37.pyc,,
-ecdsa/__pycache__/ellipticcurve.cpython-37.pyc,,
-ecdsa/__pycache__/keys.cpython-37.pyc,,
-ecdsa/__pycache__/numbertheory.cpython-37.pyc,,
-ecdsa/__pycache__/rfc6979.cpython-37.pyc,,
-ecdsa/__pycache__/test_der.cpython-37.pyc,,
-ecdsa/__pycache__/test_ecdh.cpython-37.pyc,,
-ecdsa/__pycache__/test_ecdsa.cpython-37.pyc,,
-ecdsa/__pycache__/test_ellipticcurve.cpython-37.pyc,,
-ecdsa/__pycache__/test_jacobi.cpython-37.pyc,,
-ecdsa/__pycache__/test_keys.cpython-37.pyc,,
-ecdsa/__pycache__/test_malformed_sigs.cpython-37.pyc,,
-ecdsa/__pycache__/test_numbertheory.cpython-37.pyc,,
-ecdsa/__pycache__/test_pyecdsa.cpython-37.pyc,,
-ecdsa/__pycache__/test_rw_lock.cpython-37.pyc,,
-ecdsa/__pycache__/util.cpython-37.pyc,,
+ecdsa/__pycache__/__init__.cpython-38.pyc,,
+ecdsa/__pycache__/_compat.cpython-38.pyc,,
+ecdsa/__pycache__/_rwlock.cpython-38.pyc,,
+ecdsa/__pycache__/_version.cpython-38.pyc,,
+ecdsa/__pycache__/curves.cpython-38.pyc,,
```

&
```
diff -ur old/bin/pyrsa-verify new/bin/pyrsa-verify
--- old/bin/pyrsa-verify	2020-09-24 18:52:58.000000000 -0700
+++ new/bin/pyrsa-verify	2020-09-24 11:38:08.000000000 -0700
@@ -1,4 +1,4 @@
-#!/root/.local/share/virtualenvs/build-3vGKWv3F/bin/python
+#!/home/troyready/onica/bitbucket/myapp/.venv/bin/python
 # -*- coding: utf-8 -*-
 import re
 import sys
```