### PR TITLE
CFNgin will now ignore bitbucket-pipeline.yml when finding config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CFNgin will now ignore *bitbucket-pipeline.yml* when finding config files
 
 ## [1.15.0] - 2020-10-03
 ### Changed

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -44,7 +44,7 @@ class CFNgin(object):
     """
 
     EXCLUDE_REGEX = r"runway(\..*)?\.(yml|yaml)"
-    EXCLUDE_LIST = ["buildspec.yml", "docker-compose.yml"]
+    EXCLUDE_LIST = ["bitbucket-pipelines.yml", "buildspec.yml", "docker-compose.yml"]
 
     def __init__(self, ctx, parameters=None, sys_path=None):
         """Instantiate class.

--- a/tests/unit/cfngin/test_cfngin.py
+++ b/tests/unit/cfngin/test_cfngin.py
@@ -251,7 +251,6 @@ class TestCFNgin(object):
         """Test find_config_files."""
         bad_path = tmp_path / "bad_path"
         bad_path.mkdir()
-        # tmp_path.stem
 
         good_config_paths = [
             tmp_path / "_t3sT.yaml",
@@ -266,6 +265,8 @@ class TestCFNgin(object):
         bad_config_paths = [
             tmp_path / ".anything.yaml",
             tmp_path / ".gitlab-ci.yml",
+            tmp_path / "bitbucket-pipelines.yml",
+            tmp_path / "buildspec.yml",
             tmp_path / "docker-compose.yml",
             bad_path / "00-invalid.yml",
         ]


### PR DESCRIPTION

## Why This Is Needed

resolves #470

## What Changed

### Changed

- CFNgin will now ignore *bitbucket-pipeline.yml* when finding config files

