### PR TITLE
CDK template update: add cdk.out to gitignore

### DIFF
--- a/runway/templates/cdk-tsc/.gitignore
+++ b/runway/templates/cdk-tsc/.gitignore
@@ -1,3 +1,4 @@
 *.js
 *.d.ts
 node_modules
+cdk.out


### PR DESCRIPTION
Excludes the generated cdk.out directory (the [cloud assembly directory](https://docs.aws.amazon.com/cdk/latest/guide/assets.html)) from git