### PR TITLE
bump python-hcl2 dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump python-hcl2 dependency requirement to reduce parsing failures
 
 ## [1.16.2] - 2020-12-07
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ INSTALL_REQUIRES = [
     "requests",
     "future",
     "pyhcl~=0.4",  # does not support HCL2, possibly move to extras_require in the future
-    'python-hcl2>=0.3.0,<1.0.0; python_version >= "3.6"',  # only support >=3.6
+    'python-hcl2~=2.0; python_version >= "3.6"',  # only support >=3.6
     "gitpython",
     'importlib-metadata; python_version < "3.8"',
     "packaging",  # component of setuptools needed for version compare


### PR DESCRIPTION
Users are reporting that lines like:
```
locals {
  nlb_name = substr("hello world", 0, 4)
}
```

are generating errors that don't occur on newer python-hcl2 versions.