### PR TITLE
update uses of `runway.cfngin.session_cache.get_session` to `context.get_session()`

### DIFF
--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -21,7 +21,6 @@ import formic
 from troposphere.awslambda import Code
 
 from ..exceptions import InvalidDockerizePipConfiguration, PipenvError, PipError
-from ..session_cache import get_session
 from ..util import ensure_s3_bucket
 
 # mask to retrieve only UNIX file permissions from the external attributes
@@ -1038,7 +1037,7 @@ def upload_lambda_functions(context, provider, **kwargs):
     payload_acl = kwargs.get("payload_acl", "private")
 
     # Always use the global client for s3
-    session = get_session(bucket_region)
+    session = context.get_session(region=bucket_region)
     s3_client = session.client("s3")
 
     ensure_s3_bucket(s3_client, bucket_name, bucket_region)

--- a/runway/cfngin/hooks/ecs.py
+++ b/runway/cfngin/hooks/ecs.py
@@ -5,20 +5,15 @@ function, and will be removed once this pull request is accepted:
 https://github.com/boto/boto/pull/3143
 
 """
-# pylint: disable=unused-argument
 import logging
-
-from ..session_cache import get_session
 
 LOGGER = logging.getLogger(__name__)
 
 
-def create_clusters(provider, context, **kwargs):
+def create_clusters(context, *_, **kwargs):
     """Create ECS clusters.
 
     Args:
-        provider (:class:`runway.cfngin.providers.base.BaseProvider`): Provider
-            instance. (passed in by CFNgin)
         context (:class:`runway.cfngin.context.Context`): Context instance.
             (passed in by CFNgin)
 
@@ -30,7 +25,7 @@ def create_clusters(provider, context, **kwargs):
         bool: Whether or not the hook succeeded.
 
     """
-    conn = get_session(provider.region).client("ecs")
+    conn = context.get_session().client("ecs")
 
     try:
         clusters = kwargs["clusters"]

--- a/runway/cfngin/hooks/iam.py
+++ b/runway/cfngin/hooks/iam.py
@@ -1,5 +1,4 @@
 """AWS IAM hook."""
-# pylint: disable=unused-argument
 import copy
 import logging
 
@@ -8,20 +7,17 @@ from awacs.aws import Allow, Policy, Statement
 from awacs.helpers.trust import get_ecs_assumerole_policy
 from botocore.exceptions import ClientError
 
-from ..session_cache import get_session
 from . import utils
 
 LOGGER = logging.getLogger(__name__)
 
 
-def create_ecs_service_role(provider, context, **kwargs):
+def create_ecs_service_role(context, *_, **kwargs):
     """Create ecsServieRole, which has to be named exactly that currently.
 
     http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAM_policies.html#service_IAM_role
 
     Args:
-        provider (:class:`runway.cfngin.providers.base.BaseProvider`): Provider
-            instance. (passed in by CFNgin)
         context (:class:`runway.cfngin.context.Context`): Context instance.
             (passed in by CFNgin)
 
@@ -34,7 +30,7 @@ def create_ecs_service_role(provider, context, **kwargs):
 
     """
     role_name = kwargs.get("role_name", "ecsServiceRole")
-    client = get_session(provider.region).client("iam")
+    client = context.get_session().client("iam")
 
     try:
         client.create_role(
@@ -134,12 +130,10 @@ def _get_cert_contents(kwargs):
     return parameters
 
 
-def ensure_server_cert_exists(provider, context, **kwargs):
+def ensure_server_cert_exists(context, **kwargs):
     """Ensure server cert exists.
 
     Args:
-        provider (:class:`runway.cfngin.providers.base.BaseProvider`): Provider
-            instance. (passed in by CFNgin)
         context (:class:`runway.cfngin.context.Context`): Context instance.
             (passed in by CFNgin)
 
@@ -153,7 +147,7 @@ def ensure_server_cert_exists(provider, context, **kwargs):
             ``cert_arn``.
 
     """
-    client = get_session(provider.region).client("iam")
+    client = context.get_session().client("iam")
     cert_name = kwargs["cert_name"]
     status = "unknown"
     try:

--- a/runway/cfngin/hooks/keypair.py
+++ b/runway/cfngin/hooks/keypair.py
@@ -1,12 +1,10 @@
 """AWS EC2 keypair hook."""
-# pylint: disable=unused-argument
 import logging
 import os
 import sys
 
 from botocore.exceptions import ClientError
 
-from ..session_cache import get_session
 from ..ui import get_raw_input
 from . import utils
 
@@ -186,14 +184,12 @@ def interactive_prompt(keypair_name):
     return None, None
 
 
-def ensure_keypair_exists(provider, context, **kwargs):
+def ensure_keypair_exists(context, *_, **kwargs):
     """Ensure a specific keypair exists within AWS.
 
     If the key doesn't exist, upload it.
 
     Args:
