### PR TITLE
sls: use pydantic model to parse options

### DIFF
--- a/runway/config/models/runway/options/__init__.py
+++ b/runway/config/models/runway/options/__init__.py
@@ -1,0 +1,1 @@
+"""Runway module options."""

--- a/runway/config/models/runway/options/serverless.py
+++ b/runway/config/models/runway/options/serverless.py
@@ -1,0 +1,39 @@
+"""Runway Serverless Framework Module options."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import Extra
+
+from ...base import ConfigProperty
+
+
+class RunwayServerlessPromotezipOptionDataModel(ConfigProperty):
+    """Model for Runway Serverless module promotezip option."""
+
+    bucketname: Optional[str] = None
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway Serverless Framework Module promotezip option"
+
+    def __bool__(self) -> bool:
+        """Evaluate the boolean value of the object instance."""
+        return bool(self.dict(exclude_none=True))
+
+
+class RunwayServerlessModuleOptionsDataModel(ConfigProperty):
+    """Model for Runway Serverless Framework Module options."""
+
+    args: List[str] = []
+    extend_serverless_yml: Dict[str, Any] = {}
+    promotezip: RunwayServerlessPromotezipOptionDataModel = RunwayServerlessPromotezipOptionDataModel()  # noqa
+    skip_npm_ci: bool = False
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.ignore
+        title = "Runway Serverless Framework Module options"

--- a/runway/module/base.py
+++ b/runway/module/base.py
@@ -5,7 +5,17 @@ import logging
 import subprocess
 from collections.abc import MutableMapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    cast,
+    no_type_check_decorator,
+)
 
 from ..exceptions import NpmNotFound
 from ..util import merge_nested_environment_dicts, which
@@ -25,7 +35,7 @@ class RunwayModule:
     explicitly_enabled: Optional[bool]
     logger: Union[PrefixAdaptor, RunwayLogger]
     name: str
-    options: Union[Dict[str, Any], ModuleOptions]
+    options: Union[Dict[str, Any], ModuleOptions, ModuleOptionsV2]
     parameters: Dict[str, Any]
     region: str
 
@@ -37,7 +47,7 @@ class RunwayModule:
         logger: RunwayLogger = LOGGER,
         module_root: Path,
         name: Optional[str] = None,
-        options: Optional[Union[Dict[str, Any], ModuleOptions]] = None,
+        options: Optional[Union[Dict[str, Any], ModuleOptions, ModuleOptionsV2]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         **_: Any,
     ) -> None:
@@ -100,7 +110,7 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
         logger: RunwayLogger = LOGGER,
         module_root: Path,
         name: Optional[str] = None,
-        options: Optional[Union[Dict[str, Any], ModuleOptions]] = None,
+        options: Optional[Union[Dict[str, Any], ModuleOptions, ModuleOptionsV2]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         **_: Any,
     ) -> None:
@@ -207,6 +217,15 @@ class RunwayModuleNpm(RunwayModule):  # pylint: disable=abstract-method
                 "during use of nodejs-based module and AWS_PROFILE is "
                 "not set -- you likely want to set AWS_PROFILE instead"
             )
+
+
+class ModuleOptionsV2:
+    """Base class for Runway module options."""
+
+    @no_type_check_decorator
+    def get(self, name: str, default: Any = None):
+        """Get a value or return the default."""
+        return getattr(self, name, default)
 
 
 class ModuleOptions(MutableMapping):

--- a/tests/unit/config/models/runway/options/__init__.py
+++ b/tests/unit/config/models/runway/options/__init__.py
@@ -1,0 +1,1 @@
+"""Empty file for python import traversal."""

--- a/tests/unit/config/models/runway/options/test_serverless.py
+++ b/tests/unit/config/models/runway/options/test_serverless.py
@@ -1,0 +1,61 @@
+"""Test runway.config.models.runway.options.serverless."""
+# pylint: disable=no-self-use
+import pytest
+from pydantic import ValidationError
+
+from runway.config.models.runway.options.serverless import (
+    RunwayServerlessModuleOptionsDataModel,
+    RunwayServerlessPromotezipOptionDataModel,
+)
+
+
+class TestRunwayServerlessModuleOptionsDataModel:
+    """Test RunwayServerlessModuleOptionsDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default values."""
+        obj = RunwayServerlessModuleOptionsDataModel()
+        assert obj.args == []
+        assert obj.extend_serverless_yml == {}
+        assert obj.promotezip == RunwayServerlessPromotezipOptionDataModel()
+        assert obj.skip_npm_ci is False
+
+    def test_init(self) -> None:
+        """Test init."""
+        data = {
+            "args": ["--test"],
+            "extend_serverless_yml": {"key": "val"},
+            "promotezip": {"bucketname": "test"},
+            "skip_npm_ci": True,
+        }
+        obj = RunwayServerlessModuleOptionsDataModel(**data)
+        assert obj.args == data["args"]
+        assert obj.extend_serverless_yml == data["extend_serverless_yml"]
+        assert obj.promotezip == RunwayServerlessPromotezipOptionDataModel(
+            **data["promotezip"]
+        )
+        assert obj.skip_npm_ci == data["skip_npm_ci"]
+
+
+class TestRunwayServerlessPromotezipOptionDataModel:
+    """Test RunwayServerlessPromotezipOptionDataModel."""
+
+    def test_bool(self) -> None:
+        """Test __bool__."""
+        assert RunwayServerlessPromotezipOptionDataModel(bucketname="test")
+        assert not RunwayServerlessPromotezipOptionDataModel()
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayServerlessPromotezipOptionDataModel()
+        assert obj.bucketname is None
+
+    def test_init_extra(self) -> None:
+        """Test init with extra values."""
+        with pytest.raises(ValidationError):
+            RunwayServerlessPromotezipOptionDataModel(invalid="something")
+
+    def test_init(self) -> None:
+        """Test init."""
+        obj = RunwayServerlessPromotezipOptionDataModel(bucketname="test")
+        assert obj.bucketname == "test"


### PR DESCRIPTION
## Summary

Replace the old options parser object with one that uses a pydantic model.

## Why This Is Needed

resolves #520

## What Changed

### Added

- added `ModuleOptionsV2` class that will replace `ModuleOptions` class
- add pydantic models for parsing serverless options

### Changed

- `ServerlessOptions` now uses `ModuleOptionsV2` as its parent class
- `ServerlessOptions` now uses a pydantic model during `__init__` instead of individual args
- `ServerlessOptions.parse` is now `ServerlessOptions.parse_obj` to standardize with models and other config components