### PR TITLE
fix static site regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Static Site (non-Auth@Edge) deployment regression in v1.14
 
 ## [1.14.2] - 2020-09-28
 ### Changed

--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -42,6 +42,7 @@ class Dependencies(Blueprint):
         },
         "SupportedIdentityProviders": {
             "type": list,
+            "default": [],
             "description": "Auth@Edge AppClient Identity Providers",
         },
         "OAuthScopes": {


### PR DESCRIPTION
The lack of a default value on the blueprint params is causing a rendering error with non-a@e deployments. For A@E deployments (where the variable is actually used), a value is always provided so there's no issue having the default in any scenario.

Fixes:
```
runway.cfngin.exceptions.MissingVariable: Variable "SupportedIdentityProviders" in blueprint "site-dependencies" is missing
[runway] site-dependencies:failed (Variable "SupportedIdentityProviders" in blueprint "site-dependencies" is missing)
[runway] The following steps failed: site-dependencies

```