-        provider (:class:`runway.cfngin.providers.base.BaseProvider`): Provider
-            instance. (passed in by CFNgin)
         context (:class:`runway.cfngin.context.Context`): Context instance.
             (passed in by CFNgin)
 
@@ -239,7 +235,7 @@ def ensure_keypair_exists(provider, context, **kwargs):
         )
         return False
 
-    session = get_session(region=provider.region, profile=kwargs.get("profile"))
+    session = context.get_session(profile=kwargs.get("profile"))
     ec2 = session.client("ec2")
 
     keypair = get_existing_key_pair(ec2, keypair_name)

--- a/runway/cfngin/hooks/route53.py
+++ b/runway/cfngin/hooks/route53.py
@@ -2,18 +2,15 @@
 # pylint: disable=unused-argument
 import logging
 
-from ..session_cache import get_session
 from ..util import create_route53_zone
 
 LOGGER = logging.getLogger(__name__)
 
 
-def create_domain(provider, context, **kwargs):
+def create_domain(context, *_, **kwargs):
     """Create a domain within route53.
 
     Args:
-        provider (:class:`runway.cfngin.providers.base.BaseProvider`): Provider
-            instance. (passed in by CFNgin)
         context (:class:`runway.cfngin.context.Context`): Context instance.
             (passed in by CFNgin)
 
@@ -25,7 +22,7 @@ def create_domain(provider, context, **kwargs):
         Dict[str, str]: Dict containing ``domain`` and ``zone_id``.
 
     """
-    session = get_session(provider.region)
+    session = context.get_session()
     client = session.client("route53")
     domain = kwargs.get("domain")
     if not domain:

--- a/runway/cfngin/lookups/handlers/ami.py
+++ b/runway/cfngin/lookups/handlers/ami.py
@@ -5,7 +5,6 @@ import re
 
 from runway.lookups.handlers.base import LookupHandler
 
-from ...session_cache import get_session
 from ...util import read_value_from_path
 
 TYPE_NAME = "ami"
@@ -27,14 +26,12 @@ class AmiLookup(LookupHandler):
     """AMI lookup."""
 
     @classmethod
-    def handle(cls, value, context=None, provider=None, **kwargs):
+    def handle(cls, value, context, *_, **kwargs):
         """Fetch the most recent AMI Id using a filter.
 
         Args:
             value (str): Parameter(s) given to this lookup.
             context (:class:`runway.cfngin.context.Context`): Context instance.
-            provider (:class:`runway.cfngin.providers.base.BaseProvider`):
-                Provider instance.
 
         Returns:
             str: Looked up value.
@@ -68,12 +65,11 @@ class AmiLookup(LookupHandler):
         """  # noqa
         value = read_value_from_path(value)
 
+        region = None
         if "@" in value:
             region, value = value.split("@", 1)
-        else:
-            region = provider.region
 
-        ec2 = get_session(region).client("ec2")
+        ec2 = context.get_session(region=region).client("ec2")
 
         values = {}
         describe_args = {}

--- a/runway/cfngin/lookups/handlers/dynamodb.py
+++ b/runway/cfngin/lookups/handlers/dynamodb.py
@@ -6,7 +6,6 @@ from botocore.exceptions import ClientError
 
 from runway.lookups.handlers.base import LookupHandler
 
-from ...session_cache import get_session
 from ...util import read_value_from_path
 
 TYPE_NAME = "dynamodb"
@@ -16,15 +15,13 @@ class DynamodbLookup(LookupHandler):
     """DynamoDB lookup."""
 
     @classmethod
-    def handle(cls, value, context=None, provider=None, **kwargs):
+    def handle(cls, value, context, *_, **kwargs):
         """Get a value from a DynamoDB table.
 
         Args:
             value (str): Parameter(s) given to this lookup.
                 ``[<region>:]<tablename>@<primarypartionkey>:<keyvalue>.<keyvalue>...``
             context (:class:`runway.cfngin.context.Context`): Context instance.
-            provider (:class:`runway.cfngin.providers.base.BaseProvider`):
-                Provider instance.
 
         .. note:: The region is optional, and defaults to the environment's
                   ``AWS_DEFAULT_REGION`` if not specified.
@@ -58,7 +55,7 @@ class DynamodbLookup(LookupHandler):
         projection_expression = _build_projection_expression(clean_table_keys)
 
         # lookup the data from DynamoDB
-        dynamodb = get_session(region).client("dynamodb")
+        dynamodb = context.get_session(region=region).client("dynamodb")
         try:
             response = dynamodb.get_item(
                 TableName=table_name,

--- a/runway/cfngin/lookups/handlers/kms.py
+++ b/runway/cfngin/lookups/handlers/kms.py
@@ -5,7 +5,6 @@ import sys
 
 from runway.lookups.handlers.base import LookupHandler
 
-from ...session_cache import get_session
 from ...util import read_value_from_path
 
 TYPE_NAME = "kms"
@@ -15,14 +14,12 @@ class KmsLookup(LookupHandler):
     """AWS KMS lookup."""
 
     @classmethod
-    def handle(cls, value, context=None, provider=None, **kwargs):
+    def handle(cls, value, context, *_, **kwargs):
         r"""Decrypt the specified value with a master key in KMS.
 
         Args:
             value (str): Parameter(s) given to this lookup.
             context (:class:`runway.cfngin.context.Context`): Context instance.
