### PR TITLE
Revert GitHub Actions Ubuntu 20.04 upgrade

### DIFF
--- a/.github/scripts/cicd/build_pyinstaller.sh
+++ b/.github/scripts/cicd/build_pyinstaller.sh
@@ -4,14 +4,14 @@
 
 set -ev
 
-if [ "$OS_NAME" == "ubuntu-latest" ]; then
+if [ "$OS_NAME" == "ubuntu-18.04" ]; then
     LOCAL_OS_NAME="linux"
-elif [ "$OS_NAME" == "macos-latest" ]; then
+elif [ "$OS_NAME" == "macos-10.15" ]; then
     LOCAL_OS_NAME="osx"
 elif [ "$OS_NAME" == "windows-latest" ]; then
     LOCAL_OS_NAME="windows"
 else
-    echo 'Environment variable "OS_NAME" must be one of ["ubuntu-latest", "macos-latest", "windows-latest"]'
+    echo 'Environment variable "OS_NAME" must be one of ["ubuntu-18.04", "macos-10.15", "windows-latest"]'
     exit 1
 fi
 

--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   branch-name:
     name: Enforce Branch Name
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: deepakputhraya/action-branch-name@v1.0.0
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-18.04, windows-latest]
         python-version: [2.7, 3.6, 3.7]
     runs-on: ${{ matrix.os }}
     env:
@@ -41,7 +41,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - # &dependencies_ubuntu
         name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get update && sudo apt-get install sed -y
       - # &dependencies_windows
         name: Install Dependencies (windows)
@@ -50,7 +50,7 @@ jobs:
       - # &cache_pip_ubuntu
         name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-10.15, ubuntu-18.04, windows-latest]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     env:
@@ -119,7 +119,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       # - *dependencies_ubuntu
       - name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get update && sudo apt-get install sed -y
       # - *dependencies_windows
       - name: Install Dependencies (windows)
@@ -128,7 +128,7 @@ jobs:
       # - &cache_pip_mac
       - name: Pip Cache (macOS)
         uses: actions/cache@v1
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-10.15'
         with:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -137,7 +137,7 @@ jobs:
       # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-10.15, ubuntu-18.04, windows-latest]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     env:
@@ -191,7 +191,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       # - *dependencies_ubuntu
       - name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get update && sudo apt-get install sed -y
       # - *dependencies_windows
       - name: Install Dependencies (windows)
@@ -200,7 +200,7 @@ jobs:
       # - *cache_pip_mac
       - name: Pip Cache (macOS)
         uses: actions/cache@v1
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-10.15'
         with:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -209,7 +209,7 @@ jobs:
       # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -253,7 +253,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
@@ -284,7 +284,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install sed tree -y
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -299,13 +299,13 @@ jobs:
         if: steps.check_distance.outcome == 'success'
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefolder-macos-latest
+          name: pyinstaller-onefolder-macos-10.15
           path: artifacts
       - name: Download Artifacts (ubuntu)
         if: steps.check_distance.outcome == 'success'
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefolder-ubuntu-latest
+          name: pyinstaller-onefolder-ubuntu-18.04
           path: artifacts
       - name: Download Artifacts (windows)
         if: steps.check_distance.outcome == 'success'
@@ -348,7 +348,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
@@ -382,7 +382,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
@@ -397,12 +397,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       # - *dependencies_ubuntu
       - name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get update && sudo apt-get install sed -y
       # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -428,7 +428,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs:
       - build-pypi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Download Distribution Artifact
         uses: actions/download-artifact@v1.0.0
@@ -452,7 +452,7 @@ jobs:
       AWS_S3_BUCKET: common-runway-assets-bucket83908e77-u2xp1bj1tuhp
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Install Python
         uses: actions/setup-python@v1
@@ -461,12 +461,12 @@ jobs:
       - name: Download Artifacts (macOS)
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefile-macos-latest
+          name: pyinstaller-onefile-macos-10.15
           path: artifacts
       - name: Download Artifacts (ubuntu)
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefile-ubuntu-latest
+          name: pyinstaller-onefile-ubuntu-18.04
           path: artifacts
       - name: Download Artifacts (windows)
         uses: actions/download-artifact@v1.0.0

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-10.15, ubuntu-18.04, windows-latest]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     env:
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       # - *dependencies_ubuntu
       - name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get update && sudo apt-get install sed -y
       # - *dependencies_windows
       - name: Install Dependencies (windows)
@@ -43,7 +43,7 @@ jobs:
       # - &cache_pip_mac
       - name: Pip Cache (macOS)
         uses: actions/cache@v1
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-10.15'
         with:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -52,7 +52,7 @@ jobs:
       # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-10.15, ubuntu-18.04, windows-latest]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     env:
