### PR TITLE
relocate `RunwayModuleType` class

### DIFF
--- a/runway/core/components/__init__.py
+++ b/runway/core/components/__init__.py
@@ -3,5 +3,12 @@ from ._deploy_environment import DeployEnvironment
 from ._deployment import Deployment
 from ._module import Module
 from ._module_path import ModulePath
+from ._module_type import RunwayModuleType
 
-__all__ = ["DeployEnvironment", "Deployment", "Module", "ModulePath"]
+__all__ = [
+    "DeployEnvironment",
+    "Deployment",
+    "Module",
+    "ModulePath",
+    "RunwayModuleType",
+]

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -16,10 +16,10 @@ from ...config.models.runway import (
     RunwayFutureDefinitionModel,
     RunwayVariablesDefinitionModel,
 )
-from ...runway_module_type import RunwayModuleType
 from ...util import cached_property, change_dir, flatten_path_lists, merge_dicts
 from ..providers import aws
 from ._module_path import ModulePath
+from ._module_type import RunwayModuleType
 
 if TYPE_CHECKING:
     from ..._logging import RunwayLogger

--- a/runway/core/components/_module_type.py
+++ b/runway/core/components/_module_type.py
@@ -7,10 +7,10 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Type, cast
 
-from .util import load_object_from_string
+from ...util import load_object_from_string
 
 if TYPE_CHECKING:
-    from .module.base import RunwayModule
+    from ...module.base import RunwayModule
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/unit/core/components/test_module_type.py
+++ b/tests/unit/core/components/test_module_type.py
@@ -1,4 +1,4 @@
-"""Test runway.runway_module_type."""
+"""Test runway.core.components._module_type."""
 # pylint: disable=no-self-use
 from __future__ import annotations
 
@@ -7,13 +7,13 @@ from typing import TYPE_CHECKING, List, Type
 
 import pytest
 
+from runway.core.components import RunwayModuleType
 from runway.module.cdk import CloudDevelopmentKit
 from runway.module.cloudformation import CloudFormation
 from runway.module.k8s import K8s
 from runway.module.serverless import Serverless
 from runway.module.staticsite import StaticSite
 from runway.module.terraform import Terraform
-from runway.runway_module_type import RunwayModuleType
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class TestRunwayModuleType:
-    """Test runway.runway_module_type.RunwayModuleType."""
+    """Test runway.core.components._module_type.RunwayModuleType."""
 
     @pytest.mark.parametrize(
         "files, expected",


### PR DESCRIPTION
## Why This Is Needed

Moves the class closer to where it is consumed.

## What Changed

### Changed

- moved `runway.runway_module_type.RunwayModuleType` to `runway.core.components._module_type.RunwayModuleType`
