### PR TITLE
remove stacker argv override that was left over from using parts of CLI

### DIFF
--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -122,10 +122,7 @@ class CFNgin:
             for config_path in config_file_paths:
                 logger = PrefixAdaptor(os.path.basename(config_path), LOGGER)
                 logger.notice("deploy (in progress)")
-                with SafeHaven(
-                    argv=["stacker", "build", str(config_path)],
-                    sys_modules_exclude=["awacs", "troposphere"],
-                ):
+                with SafeHaven(sys_modules_exclude=["awacs", "troposphere"],):
                     ctx = self.load(config_path)
                     action = build.Action(
                         context=ctx,
@@ -158,7 +155,7 @@ class CFNgin:
             for config_path in config_file_paths:
                 logger = PrefixAdaptor(config_path.name, LOGGER)
                 logger.notice("destroy (in progress)")
-                with SafeHaven(argv=["stacker", "destroy", str(config_path)]):
+                with SafeHaven():
                     ctx = self.load(config_path)
                     action = destroy.Action(
                         context=ctx,
@@ -215,7 +212,7 @@ class CFNgin:
             for config_path in config_file_paths:
                 logger = PrefixAdaptor(config_path.name, LOGGER)
                 logger.notice("plan (in progress)")
-                with SafeHaven(argv=["stacker", "diff", str(config_path)]):
+                with SafeHaven():
                     ctx = self.load(config_path)
                     action = diff.Action(
                         context=ctx,

--- a/tests/unit/cfngin/test_cfngin.py
+++ b/tests/unit/cfngin/test_cfngin.py
@@ -140,16 +140,10 @@ class TestCFNgin:
                     sys_modules_exclude=["awacs", "troposphere"],
                 ),
                 call.__enter__(),
-                call(
-                    argv=["stacker", "build", str(tmp_path / "basic.yml")],
-                    sys_modules_exclude=["awacs", "troposphere"],
-                ),
+                call(sys_modules_exclude=["awacs", "troposphere"],),
                 call.__enter__(),
                 call.__exit__(None, None, None),
-                call(
-                    argv=["stacker", "build", str(tmp_path / "basic2.yml")],
-                    sys_modules_exclude=["awacs", "troposphere"],
-                ),
+                call(sys_modules_exclude=["awacs", "troposphere"],),
                 call.__enter__(),
                 call.__exit__(None, None, None),
                 call.__exit__(None, None, None),
@@ -180,7 +174,7 @@ class TestCFNgin:
             [
                 call(environ=context.env.vars),
                 call.__enter__(),
-                call(argv=["stacker", "destroy", str(tmp_path / "basic.yml")]),
+                call(),
                 call.__enter__(),
                 call.__exit__(None, None, None),
                 call.__exit__(None, None, None),
@@ -233,7 +227,7 @@ class TestCFNgin:
             [
                 call(environ=context.env.vars),
                 call.__enter__(),
-                call(argv=["stacker", "diff", str(tmp_path / "basic.yml")]),
+                call(),
                 call.__enter__(),
                 call.__exit__(None, None, None),
                 call.__exit__(None, None, None),


### PR DESCRIPTION
## Why This Is Needed

We no longer need to override argv when using CFNgin as the deprecated utility function that was using the remains of Stacker CLI components to read it has been removed.

## What Changed

### Removed

- removed `stacker <cmd> <args>` argv override when processing CFNgin modules
