### PR TITLE
cdk: use pydantic model to parse options

### DIFF
--- a/runway/config/models/runway/options/cdk.py
+++ b/runway/config/models/runway/options/cdk.py
@@ -1,0 +1,21 @@
+"""Runway AWS Cloud Development Kit Module options."""
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import Extra
+
+from ...base import ConfigProperty
+
+
+class RunwayCdkModuleOptionsDataModel(ConfigProperty):
+    """Model for Runway AWS Cloud Development Kit Module options."""
+
+    build_steps: List[str] = []
+    skip_npm_ci: bool = False
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.ignore
+        title = "Runway AWS Cloud Development Kit Module options."

--- a/tests/unit/config/models/runway/options/test_cdk.py
+++ b/tests/unit/config/models/runway/options/test_cdk.py
@@ -1,0 +1,26 @@
+"""Test runway.config.models.runway.options.cdk."""
+# pylint: disable=no-self-use
+from runway.config.models.runway.options.cdk import RunwayCdkModuleOptionsDataModel
+
+
+class TestRunwayCdkModuleOptionsDataModel:
+    """Test RunwayCdkModuleOptionsDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayCdkModuleOptionsDataModel()
+        assert obj.build_steps == []
+        assert not obj.skip_npm_ci
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        obj = RunwayCdkModuleOptionsDataModel(invalid="val")
+        assert "invalid" not in obj.dict()
+
+    def test_init(self) -> None:
+        """Test init."""
+        obj = RunwayCdkModuleOptionsDataModel(
+            build_steps=["test0", "test1"], skip_npm_ci=True
+        )
+        assert obj.build_steps == ["test0", "test1"]
+        assert obj.skip_npm_ci

--- a/tests/unit/module/test_cdk.py
+++ b/tests/unit/module/test_cdk.py
@@ -1,0 +1,26 @@
+"""Test runway.module.cdk."""
+# pylint: disable=no-self-use,unused-argument
+from __future__ import annotations
+
+from runway.config.models.runway.options.cdk import RunwayCdkModuleOptionsDataModel
+from runway.module.cdk import CloudDevelopmentKitOptions
+
+
+class TestCloudDevelopmentKitOptions:
+    """Test CloudDevelopmentKitOptions."""
+
+    def test_init(self) -> None:
+        """Test __init__."""
+        data = RunwayCdkModuleOptionsDataModel(build_steps=["test"])
+        obj = CloudDevelopmentKitOptions(data)
+        assert obj.build_steps == data.build_steps
+        assert obj.skip_npm_ci == data.skip_npm_ci
+
+    def test_parse_obj(self) -> None:
+        """Test parse_obj."""
+        config = {"build_steps": ["test-cmd"], "skip_npm_ci": True, "key": "val"}
+        obj = CloudDevelopmentKitOptions.parse_obj(config)
+        assert isinstance(obj.data, RunwayCdkModuleOptionsDataModel)
+        assert obj.data.build_steps == config["build_steps"]
+        assert obj.data.skip_npm_ci == config["skip_npm_ci"]
+        assert "key" not in obj.data.dict()


### PR DESCRIPTION
## Summary

Replace the old options parser object with one that uses a pydantic model.

## Why This Is Needed

resolves #316

## What Changed

### Added

- added pydantic model for parsing terraform options
