### PR TITLE
fixed `TypeError` when staticsite cf is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- fixed `TypeError` when Static Site is configured to use the S3 bucket to serve the website directly (e.g. CloudFront disabled)
+
 ## [1.16.0] - 2020-11-09
 ### Added
 - Static Site Auth@Edge: Add option to restrict access to a UserPool group

--- a/runway/blueprints/staticsite/staticsite.py
+++ b/runway/blueprints/staticsite/staticsite.py
@@ -388,7 +388,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
 
         if not self.cf_enabled:
             # bucket cannot be configured with WebsiteConfiguration when using OAI S3Origin
-            bucket["WebsiteConfiguration"] = s3.WebsiteConfiguration(
+            bucket.WebsiteConfiguration = s3.WebsiteConfiguration(
                 IndexDocument="index.html", ErrorDocument="error.html"
             )
             self.template.add_output(


### PR DESCRIPTION

## Why This Is Needed

resolved #488 

## What Changed

### Fixed

- fixed `TypeError` when Static Site is configured to use the S3 bucket to serve the website directly (e.g. CloudFront disabled)
