### PR TITLE
sls-tsc sample: update typedoc dependency to remove beta requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Broader dependency update for typedoc in sls-tsc sample.
 
 ## [1.16.4] - 2020-12-22
 ### Fixed

--- a/runway/templates/sls-tsc/package.json
+++ b/runway/templates/sls-tsc/package.json
@@ -32,7 +32,7 @@
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.12",
     "ts-node": "^9.1.1",
-    "typedoc": "^0.20.0-beta.27",
+    "typedoc": ">=0.20",
     "typescript": "^4.1.3",
     "webpack": "^5.10.3"
   },


### PR DESCRIPTION
Typedoc v0.20 final has been released making version pinning simple again. For a devDependency having a wide pin (bringing in a future 1.0 update) should be safe enough.