### PR TITLE
fix dependency conflict in sls-tsc sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixed dependency conflict by bumping dependency versions of the sls-tsc sample. now using typedoc beta version to support typescript>=4.1.x.
 
 ## [1.16.3] - 2020-12-10
 ### Changed

--- a/runway/templates/sls-tsc/package.json
+++ b/runway/templates/sls-tsc/package.json
@@ -13,28 +13,28 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.556.0",
-    "source-map-support": "^0.5.10"
+    "aws-sdk": "^2.811.0",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.20",
-    "@types/jest": "^24.0.20",
-    "@types/node": "^11.10.4",
-    "@typescript-eslint/eslint-plugin": "^3.1.0",
-    "@typescript-eslint/parser": "^3.1.0",
-    "eslint": "^7.1.0",
-    "eslint-config-prettier": "^6.11.0",
-    "jest": "^26.0.1",
-    "prettier": "^1.19.1",
-    "serverless": "^1.71.3",
-    "serverless-iam-roles-per-function": "^2.0.2",
-    "serverless-webpack": "^5.2.0",
-    "ts-jest": "^26.1.0",
-    "ts-loader": "^5.3.3",
-    "ts-node": "^8.0.2",
-    "typedoc": "^0.15.6",
-    "typescript": "^3.3.3333",
-    "webpack": "^4.29.6"
+    "@types/aws-lambda": "^8.10.66",
+    "@types/jest": "^26.0.19",
+    "@types/node": "^14.14.14",
+    "@typescript-eslint/eslint-plugin": "^4.10.0",
+    "@typescript-eslint/parser": "^4.10.0",
+    "eslint": "^7.15.0",
+    "eslint-config-prettier": "^7.0.0",
+    "jest": "^26.6.3",
+    "prettier": "^2.2.1",
+    "serverless": "^2.15.0",
+    "serverless-iam-roles-per-function": "^3.0.1",
+    "serverless-webpack": "^5.3.5",
+    "ts-jest": "^26.4.4",
+    "ts-loader": "^8.0.12",
+    "ts-node": "^9.1.1",
+    "typedoc": "^0.20.0-beta.27",
+    "typescript": "^4.1.3",
+    "webpack": "^5.10.3"
   },
   "prettier": {
     "trailingComma": "all"


### PR DESCRIPTION
## Why This Is Needed

resolves #497 

## What Changed

### Fixed

- fixed dependency conflict by bumping dependency versions of the sls-tsc sample. now using typedoc beta version to support typescript>=4.1.x.