### PR TITLE
tf: use pydantic model to parse options

### DIFF
--- a/runway/config/models/runway/options/terraform.py
+++ b/runway/config/models/runway/options/terraform.py
@@ -1,0 +1,69 @@
+"""Runway Terraform Module options."""
+# pylint: disable=no-self-argument,no-self-use
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from pydantic import Extra, Field, validator
+
+from ...base import ConfigProperty
+
+
+class RunwayTerraformArgsDataModel(ConfigProperty):
+    """Modelf for Runway Terraform Module args option."""
+
+    apply: List[str] = []
+    init: List[str] = []
+    plan: List[str] = []
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway Terraform Module args option"
+
+
+class RunwayTerraformBackendConfigDataModel(ConfigProperty):
+    """Model for Runway Terraform Module terraform_backend_config option."""
+
+    bucket: Optional[str] = None
+    dynamodb_table: Optional[str] = None
+    region: Optional[str] = None
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway Terraform Module terraform_backend_config option"
+
+    def __bool__(self) -> bool:
+        """Evaluate the boolean value of the object instance."""
+        data = self.dict(exclude_none=True)
+        return "bucket" in data or "dynamodb_table" in data
+
+
+class RunwayTerraformModuleOptionsDataModel(ConfigProperty):
+    """Model for Runway Terraform Module options."""
+
+    args: RunwayTerraformArgsDataModel = RunwayTerraformArgsDataModel()
+    backend_config: RunwayTerraformBackendConfigDataModel = Field(
+        RunwayTerraformBackendConfigDataModel(), alias="terraform_backend_config"
+    )
+    version: Optional[str] = Field(None, alias="terraform_version")
+    workspace: Optional[str] = Field(None, alias="terraform_workspace")
+    write_auto_tfvars: bool = Field(False, alias="terraform_write_auto_tfvars")
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.ignore
+        title = "Runway Terraform Module options"
+
+    @validator("args", pre=True)
+    def _convert_args(
+        cls, v: Union[List[str], Dict[str, List[str]]]  # noqa: N805
+    ) -> Dict[str, List[str]]:
+        """Convert args from list to dict."""
+        if isinstance(v, list):
+            return {"apply": v}
+        return v

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -21,7 +21,7 @@ from ..config.models.runway.options.serverless import (
 from ..hooks.staticsite.util import get_hash_of_files
 from ..s3_util import does_s3_object_exist, download, ensure_bucket_exists, upload
 from ..util import YamlDumper, cached_property, merge_dicts
-from .base import ModuleOptionsV2, RunwayModuleNpm
+from .base import ModuleOptions, RunwayModuleNpm
 from .utils import generate_node_command, run_module_command
 
 if TYPE_CHECKING:
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 
     from .._logging import RunwayLogger
     from ..context.runway import RunwayContext
-    from .base import ModuleOptions
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 
@@ -155,7 +154,7 @@ class Serverless(RunwayModuleNpm):
         logger: RunwayLogger = LOGGER,
         module_root: Path,
         name: Optional[str] = None,
-        options: Optional[Union[Dict[str, Any], ModuleOptions, ModuleOptionsV2]] = None,
+        options: Optional[Union[Dict[str, Any], ModuleOptions]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         **_: Any,
     ) -> None:
@@ -400,7 +399,7 @@ class Serverless(RunwayModuleNpm):
             self.sls_remove()
 
 
-class ServerlessOptions(ModuleOptionsV2):
+class ServerlessOptions(ModuleOptions):
     """Module options for Serverless Framework.
 
     Attributes:

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -20,7 +20,7 @@ from ..config.models.runway.options.terraform import (
 )
 from ..env_mgr.tfenv import TFEnvManager
 from ..util import DOC_SITE, which
-from .base import ModuleOptionsV2, RunwayModule
+from .base import ModuleOptions, RunwayModule
 from .utils import run_module_command
 
 if TYPE_CHECKING:
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from .._logging import RunwayLogger
     from ..context.runway import RunwayContext
     from ..core.components import DeployEnvironment
-    from .base import ModuleOptions
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 
@@ -516,7 +515,7 @@ class Terraform(RunwayModule):
         self.run("destroy")
 
 
-class TerraformOptions(ModuleOptionsV2):
+class TerraformOptions(ModuleOptions):
     """Module options for Terraform.
 
     Attributes:
@@ -583,7 +582,7 @@ class TerraformOptions(ModuleOptionsV2):
         )
 
 
