### PR TITLE
kbenv: allow additional checksum verification types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - fixed `TypeError` when Static Site is configured to use the S3 bucket to serve the website directly (e.g. CloudFront disabled)
+- Newer kubectl versions download errors (now supporting sha1/256/512 checksum verification)
 
 ## [1.16.0] - 2020-11-09
 ### Added

--- a/runway/util.py
+++ b/runway/util.py
@@ -721,6 +721,18 @@ def run_commands(
                     sys.exit(1)
 
 
+def get_file_hash(filename, algorithm):
+    """Return cryptographic hash of file."""
+    file_hash = getattr(hashlib, algorithm)()
+    with open(filename, "rb") as stream:
+        while True:
+            data = stream.read(65536)  # 64kb chunks
+            if not data:
+                break
+            file_hash.update(data)
+    return file_hash.hexdigest()
+
+
 def md5sum(filename):
     """Return MD5 hash of file."""
     md5 = hashlib.md5()


### PR DESCRIPTION
The k8s release process has changed the provided checksum types a few times. Currently only sha256 & sha512 files are provided, but in the recent past only md5 & sha1 files were provided.

This new verification process should account for both old and new kubectl versions.
