### PR TITLE
k8s: use pydantic model to parse options

### DIFF
--- a/runway/config/models/runway/options/k8s.py
+++ b/runway/config/models/runway/options/k8s.py
@@ -1,0 +1,22 @@
+"""Runway Kubernetes Module options."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import Extra
+
+from ...base import ConfigProperty
+
+
+class RunwayK8sModuleOptionsDataModel(ConfigProperty):
+    """Model for Runway Kubernetes Module options."""
+
+    kubectl_version: Optional[str] = None
+    overlay_path: Optional[Path] = None
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.ignore
+        title = "Runway Kubernetes Module options."

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -594,8 +594,8 @@ class TerraformBackendConfig(ModuleOptions):
         """Instantiate class.
 
         Args:
-            deploy_environment: Current deploy environment.
             data: Options parsed into a data model.
+            deploy_environment: Current deploy environment.
             path: Module path.
 
         """

--- a/tests/unit/config/models/runway/options/test_k8s.py
+++ b/tests/unit/config/models/runway/options/test_k8s.py
@@ -1,0 +1,33 @@
+"""Test runway.config.models.runway.options.k8s."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from runway.config.models.runway.options.k8s import RunwayK8sModuleOptionsDataModel
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestRunwayK8sModuleOptionsDataModel:
+    """Test RunwayK8sModuleOptionsDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayK8sModuleOptionsDataModel()
+        assert not obj.kubectl_version
+        assert not obj.overlay_path
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        obj = RunwayK8sModuleOptionsDataModel(invalid="val")
+        assert "invalid" not in obj.dict()
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test init."""
+        obj = RunwayK8sModuleOptionsDataModel(
+            kubectl_version="0.13.0", overlay_path=tmp_path
+        )
+        assert obj.kubectl_version == "0.13.0"
+        assert obj.overlay_path == tmp_path

--- a/tests/unit/module/test_k8s.py
+++ b/tests/unit/module/test_k8s.py
@@ -1,0 +1,121 @@
+"""Test runway.module.k8s."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+import pytest
+
+from runway.config.models.runway.options.k8s import RunwayK8sModuleOptionsDataModel
+from runway.module.k8s import K8s, K8sOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+    from ..factories import MockRunwayContext
+
+MODULE = "runway.module.k8s"
+
+
+class TestK8s:
+    """Test runway.module.k8s.K8s."""
+
+    def test_skip(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
+        """Test skip."""
+        obj = K8s(runway_context, module_root=tmp_path)  # type: ignore
+        assert obj.skip
+        obj.options.kustomize_config.parent.mkdir(parents=True, exist_ok=True)
+        obj.options.kustomize_config.touch()
+        assert not obj.skip
+
+
+class TestK8sOptions:
+    """Test runway.module.k8s.K8sOptions."""
+
+    def test_gen_overlay_dirs(self) -> None:
+        """Test gen_overlay_dirs."""
+        assert K8sOptions.gen_overlay_dirs("test", "us-east-1") == [
+            "test-us-east-1",
+            "test",
+        ]
+
+    @pytest.mark.parametrize(
+        "files, expected",
+        [
+            (["test-us-east-1/kustomization.yaml"], "test-us-east-1"),
+            (
+                ["test-us-east-1/kustomization.yaml", "test/kustomization.yaml"],
+                "test-us-east-1",
+            ),
+            (["test/kustomization.yaml"], "test"),
+            (["test2/kustomization.yaml"], "test"),
+        ],
+    )
+    def test_get_overlay_dir(
+        self, expected: str, files: List[str], tmp_path: Path
+    ) -> None:
+        """Test get_overlay_dir."""
+        for f in files:
+            tmp_file = tmp_path / f
+            tmp_file.parent.mkdir(parents=True, exist_ok=True)
+            tmp_file.touch()
+        assert (
+            K8sOptions.get_overlay_dir(tmp_path, "test", "us-east-1")
+            == tmp_path / expected
+        )
+
+    def test_kustomize_config(
+        self, mocker: MockerFixture, runway_context: MockRunwayContext, tmp_path: Path
+    ) -> None:
+        """Test kustomize_config."""
+        overlay_path = tmp_path / "overlays" / "test"
+        mocker.patch.object(K8sOptions, "overlay_path", overlay_path)
+        obj = K8sOptions.parse_obj(
+            deploy_environment=runway_context.env, obj={}, path=tmp_path,
+        )
+        assert obj.kustomize_config == overlay_path / "kustomization.yaml"
+
+    def test_overlay_path_found(
+        self, mocker: MockerFixture, runway_context: MockRunwayContext, tmp_path: Path
+    ) -> None:
+        """Test overlay_path found."""
+        overlay_path = tmp_path / "overlays" / "test"
+        mock_get_overlay_dir = mocker.patch.object(
+            K8sOptions, "get_overlay_dir", return_value=overlay_path
+        )
+        obj = K8sOptions.parse_obj(
+            deploy_environment=runway_context.env, obj={}, path=tmp_path,
+        )
+        assert obj.overlay_path == overlay_path
+        mock_get_overlay_dir.assert_called_once_with(
+            path=tmp_path / "overlays",
+            environment=runway_context.env.name,
+            region=runway_context.env.aws_region,
+        )
+
+    def test_overlay_path_provided(
+        self, runway_context: MockRunwayContext, tmp_path: Path
+    ) -> None:
+        """Test overlay_path provided."""
+        overlay_path = tmp_path / "overlays" / "test"
+        obj = K8sOptions.parse_obj(
+            deploy_environment=runway_context.env,
+            obj={"overlay_path": overlay_path},
+            path=tmp_path,
+        )
+        assert obj.overlay_path == overlay_path
+
+    def test_parse_obj(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
+        """Test parse_obj."""
+        config = {"kubectl_version": "0.13.0"}
+        obj = K8sOptions.parse_obj(
+            deploy_environment=runway_context.env, obj=config, path=tmp_path
+        )
+        assert isinstance(obj.data, RunwayK8sModuleOptionsDataModel)
+        assert obj.data.kubectl_version == config["kubectl_version"]
+        assert not obj.data.overlay_path
+        assert obj.env == runway_context.env
+        assert obj.kubectl_version == config["kubectl_version"]
+        assert obj.path == tmp_path


### PR DESCRIPTION
## Summary

Replace the old options parser object with one that uses a pydantic model.

## Why This Is Needed

resolves #317

## What Changed

### Added

- added pydantic model for parsing k8s options
- added `K8s.skip` which now contains the logic to determine if the module should be skipped

### Changed

- moved logic from some functions in `runway.module.k8s` into `classmethod`s and `staticmethod`s on the `K8s` class
- `K8s.options` is not of type `K8sOptions`

### Removed

- removed `runway.module.k8s.gen_overlay_dirs`
- removed `runway.module.k8s.get_module_defined_k8s_ver`
- removed `runway.module.k8s.get_overlay_dir`
- removed `runway.module.k8s.generate_response`
- remove support for environment map in `kubectl_version` option