-            provider (:class:`runway.cfngin.providers.base.BaseProvider`):
-                Provider instance.
 
         ``value`` should be in the following format:
 
@@ -65,7 +62,7 @@ class KmsLookup(LookupHandler):
         if "@" in value:
             region, value = value.split("@", 1)
 
-        kms = get_session(region).client("kms")
+        kms = context.get_session(region=region).client("kms")
 
         # encode str value as an utf-8 bytestring for use with codecs.decode.
         value = value.encode("utf-8")

--- a/runway/cfngin/lookups/handlers/ssmstore.py
+++ b/runway/cfngin/lookups/handlers/ssmstore.py
@@ -5,7 +5,6 @@ import warnings
 
 from runway.lookups.handlers.base import LookupHandler
 
-from ...session_cache import get_session
 from ...util import read_value_from_path
 
 LOGGER = logging.getLogger(__name__)
@@ -18,7 +17,7 @@ class SsmstoreLookup(LookupHandler):
     DEPRECATION_MSG = "ssmstore lookup has been deprecated; use the ssm lookup instead"
 
     @classmethod
-    def handle(cls, value, context=None, provider=None, **kwargs):
+    def handle(cls, value, context, *_, **kwargs):
         """Retrieve (and decrypt) a parameter from AWS SSM Parameter Store.
 
         Args:
@@ -65,7 +64,7 @@ class SsmstoreLookup(LookupHandler):
         if "@" in value:
             region, value = value.split("@", 1)
 
-        client = get_session(region).client("ssm")
+        client = context.get_session(region=region).client("ssm")
         response = client.get_parameters(Names=[value], WithDecryption=True)
         if "Parameters" in response:
             return str(response["Parameters"][0]["Value"])

--- a/runway/templates/k8s-cfn-repo/k8s-master.cfn/k8s_hooks/auth_map.py
+++ b/runway/templates/k8s-cfn-repo/k8s-master.cfn/k8s_hooks/auth_map.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 from runway.cfngin.lookups.handlers.output import OutputLookup
-from runway.cfngin.session_cache import get_session
 
 LOGGER = logging.getLogger(__name__)
 
@@ -16,10 +15,10 @@ def assumed_role_to_principle(assumed_role_arn):
     return base_arn + assumed_role_arn.split("/")[1]
 
 
-def get_principal_arn(provider):
+def get_principal_arn(context):
     """Return ARN of current session principle."""
     # looking up caller identity
-    session = get_session(provider.region)
+    session = context.get_session()
     sts_client = session.client("sts")
     caller_identity_arn = sts_client.get_caller_identity()["Arn"]
     if caller_identity_arn.split(":")[2] == "iam" and (
@@ -48,7 +47,7 @@ def generate(provider, context, **kwargs):  # pylint: disable=W0613
     LOGGER.info("Creating auth_map at %s", filename)
     if not os.path.isdir(overlay_path):
         os.makedirs(overlay_path)
-    principal_arn = get_principal_arn(provider)
+    principal_arn = get_principal_arn(context)
     stack_name = kwargs["stack"]
     node_instancerole_arn = OutputLookup.handle(
         "%s::NodeInstanceRoleArn" % stack_name, provider=provider, context=context

--- a/tests/unit/cfngin/lookups/handlers/test_ssmstore.py
+++ b/tests/unit/cfngin/lookups/handlers/test_ssmstore.py
@@ -1,78 +1,58 @@
 """Tests for runway.cfngin.lookups.handlers.ssmstore."""
-import unittest
+# pylint: disable=no-self-use
+from __future__ import annotations
 
-import boto3
-import mock
-from botocore.stub import Stubber
+from typing import TYPE_CHECKING
+
+import pytest
 
 from runway.cfngin.lookups.handlers.ssmstore import SsmstoreLookup
 
-from ...factories import SessionStub
+if TYPE_CHECKING:
+    from ....factories import MockCFNginContext
 
 
-class TestSSMStoreHandler(unittest.TestCase):
+SSM_KEY = "ssmkey"
+SSM_VALUE = "ssmvalue"
+
+EXPECTED_PARAMS = {"Names": [SSM_KEY], "WithDecryption": True}
+GET_PARAMETER_RESPONSE = {
+    "Parameters": [{"Name": SSM_KEY, "Type": "String", "Value": SSM_VALUE}],
+    "InvalidParameters": ["invalid_ssm_param"],
+}
+INVALID_GET_PARAMETER_RESPONSE = {"InvalidParameters": [SSM_KEY]}
+
+
+class TestSSMStoreHandler:
     """Tests for runway.cfngin.lookups.handlers.ssmstore.SsmstoreLookup."""
 
-    client = boto3.client(
-        "ssm",
-        region_name="us-east-1",
-        # bypass the need to have these in the env
-        aws_access_key_id="testing",
-        aws_secret_access_key="testing",
-    )
-
-    def setUp(self):
-        """Run before tests."""
-        self.stubber = Stubber(self.client)
-        self.get_parameters_response = {
-            "Parameters": [{"Name": "ssmkey", "Type": "String", "Value": "ssmvalue"}],
-            "InvalidParameters": ["invalid_ssm_param"],
-        }
-        self.invalid_get_parameters_response = {"InvalidParameters": ["ssmkey"]}
-        self.expected_params = {"Names": ["ssmkey"], "WithDecryption": True}
-        self.ssmkey = "ssmkey"
-        self.ssmvalue = "ssmvalue"
-
-    @mock.patch(
-        "runway.cfngin.lookups.handlers.ssmstore.get_session",
-        return_value=SessionStub(client),
-    )
-    def test_ssmstore_handler(self, _mock_client):
+    def test_ssmstore_handler(self, cfngin_context: MockCFNginContext) -> None:
         """Test ssmstore handler."""
-        self.stubber.add_response(
-            "get_parameters", self.get_parameters_response, self.expected_params
-        )
-        with self.stubber:
-            value = SsmstoreLookup.handle(self.ssmkey)
-            self.assertEqual(value, self.ssmvalue)
-            self.assertIsInstance(value, str)
+        stubber = cfngin_context.add_stubber("ssm")
+        stubber.add_response("get_parameters", GET_PARAMETER_RESPONSE, EXPECTED_PARAMS)
+        with stubber:
+            assert SsmstoreLookup.handle(SSM_KEY, context=cfngin_context) == SSM_VALUE
 
-    @mock.patch(
-        "runway.cfngin.lookups.handlers.ssmstore.get_session",
-        return_value=SessionStub(client),
-    )
-    def test_ssmstore_invalid_value_handler(self, _mock_client):
+    def test_ssmstore_invalid_value_handler(
+        self, cfngin_context: MockCFNginContext
+    ) -> None:
         """Test ssmstore invalid value handler."""
-        self.stubber.add_response(
-            "get_parameters", self.invalid_get_parameters_response, self.expected_params
+        stubber = cfngin_context.add_stubber("ssm")
+        stubber.add_response(
+            "get_parameters", INVALID_GET_PARAMETER_RESPONSE, EXPECTED_PARAMS
         )
-        with self.stubber:
-            try:
-                SsmstoreLookup.handle(self.ssmkey)
-            except ValueError:
-                assert True
+        with stubber, pytest.raises(ValueError):
+            SsmstoreLookup.handle(SSM_KEY, context=cfngin_context)
 
-    @mock.patch(
-        "runway.cfngin.lookups.handlers.ssmstore.get_session",
-        return_value=SessionStub(client),
-    )
-    def test_ssmstore_handler_with_region(self, _mock_client):
+    def test_ssmstore_handler_with_region(
+        self, cfngin_context: MockCFNginContext
+    ) -> None:
         """Test ssmstore handler with region."""
-        self.stubber.add_response(
-            "get_parameters", self.get_parameters_response, self.expected_params
-        )
-        with self.stubber:
-            region = "us-east-1"
-            temp_value = "%s@%s" % (region, self.ssmkey)
-            value = SsmstoreLookup.handle(temp_value)
-            self.assertEqual(value, self.ssmvalue)
+        region = "us-west-2"
+        stubber = cfngin_context.add_stubber("ssm", region=region)
+        stubber.add_response("get_parameters", GET_PARAMETER_RESPONSE, EXPECTED_PARAMS)
+        with stubber:
+            assert (
+                SsmstoreLookup.handle(f"{region}@{SSM_KEY}", context=cfngin_context)
+                == SSM_VALUE
+            )


### PR DESCRIPTION
## Why This Is Needed

resolves #314 

## What Changed

_A detailed list of all the changes made, broken down by category._

### Changed

- replaced uses of `runway.cfngin.session_cache.get_session` with `context.get_session()` where possible
- `context` is no longer optional for hooks/lookups that use to use `runway.cfngin.session_cache.get_session`

### Removed

- removed `provider` as a positional argument from hooks/lookups that no longer need it