-class TerraformBackendConfig(ModuleOptionsV2):
+class TerraformBackendConfig(ModuleOptions):
     """Terraform backend configuration module options."""
 
     def __init__(

--- a/tests/unit/config/models/runway/options/test_terraform.py
+++ b/tests/unit/config/models/runway/options/test_terraform.py
@@ -1,0 +1,115 @@
+"""Test runway.config.models.runway.options.terraform."""
+# pylint: disable=no-self-use
+import pytest
+from pydantic import ValidationError
+
+from runway.config.models.runway.options.terraform import (
+    RunwayTerraformArgsDataModel,
+    RunwayTerraformBackendConfigDataModel,
+    RunwayTerraformModuleOptionsDataModel,
+)
+
+
+class TestRunwayTerraformArgsDataModel:
+    """Test RunwayTerraformArgsDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayTerraformArgsDataModel()
+        assert obj.apply == []
+        assert obj.init == []
+        assert obj.plan == []
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayTerraformArgsDataModel(invalid="val")
+
+    def test_init(self) -> None:
+        """Test init."""
+        obj = RunwayTerraformArgsDataModel(
+            apply=["-apply"], init=["-init"], plan=["-plan"]
+        )
+        assert obj.apply == ["-apply"]
+        assert obj.init == ["-init"]
+        assert obj.plan == ["-plan"]
+
+
+class TestRunwayTerraformBackendConfigDataModel:
+    """Test RunwayTerraformBackendConfigDataModel."""
+
+    def test_bool(self) -> None:
+        """Test __bool__."""
+        assert RunwayTerraformBackendConfigDataModel(bucket="test")
+        assert RunwayTerraformBackendConfigDataModel(dynamodb_table="test")
+        assert RunwayTerraformBackendConfigDataModel(
+            bucket="test", dynamodb_table="test"
+        )
+        assert not RunwayTerraformBackendConfigDataModel(region="us-east-1")
+        assert not RunwayTerraformBackendConfigDataModel()
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayTerraformBackendConfigDataModel()
+        assert not obj.bucket
+        assert not obj.dynamodb_table
+        assert not obj.region
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayTerraformBackendConfigDataModel(invalid="val")
+
+    def test_init(self) -> None:
+        """Test init."""
+        data = {
+            "bucket": "test-bucket",
+            "dynamodb_table": "test-table",
+            "region": "us-east-1",
+        }
+        obj = RunwayTerraformBackendConfigDataModel.parse_obj(data)
+        assert obj.bucket == data["bucket"]
+        assert obj.dynamodb_table == data["dynamodb_table"]
+        assert obj.region == data["region"]
+
+
+class TestRunwayTerraformModuleOptionsDataModel:
+    """Test RunwayTerraformModuleOptionsDataModel."""
+
+    def test_convert_args(self) -> None:
+        """Test _convert_args."""
+        obj = RunwayTerraformModuleOptionsDataModel(args=["test"])
+        assert obj.args.apply == ["test"]
+        assert obj.args.init == []
+        assert obj.args.plan == []
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayTerraformModuleOptionsDataModel()
+        assert not obj.args.apply
+        assert not obj.args.init
+        assert not obj.args.plan
+        assert not obj.backend_config
+        assert not obj.version
+        assert not obj.workspace
+        assert not obj.write_auto_tfvars
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        assert RunwayTerraformModuleOptionsDataModel(invalid="val")
+
+    def test_init(self) -> None:
+        """Test init."""
+        data = {
+            "args": {"init": ["-init"]},
+            "terraform_backend_config": {"bucket": "test-bucket"},
+            "terraform_version": "0.14.0",
+            "terraform_workspace": "default",
+            "terraform_write_auto_tfvars": True,
+        }
+        obj = RunwayTerraformModuleOptionsDataModel.parse_obj(data)
+        assert obj.args.init == data["args"]["init"]
+        assert obj.backend_config.bucket == data["terraform_backend_config"]["bucket"]
+        assert obj.version == data["terraform_version"]
+        assert obj.workspace == data["terraform_workspace"]
+        assert obj.write_auto_tfvars == data["terraform_write_auto_tfvars"]

--- a/tests/unit/module/test_base.py
+++ b/tests/unit/module/test_base.py
@@ -31,61 +31,13 @@ def does_not_raise() -> Iterator[None]:
 class TestModuleOptions:
     """Test runway.module.ModuleOptions."""
 
-    @pytest.mark.parametrize(
-        "data, env, expected, exception",
-        [
-            ("test", None, "test", does_not_raise()),
-            ("test", "env", "test", does_not_raise()),
-            ({"key": "value"}, "test", {"key": "called"}, does_not_raise()),
-            ({"key": "value"}, None, {"key": "called"}, does_not_raise()),
-            (["test"], None, ["test"], does_not_raise()),
-            (["test"], "env", ["test"], does_not_raise()),
-            (None, None, None, does_not_raise()),
-            (None, "env", None, does_not_raise()),
-            (100, None, None, pytest.raises(TypeError)),
-            (100, "env", None, pytest.raises(TypeError)),
-        ],
-    )
-    def test_merge_nested_env_dicts(
-        self, mocker: MockerFixture, data: Any, env: Any, expected: Any, exception: Any
-    ) -> None:
-        """Test merge_nested_env_dicts."""
-
-        def merge_nested_environment_dicts(value, env_name):
-            """Assert args passed to the method during parse."""
-            assert value == list(data.values())[0]  # only pass data dict of 1 item
-            assert env_name == env
-            return "called"
-
-        mocker.patch(
-            f"{MODULE}.merge_nested_environment_dicts", merge_nested_environment_dicts,
-        )
-
-        with exception:
-            assert ModuleOptions.merge_nested_env_dicts(data, env) == expected
-
-    def test_parse(self, runway_context: MockRunwayContext) -> None:
-        """Test parse."""
-        with pytest.raises(NotImplementedError):
-            assert ModuleOptions.parse(runway_context)
-
-    @pytest.mark.parametrize("value", ["test", None, 123, {"key": "val"}])
-    def test_mutablemapping_abstractmethods(self, value: Any) -> None:
-        """Test the abstractmethods of MutableMapping."""
+    def test_get(self) -> None:
+        """Test get."""
         obj = ModuleOptions()
-        obj["key"] = value  # __setitem__
-        assert obj["key"] == value, "test __setitem__ and __getitem__"
-        assert isinstance(obj["key"], type(value)), "test type retention"
-        assert obj.get("key") == value, "ensure .get() is working"
-        assert len(obj) == 1, "test __len__"
-
-        counter = sum(1 for _ in obj)
-        assert counter == 1, "test __iter__"
-
-        del obj["key"]
-        assert "key" not in obj, "test __delitem__ with __contains__"
-        with pytest.raises(KeyError):
-            assert obj["key"], "test __delitem__ with __getitem__"
+        obj.key = "val"  # type: ignore
+        assert obj.get("key") == "val"
+        assert obj.get("missing") is None
+        assert obj.get("missing", "default") == "default"
 
 
 class TestRunwayModuleNpm:


### PR DESCRIPTION
## Summary

Replace the old options parser object with one that uses a pydantic model.

## Why This Is Needed

resolves #521

## What Changed

### Added

- added pydantic models for parsing terraform options

### Changed

- what was `ModulesOptionsV2` is now `ModuleOptions`
- `TerraformOptions` and `TerraformBackendConfig` now use pydantic models
- `TerraformOptions.parse` and `TerraformBackendConfig.parse` are now `TerraformOptions.parse_obj` and `TerraformBackendConfig.parse_obj`

### Removed

- removed some methods from `TerraformOptions` and `TerraformBackendConfig` that are no longer needed with pydantic handling parsing & data conversion
- removed support for deprecated `ssm` and `cfn` backend config options
-  removed support for environment maps in terraform options to align with current features