@@ -106,7 +106,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       # - *dependencies_ubuntu
       - name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get update && sudo apt-get install sed -y
       # - *dependencies_windows
       - name: Install Dependencies (windows)
@@ -115,7 +115,7 @@ jobs:
       # - *cache_pip_mac
       - name: Pip Cache (macOS)
         uses: actions/cache@v1
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-10.15'
         with:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -124,7 +124,7 @@ jobs:
       # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
@@ -191,7 +191,7 @@ jobs:
       # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -204,12 +204,12 @@ jobs:
       - name: Download Artifacts (macOS)
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefolder-macos-latest
+          name: pyinstaller-onefolder-macos-10.15
           path: artifacts
       - name: Download Artifacts (ubuntu)
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefolder-ubuntu-latest
+          name: pyinstaller-onefolder-ubuntu-18.04
           path: artifacts
       - name: Download Artifacts (windows)
         uses: actions/download-artifact@v1.0.0
@@ -243,7 +243,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
@@ -268,7 +268,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         python-version: [3.7]
     runs-on: ${{ matrix.os }}
     steps:
@@ -283,12 +283,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       # - *dependencies_ubuntu
       - name: Install Dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get update && sudo apt-get install sed -y
       # - *cache_pip_ubuntu
       - name: Pip Cache (ubuntu)
         uses: actions/cache@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         with:
           path:  ~/.cache/pip
           key: ${{ matrix.os }}-pip-${{ matrix.python-version }}
@@ -313,7 +313,7 @@ jobs:
     name: Publish 📦 To PyPI
     needs:
       - build-pypi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Download Distribution Artifact
         uses: actions/download-artifact@v1.0.0
@@ -334,7 +334,7 @@ jobs:
       AWS_S3_BUCKET: common-runway-assets-bucket83908e77-u2xp1bj1tuhp
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Install Python
         uses: actions/setup-python@v1
@@ -343,12 +343,12 @@ jobs:
       - name: Download Artifacts (macOS)
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefile-macos-latest
+          name: pyinstaller-onefile-macos-10.15
           path: artifacts
       - name: Download Artifacts (ubuntu)
         uses: actions/download-artifact@v1.0.0
         with:
-          name: pyinstaller-onefile-ubuntu-latest
+          name: pyinstaller-onefile-ubuntu-18.04
           path: artifacts
       - name: Download Artifacts (windows)
         uses: actions/download-artifact@v1.0.0
@@ -372,7 +372,7 @@ jobs:
       TABLE: onica-urlshortener-prod
       TABLE_REGION: us-east-1
       VERSION: ${{ github.ref }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2.3.2

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update_draft_release:
     name: Draft release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       # https://github.com/release-drafter/release-drafter
       - uses: release-drafter/release-drafter@v5.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- (binary builds) Support older glibc versions (e.g. Amazon Linux 2) by reverting Linux binary build platform to Ubuntu 18.04
+  - Also pinning macOS build environment version explicitly in an attempt to prevent similiar issues there in the future
+
 
 ## [1.18.0] - 2021-01-13
 ### Added

--- a/docs/source/developers/pyinstaller.rst
+++ b/docs/source/developers/pyinstaller.rst
@@ -23,7 +23,7 @@ These need to be installed globally so they are not included in the Pipfile.
 Process
 *******
 
-1. Export ``OS_NAME`` environment variable for your system (``ubuntu-latest``, ``macos-latest``, or ``windows-latest``).
+1. Export ``OS_NAME`` environment variable for your system (``ubuntu-18.04``, ``macos-10.15``, or ``windows-latest``).
 2. Execute ``make build_pyinstaller_file`` or ``make build_pyinstaller_folder`` from the root of the repo.
 
 The output of these commands can be found in ``./artifacts``

--- a/docs/source/maintainers/release_process.rst
+++ b/docs/source/maintainers/release_process.rst
@@ -95,8 +95,8 @@ After all the publishing steps have completed:
 12. Download the following artifacts from the **Publish Release** workflow:
 
 - npm-pack
-- pyinstaller-onefile-macos-latest
-- pyinstaller-onefile-ubuntu-latest
+- pyinstaller-onefile-macos-10.15
+- pyinstaller-onefile-ubuntu-18.04
 - pyinstaller-onefile-windows-latest
 - pypi-dist
 


### PR DESCRIPTION
This brings along newer glibc requirement in pyinstaller builds, breaking compatibility with Amazon Linux 2 (among others).

Included a premptive change to the macOS settings for the same issue.

Fixes #506