### PR TITLE
staticsite: use pydantic model to parse options and parameters

### DIFF
--- a/docs/source/staticsite/configuration.rst
+++ b/docs/source/staticsite/configuration.rst
@@ -245,7 +245,7 @@ Parameters
           arn: arn:aws:lambda:<region>:<account-id>:function:<function>:<version>
 
 **staticsite_non_spa (Optional[bool])**
-  Whether this site is a single page application (*SPA*). (*default:* ``true``)
+  Whether this site is a single page application (*SPA*). (*default:* ``false``)
 
   A custom error response directing ``ErrorCode: 404`` to the primary ``/index.html`` as a ``ResponseCode: 200`` is added, allowing the *SPA* to take over error handling.
   If you are not running an *SPA*, setting this to ``true`` will prevent this custom error from being added.

--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -8,7 +8,7 @@ from troposphere import AccountId, Join, Output, cognito, s3
 
 from ...cfngin.blueprints.base import Blueprint
 from ...hooks.staticsite.auth_at_edge.client_updater import get_redirect_uris
-from ...module.staticsite.handler import add_url_scheme
+from ...module.staticsite.utils import add_url_scheme
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/blueprints/staticsite/dependencies.py
+++ b/runway/blueprints/staticsite/dependencies.py
@@ -8,7 +8,7 @@ from troposphere import AccountId, Join, Output, cognito, s3
 
 from ...cfngin.blueprints.base import Blueprint
 from ...hooks.staticsite.auth_at_edge.client_updater import get_redirect_uris
-from ...module.staticsite import add_url_scheme
+from ...module.staticsite.handler import add_url_scheme
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runway/core/components/_module_type.py
+++ b/runway/core/components/_module_type.py
@@ -59,7 +59,7 @@ class RunwayModuleType:
         "cdk": "runway.module.cdk.CloudDevelopmentKit",
         "k8s": "runway.module.k8s.K8s",
         "cfn": "runway.module.cloudformation.CloudFormation",
-        "web": "runway.module.staticsite.StaticSite",
+        "web": "runway.module.staticsite.handler.StaticSite",
     }
 
     TYPE_MAP = {

--- a/runway/module/base.py
+++ b/runway/module/base.py
@@ -214,3 +214,9 @@ class ModuleOptions:
     def get(self, name: str, default: Any = None) -> Any:
         """Get a value or return the default."""
         return getattr(self, name, default)
+
+    def __eq__(self, other: Any) -> bool:
+        """Assess equality."""
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False

--- a/runway/module/staticsite/__init__.py
+++ b/runway/module/staticsite/__init__.py
@@ -1,0 +1,4 @@
+"""Runway Static Site Module."""
+from .handler import StaticSite
+
+__all__ = ["StaticSite"]

--- a/runway/module/staticsite/handler.py
+++ b/runway/module/staticsite/handler.py
@@ -17,6 +17,7 @@ from ..base import RunwayModule
 from ..cloudformation import CloudFormation
 from .options import StaticSiteOptions
 from .parameters import RunwayStaticSiteModuleParametersDataModel
+from .utils import add_url_scheme
 
 if TYPE_CHECKING:
     from ..._logging import RunwayLogger
@@ -24,18 +25,6 @@ if TYPE_CHECKING:
     from ..base import ModuleOptions
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
-
-
-def add_url_scheme(url: str) -> str:
-    """Add the scheme to an existing url.
-
-    Args:
-        url (str): The current url.
-
-    """
-    if url.startswith("https://") or url.startswith("http://"):
-        return url
-    return "https://%s" % url
 
 
 class StaticSite(RunwayModule):

--- a/runway/module/staticsite/options/__init__.py
+++ b/runway/module/staticsite/options/__init__.py
@@ -1,0 +1,18 @@
+"""Runway Static Site Module options."""
+from .components import StaticSiteOptions
+from .models import (
+    RunwayStaticSiteExtraFileDataModel,
+    RunwayStaticSiteModuleOptionsDataModel,
+    RunwayStaticSitePreBuildStepDataModel,
+    RunwayStaticSiteSourceHashingDataModel,
+    RunwayStaticSiteSourceHashingDirectoryDataModel,
+)
+
+__all__ = [
+    "RunwayStaticSiteExtraFileDataModel",
+    "RunwayStaticSiteModuleOptionsDataModel",
+    "RunwayStaticSitePreBuildStepDataModel",
+    "RunwayStaticSiteSourceHashingDataModel",
+    "RunwayStaticSiteSourceHashingDirectoryDataModel",
+    "StaticSiteOptions",
+]

--- a/runway/module/staticsite/options/components.py
+++ b/runway/module/staticsite/options/components.py
@@ -1,0 +1,40 @@
+"""Runway Static Site Module options component classes."""
+from __future__ import annotations
+
+from ...base import ModuleOptions
+from .models import RunwayStaticSiteModuleOptionsDataModel
+
+
+class StaticSiteOptions(ModuleOptions):
+    """Static site options.
+
+    Attributes:
+        build_output: Directory where build output is placed. Defaults to current
+            working directory.
+        build_steps: List of commands to run to build the static site.
+        data: Options parsed into a data model.
+        extra_files: List of files that should be uploaded to S3 after the build.
+            Used to dynamically create or select file.
+        pre_build_steps: Commands to be run prior to the build process.
+        source_hashing: Overrides for source hash calculation and tracking.
+
+    """
+
+    def __init__(self, data: RunwayStaticSiteModuleOptionsDataModel) -> None:
+        """Instantiate class."""
+        self.build_output = data.build_output
+        self.build_steps = data.build_steps
+        self.data = data
+        self.extra_files = data.extra_files
+        self.pre_build_steps = data.pre_build_steps
+        self.source_hashing = data.source_hashing
+
+    @classmethod
+    def parse_obj(cls, obj: object) -> StaticSiteOptions:
+        """Parse options definition and return an options object.
+
+        Args:
+            obj: Object to parse.
+
+        """
+        return cls(data=RunwayStaticSiteModuleOptionsDataModel.parse_obj(obj))

--- a/runway/module/staticsite/options/models.py
+++ b/runway/module/staticsite/options/models.py
@@ -1,0 +1,155 @@
+"""Runway static site Module options."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, cast
+
+from pydantic import Extra, root_validator
+
+from ....config.models.base import ConfigProperty
+
+
+class RunwayStaticSiteExtraFileDataModel(ConfigProperty):
+    """Model for Runway static site Module extra_files option item.
+
+    Attributes:
+        content_type: An explicit content type for the file. If not provided,
+            will attempt to determine based on the name provided.
+        content: Inline content that will be used as the file content.
+            This or ``file`` must be provided.
+        file: Path to an existing file. The content of this file will be uploaded
+            to the static site S3 bucket using the name as the object key.
+            This or ``content`` must be provided.
+        name: The destination name of the file to create.
+
+    """
+
+    content_type: Optional[str]
+    content: Any = None
+    file: Optional[Path]
+    name: str
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway static site Module extra_files option item."
+
+    @root_validator
+    def _autofill_content_type(  # pylint: disable=no-self-argument,no-self-use
+        cls, values: Dict[str, Any]  # noqa: N805
+    ) -> Dict[str, Any]:
+        """Attempt to fill content_type if not provided."""
+        if values.get("content_type"):
+            return values
+        name = cast(str, values.get("name", ""))
+        if name.endswith(".json"):
+            values["content_type"] = "application/json"
+        elif name.endswith(".yaml") or name.endswith(".yml"):
+            values["content_type"] = "text/yaml"
+        return values
+
+    @root_validator(pre=True)
+    def _validate_content_or_file(  # pylint: disable=no-self-argument,no-self-use
+        cls, values: Dict[str, Any]  # noqa: N805
+    ) -> Dict[str, Any]:
+        """Validate that content or file is provided."""
+        content = values.get("content")
+        file_val = values.get("file")
+        if content and file_val:
+            raise ValueError("only one of content or file can be provided")
+        if not (content or file_val):
+            raise ValueError("one of content or file must be provided")
+        return values
+
+
+class RunwayStaticSitePreBuildStepDataModel(ConfigProperty):
+    """Model for Runway static site Module pre_build_steps option item.
+
+    Attributes:
+        command: The command to run.
+        cwd: The working directory for the subprocess running the command.
+            If not provided, the current working directory is used.
+
+    """
+
+    command: str
+    cwd: Path = Path.cwd()
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway static site Module pre_build_steps option item."
+
+
+class RunwayStaticSiteSourceHashingDirectoryDataModel(ConfigProperty):
+    """Model for Runway static site Module source_hashing.directory option item.
+
+    Attributes:
+        exclusions: List of gitignore formmated globs to ignore when calculating
+            the hash.
+        path: Path to files to include in the hash.
+
+    """
+
+    exclusions: List[str] = []
+    path: Path
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway static site Module source_hashing.directories option item."
+
+
+class RunwayStaticSiteSourceHashingDataModel(ConfigProperty):
+    """Model for Runway static site Module source_hashing option.
+
+    Attributes:
+        directories: Explicitly provide the directories to use when calculating
+            the hash. If not provided, will default to the root of the module.
+        enabled: Enable source hashing. If not enabled, build and upload will
+            occur on every deploy.
+        parameter: SSM parameter where the hash of each build is stored.
+
+    """
+
+    directories: List[RunwayStaticSiteSourceHashingDirectoryDataModel] = [
+        RunwayStaticSiteSourceHashingDirectoryDataModel(path="./")
+    ]
+    enabled: bool = True
+    parameter: Optional[str] = None
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway static site Module source_hashing option."
+
+
+class RunwayStaticSiteModuleOptionsDataModel(ConfigProperty):
+    """Model for Runway static site Module options.
+
+    Attributes:
+        build_output: Directory where build output is placed. Defaults to current
+            working directory.
+        build_steps: List of commands to run to build the static site.
+        extra_files: List of files that should be uploaded to S3 after the build.
+            Used to dynamically create or select file.
+        pre_build_steps: Commands to be run prior to the build process.
+        source_hashing: Overrides for source hash calculation and tracking.
+
+    """
+
+    build_output: str = "./"
+    build_steps: List[str] = []
+    extra_files: List[RunwayStaticSiteExtraFileDataModel] = []
+    pre_build_steps: List[RunwayStaticSitePreBuildStepDataModel] = []
+    source_hashing: RunwayStaticSiteSourceHashingDataModel = RunwayStaticSiteSourceHashingDataModel()  # noqa: E501
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.ignore
+        title = "Runway static site Module options."

--- a/runway/module/staticsite/parameters/__init__.py
+++ b/runway/module/staticsite/parameters/__init__.py
@@ -1,0 +1,12 @@
+"""Runway Static Site Module parameters."""
+from .models import (
+    RunwayStaticSiteCustomErrorResponseDataModel,
+    RunwayStaticSiteLambdaFunctionAssociationDataModel,
+    RunwayStaticSiteModuleParametersDataModel,
+)
+
+__all__ = [
+    "RunwayStaticSiteCustomErrorResponseDataModel",
+    "RunwayStaticSiteLambdaFunctionAssociationDataModel",
+    "RunwayStaticSiteModuleParametersDataModel",
+]

--- a/runway/module/staticsite/parameters/models.py
+++ b/runway/module/staticsite/parameters/models.py
@@ -1,0 +1,183 @@
+"""Runway static site Module parameters."""
+# pylint: disable=no-self-argument,no-self-use
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from pydantic import Extra, Field, validator
+
+from ....config.models.base import ConfigProperty
+
+
+class RunwayStaticSiteCustomErrorResponseDataModel(ConfigProperty):
+    """Model for Runway stat site Module staticsite_custom_error_responses parameter item.
+
+    https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-customerrorresponse.html
+
+    """
+
+    ErrorCachingMinTTL: Optional[int] = None
+    ErrorCode: Optional[int] = None
+    ResponseCode: Optional[int] = None
+    ResponsePagePath: Optional[str] = None
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway static site Module staticsite_custom_error_responses parameter item."
+
+
+class RunwayStaticSiteLambdaFunctionAssociationDataModel(ConfigProperty):
+    """Model for Runway stat site Module staticsite_lambda_function_associations parameter item.
+
+    Attributes:
+        arn: Lambda function ARN.
+        type: Association type.
+
+    """
+
+    arn: str
+    type: str
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.forbid
+        title = "Runway static site Module staticsite_lambda_function_associations parameter item."  # noqa
+
+
+class RunwayStaticSiteModuleParametersDataModel(ConfigProperty):
+    """Model for Runway static site Module parameters.
+
+    Attributes:
+        acmcert_arn: The certificate arn used for any alias domains supplied.
+            This is a requirement when supplying any custom domain.
+        additional_redirect_domains: Additional domains (beyond the ``aliases``
+            domains or the CloudFront URL if no aliases are provided) that will
+            be authorized by the Auth@Edge UserPool AppClient.
+        aliases: Any custom domains that should be added to the CloudFront
+            Distribution.
+        auth_at_edge: Auth@Edge make the static site private by placing it behind
+            an authorization wall.
+        cf_disable: Wether deployment of the CloudFront Distribution should be
+            disabled.
+        cookie_settings: The default cookie settings for retrieved tokens and
+            generated nonce’s.
+        create_user_pool: Wether to create a User Pool for the Auth@Edge
+            configuration.
+        custom_error_responses: Define custom error responses.
+        enable_cf_logging: Enable CloudFront logging.
+        http_headers: Headers that should be sent with each origin response.
+        lambda_function_associations: This allows the user to deploy custom
+            Lambda@Edge associations with their pre-build function versions.
+        namespace: The unique namespace for the deployment.
+        non_spa: Wether this site is a single page application (SPA).
+        oauth_scopes: Scope is a mechanism in OAuth 2.0 to limit an application’s
+            access to a user’s account.
+        redirect_path_auth_refresh: The path that a user is redirected to when
+            their authorization tokens have expired (1 hour).
+        redirect_path_sign_in: The path that a user is redirected to after sign-in.
+        redirect_path_sign_out: The path that a user is redirected to after sign-out.
+        required_group: Name of Cognito User Pool group of which users must be a
+            member to be granted access to the site. If ``None``, allows all
+            UserPool users to have access.
+        rewrite_directory_index: Deploy a Lambda@Edge function designed to
+            rewrite directory indexes.
+        role_boundary_arn: Defines an IAM Managed Policy that will be set as the
+            permissions boundary for any IAM Roles created to support the site.
+        sign_out_url: The path a user should access to sign themselves out of the
+            application.
+        supported_identity_providers: A comma delimited list of the User Pool
+            client identity providers.
+        user_pool_arn: The ARN of a pre-existing Cognito User Pool to use with
+            Auth@Edge.
+        web_acl: The ARN of a web access control list (web ACL) to associate with
+            the CloudFront Distribution.
+
+    """
+
+    acmcert_arn: Optional[str] = Field(None, alias="staticsite_acmcert_arn")
+    additional_redirect_domains: List[str] = Field(
+        [], alias="staticsite_additional_redirect_domains"
+    )
+    aliases: List[str] = Field([], alias="staticsite_aliases")
+    auth_at_edge: bool = Field(False, alias="staticsite_auth_at_edge")
+    cf_disable: bool = Field(False, alias="staticsite_cf_disable")
+    cookie_settings: Dict[str, str] = Field(
+        {
+            "idToken": "Path=/; Secure; SameSite=Lax",
+            "accessToken": "Path=/; Secure; SameSite=Lax",
+            "refreshToken": "Path=/; Secure; SameSite=Lax",
+            "nonce": "Path=/; Secure; HttpOnly; Max-Age=1800; SameSite=Lax",
+        },
+        alias="staticsite_cookie_settings",
+    )
+    create_user_pool: bool = Field(False, alias="staticsite_create_user_pool")
+    custom_error_responses: List[RunwayStaticSiteCustomErrorResponseDataModel] = Field(
+        [], alias="staticsite_custom_error_responses"
+    )
+    enable_cf_logging: bool = Field(True, alias="staticsite_enable_cf_logging")
+    http_headers: Dict[str, str] = Field(
+        {
+            "Content-Security-Policy": "default-src https: 'unsafe-eval' 'unsafe-inline'; "
+            "font-src 'self' 'unsafe-inline' 'unsafe-eval' data: https:; "
+            "object-src 'none'; "
+            "connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com",
+            "Strict-Transport-Security": "max-age=31536000; "
+            "includeSubdomains; "
+            "preload",
+            "Referrer-Policy": "same-origin",
+            "X-XSS-Protection": "1; mode=block",
+            "X-Frame-Options": "DENY",
+            "X-Content-Type-Options": "nosniff",
+        },
+        alias="staticsite_http_headers",
+    )
+    lambda_function_associations: List[
+        RunwayStaticSiteLambdaFunctionAssociationDataModel
+    ] = Field([], alias="staticsite_lambda_function_associations")
+    namespace: str
+    non_spa: bool = Field(False, alias="staticsite_non_spa")
+    oauth_scopes: List[str] = Field(
+        ["phone", "email", "profile", "openid", "aws.cognito.signin.user.admin"],
+        alias="staticsite_oauth_scopes",
+    )
+    redirect_path_auth_refresh: str = Field(
+        "/refreshauth", alias="staticsite_redirect_path_auth_refresh"
+    )
+    redirect_path_sign_in: str = Field(
+        "/parseauth", alias="staticsite_redirect_path_sign_in"
+    )
+    redirect_path_sign_out: str = Field("/", alias="staticsite_redirect_path_sign_out")
+    required_group: Optional[str] = Field(None, alias="staticsite_required_group")
+    rewrite_directory_index: Optional[str] = Field(
+        None, alias="staticsite_rewrite_directory_index"
+    )
+    role_boundary_arn: Optional[str] = Field(None, alias="staticsite_role_boundary_arn")
+    sign_out_url: str = Field("/signout", alias="staticsite_sign_out_url")
+    supported_identity_providers: List[str] = Field(
+        ["COGNITO"], alias="staticsite_supported_identity_providers"
+    )
+    user_pool_arn: Optional[str] = Field(None, alias="staticsite_user_pool_arn")
+    web_acl: Optional[str] = Field(None, alias="staticsite_web_acl")
+
+    class Config:
+        """Model configuration."""
+
+        extra = Extra.ignore
+        title = "Runway static site Module parameters."
+
+    @validator(
+        "additional_redirect_domains",
+        "aliases",
+        "supported_identity_providers",
+        pre=True,
+    )
+    def _convert_comma_delimited_list(
+        cls, v: Union[List[str], str]  # noqa: N805
+    ) -> List[str]:
+        """Convert comma delimited lists to a string."""
+        if isinstance(v, str):
+            return [i.strip() for i in v.split(",")]
+        return v

--- a/runway/module/staticsite/utils.py
+++ b/runway/module/staticsite/utils.py
@@ -1,0 +1,13 @@
+"""Static site utilities."""
+
+
+def add_url_scheme(url: str) -> str:
+    """Add the scheme to an existing url.
+
+    Args:
+        url (str): The current url.
+
+    """
+    if url.startswith("https://") or url.startswith("http://"):
+        return url
+    return "https://%s" % url

--- a/tests/unit/core/components/test_module_type.py
+++ b/tests/unit/core/components/test_module_type.py
@@ -12,7 +12,7 @@ from runway.module.cdk import CloudDevelopmentKit
 from runway.module.cloudformation import CloudFormation
 from runway.module.k8s import K8s
 from runway.module.serverless import Serverless
-from runway.module.staticsite import StaticSite
+from runway.module.staticsite.handler import StaticSite
 from runway.module.terraform import Terraform
 
 if TYPE_CHECKING:

--- a/tests/unit/module/staticsite/__init__.py
+++ b/tests/unit/module/staticsite/__init__.py
@@ -1,0 +1,1 @@
+"""Empty file for python import traversal."""

--- a/tests/unit/module/staticsite/options/__init__.py
+++ b/tests/unit/module/staticsite/options/__init__.py
@@ -1,0 +1,1 @@
+"""Empty file for python import traversal."""

--- a/tests/unit/module/staticsite/options/test_components.py
+++ b/tests/unit/module/staticsite/options/test_components.py
@@ -1,0 +1,38 @@
+"""Test runway.module.staticsite.options.components."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+from runway.module.staticsite.options.components import StaticSiteOptions
+from runway.module.staticsite.options.models import (
+    RunwayStaticSiteModuleOptionsDataModel,
+)
+
+MODULE = "runway.module.staticsite.options.components"
+
+
+class TestStaticSiteOptions:
+    """Test StaticSiteOptions."""
+
+    def test_init(self) -> None:
+        """Test __init__."""
+        data = RunwayStaticSiteModuleOptionsDataModel(
+            build_output="./dist",
+            build_steps=["runway --help"],
+            pre_build_steps=[{"command": "runway --help"}],
+        )
+        obj = StaticSiteOptions(data=data)
+        assert obj.build_output == data.build_output
+        assert obj.build_steps == data.build_steps
+        assert obj.data == data
+        assert obj.extra_files == data.extra_files
+        assert obj.pre_build_steps == data.pre_build_steps
+        assert obj.source_hashing == data.source_hashing
+
+    def test_parse_obj(self) -> None:
+        """Test parse_obj."""
+        obj = StaticSiteOptions.parse_obj({})
+        assert isinstance(obj.data, RunwayStaticSiteModuleOptionsDataModel)
+        assert (
+            obj.data.dict(exclude_defaults=True, exclude_none=True, exclude_unset=True)
+            == {}
+        )

--- a/tests/unit/module/staticsite/options/test_models.py
+++ b/tests/unit/module/staticsite/options/test_models.py
@@ -1,0 +1,220 @@
+"""Test runway.module.staticsite.options.models."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+from pydantic import ValidationError
+
+from runway.module.staticsite.options.models import (
+    RunwayStaticSiteExtraFileDataModel,
+    RunwayStaticSiteModuleOptionsDataModel,
+    RunwayStaticSitePreBuildStepDataModel,
+    RunwayStaticSiteSourceHashingDataModel,
+    RunwayStaticSiteSourceHashingDirectoryDataModel,
+)
+
+MODULE = "runway.module.staticsite.options.models"
+
+
+class TestRunwayStaticSiteExtraFileDataModel:
+    """Test RunwayStaticSiteExtraFileDataModel."""
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("test.json", "application/json"),
+            ("test.yaml", "text/yaml"),
+            ("test.yml", "text/yaml"),
+            ("test", None),
+        ],
+    )
+    def test_autofill_content_type(self, expected: Optional[str], name: str) -> None:
+        """Test _autofill_content_type."""
+        assert (
+            RunwayStaticSiteExtraFileDataModel(content="test", name=name).content_type
+            == expected
+        )
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayStaticSiteExtraFileDataModel(
+            content="test-content", name="test-name"
+        )
+        assert not obj.content_type
+        assert obj.content == "test-content"
+        assert not obj.file
+        assert obj.name == "test-name"
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteExtraFileDataModel(
+                content="test-content", name="test-name", invalid="val"
+            )
+
+    def test_init_content_and_file(self, tmp_path: Path) -> None:
+        """Test init content and file."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteExtraFileDataModel(
+                content="test-content", file=tmp_path, name="test-name"
+            )
+
+    def test_init_content(self) -> None:
+        """Test init content."""
+        data = {"content_type": "test-data", "content": "content", "name": "test"}
+        obj = RunwayStaticSiteExtraFileDataModel(**data)
+        assert obj.content_type == data["content_type"]
+        assert obj.content == data["content"]
+        assert not obj.file
+        assert obj.name == data["name"]
+
+    def test_init_file(self, tmp_path: Path) -> None:
+        """Test init file."""
+        data = {"content_type": "test-data", "file": tmp_path, "name": "test"}
+        obj = RunwayStaticSiteExtraFileDataModel(**data)
+        assert obj.content_type == data["content_type"]
+        assert not obj.content
+        assert obj.file == data["file"]
+        assert obj.name == data["name"]
+
+    @pytest.mark.parametrize(
+        "data", [{}, {"name": "test"}, {"content": "test"}, {"file": "test"}]
+    )
+    def test_init_required(self, data: Dict[str, Any]) -> None:
+        """Test init required fields."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteExtraFileDataModel(**data)
+
+
+class TestRunwayStaticSiteModuleOptionsDataModel:
+    """Test RunwayStaticSiteModuleOptionsDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayStaticSiteModuleOptionsDataModel()
+        assert obj.build_output == "./"
+        assert obj.build_steps == []
+        assert obj.extra_files == []
+        assert obj.pre_build_steps == []
+        assert obj.source_hashing == RunwayStaticSiteSourceHashingDataModel()
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        obj = RunwayStaticSiteModuleOptionsDataModel(invalid="val")
+        assert "invalid" not in obj.dict()
+
+    def test_init(self) -> None:
+        """Test init."""
+        data = {
+            "build_output": "./dist",
+            "build_steps": ["runway --help"],
+            "extra_files": [{"name": "test.json", "content": "{}"}],
+            "pre_build_steps": [{"command": "runway --help"}],
+            "source_hashing": {"enabled": False},
+        }
+        obj = RunwayStaticSiteModuleOptionsDataModel(**data)
+        assert obj.build_output == data["build_output"]
+        assert obj.build_steps == data["build_steps"]
+        assert obj.extra_files == [
+            RunwayStaticSiteExtraFileDataModel(**data["extra_files"][0])
+        ]
+        assert obj.pre_build_steps == [
+            RunwayStaticSitePreBuildStepDataModel(**data["pre_build_steps"][0])
+        ]
+        assert obj.source_hashing == RunwayStaticSiteSourceHashingDataModel(
+            **data["source_hashing"]
+        )
+
+
+class TestRunwayStaticSitePreBuildStepDataModel:
+    """Test RunwayStaticSitePreBuildStepDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayStaticSitePreBuildStepDataModel(command="runway --help")
+        assert obj.command == "runway --help"
+        assert obj.cwd == Path.cwd()
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSitePreBuildStepDataModel(
+                command="runway --help", invalid="val"
+            )
+
+    def test_init_required(self, tmp_path: Path) -> None:
+        """Test init required."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSitePreBuildStepDataModel(cwd=tmp_path)
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test init."""
+        obj = RunwayStaticSitePreBuildStepDataModel(
+            command="runway --help", cwd=tmp_path
+        )
+        assert obj.command == "runway --help"
+        assert obj.cwd == tmp_path
+
+
+class TestRunwayStaticSiteSourceHashingDataModel:
+    """Test RunwayStaticSiteSourceHashingDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayStaticSiteSourceHashingDataModel()
+        assert obj.directories == [
+            RunwayStaticSiteSourceHashingDirectoryDataModel(path="./")
+        ]
+        assert obj.enabled is True
+        assert not obj.parameter
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteSourceHashingDataModel(invalid="test")
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test init."""
+        data = {
+            "directories": [{"path": tmp_path}],
+            "enabled": False,
+            "parameter": "test",
+        }
+        obj = RunwayStaticSiteSourceHashingDataModel(**data)
+        assert obj.directories == [
+            RunwayStaticSiteSourceHashingDirectoryDataModel(**data["directories"][0])
+        ]
+        assert obj.enabled is data["enabled"]
+        assert obj.parameter == data["parameter"]
+
+
+class TestRunwayStaticSiteSourceHashingDirectoryDataModel:
+    """Test RunwayStaticSiteSourceHashingDirectoryDataModel."""
+
+    def test_init_default(self, tmp_path: Path) -> None:
+        """Test init default."""
+        obj = RunwayStaticSiteSourceHashingDirectoryDataModel(path=tmp_path)
+        assert obj.exclusions == []
+        assert obj.path == tmp_path
+
+    def test_init_extra(self, tmp_path: Path) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteSourceHashingDirectoryDataModel(
+                path=tmp_path, invalid="val"
+            )
+
+    def test_init_required(self) -> None:
+        """Test init required."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteSourceHashingDirectoryDataModel(exclusions=["**/*.md"])
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test init."""
+        data = {"exclusions": ["**/*.md"], "path": tmp_path}
+        obj = RunwayStaticSiteSourceHashingDirectoryDataModel(**data)
+        assert obj.exclusions == data["exclusions"]
+        assert obj.path == data["path"]

--- a/tests/unit/module/staticsite/parameters/__init__.py
+++ b/tests/unit/module/staticsite/parameters/__init__.py
@@ -1,0 +1,1 @@
+"""Empty file for python import traversal."""

--- a/tests/unit/module/staticsite/parameters/test_models.py
+++ b/tests/unit/module/staticsite/parameters/test_models.py
@@ -1,0 +1,234 @@
+"""Test runway.module.staticsite.parameters.models."""
+# pylint: disable=no-self-use
+from typing import Any, Dict
+
+import pytest
+from pydantic import ValidationError
+
+from runway.module.staticsite.parameters.models import (
+    RunwayStaticSiteCustomErrorResponseDataModel,
+    RunwayStaticSiteLambdaFunctionAssociationDataModel,
+    RunwayStaticSiteModuleParametersDataModel,
+)
+
+MODULE = "runway.module.staticsite.parameters.models"
+
+
+class TestRunwayStaticSiteCustomErrorResponseDataModel:
+    """Test RunwayStaticSiteCustomErrorResponseDataModel."""
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayStaticSiteCustomErrorResponseDataModel()
+        assert not obj.ErrorCachingMinTTL
+        assert not obj.ErrorCode
+        assert not obj.ResponseCode
+        assert not obj.ResponsePagePath
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteCustomErrorResponseDataModel(invalid="val")
+
+    def test_init(self) -> None:
+        """Test init."""
+        data = {
+            "ErrorCachingMinTTL": 30,
+            "ErrorCode": 404,
+            "ResponseCode": 404,
+            "ResponsePagePath": "./errors/404.html",
+        }
+        obj = RunwayStaticSiteCustomErrorResponseDataModel(**data)
+        assert obj.ErrorCachingMinTTL == data["ErrorCachingMinTTL"]
+        assert obj.ErrorCode == data["ErrorCode"]
+        assert obj.ResponseCode == data["ResponseCode"]
+        assert obj.ResponsePagePath == data["ResponsePagePath"]
+
+
+class TestRunwayStaticSiteLambdaFunctionAssociationDataModel:
+    """Test RunwayStaticSiteLambdaFunctionAssociationDataModel."""
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteLambdaFunctionAssociationDataModel(invalid="val")
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {},
+            {"arn": "aws:arn:lambda:us-east-1:function:test"},
+            {"type": "origin-request"},
+        ],
+    )
+    def test_init_required(self, data: Dict[str, Any]) -> None:
+        """Test init required."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteLambdaFunctionAssociationDataModel.parse_obj(data)
+
+    def test_init(self) -> None:
+        """Test init."""
+        data = {
+            "arn": "aws:arn:lambda:us-east-1:function:test",
+            "type": "origin-request",
+        }
+        obj = RunwayStaticSiteLambdaFunctionAssociationDataModel(**data)
+        assert obj.arn == data["arn"]
+        assert obj.type == data["type"]
+
+
+class TestRunwayStaticSiteModuleParametersDataModel:
+    """Test RunwayStaticSiteModuleParametersDataModel."""
+
+    def test_convert_comma_delimited_list(self) -> None:
+        """Test _convert_comma_delimited_list."""
+        obj = RunwayStaticSiteModuleParametersDataModel(
+            namespace="test",
+            staticsite_additional_redirect_domains="redirect0,redirect1",
+            staticsite_aliases="test-alias",
+            staticsite_supported_identity_providers="id0, id1",
+        )
+        assert obj.additional_redirect_domains == ["redirect0", "redirect1"]
+        assert obj.aliases == ["test-alias"]
+        assert obj.supported_identity_providers == ["id0", "id1"]
+
+    def test_init_default(self) -> None:
+        """Test init default."""
+        obj = RunwayStaticSiteModuleParametersDataModel(namespace="test")
+        assert not obj.acmcert_arn
+        assert obj.additional_redirect_domains == []
+        assert obj.aliases == []
+        assert obj.auth_at_edge is False
+        assert obj.cf_disable is False
+        assert obj.cookie_settings == {
+            "idToken": "Path=/; Secure; SameSite=Lax",
+            "accessToken": "Path=/; Secure; SameSite=Lax",
+            "refreshToken": "Path=/; Secure; SameSite=Lax",
+            "nonce": "Path=/; Secure; HttpOnly; Max-Age=1800; SameSite=Lax",
+        }
+        assert obj.create_user_pool is False
+        assert obj.custom_error_responses == []
+        assert obj.enable_cf_logging is True
+        assert obj.http_headers == {
+            "Content-Security-Policy": "default-src https: 'unsafe-eval' 'unsafe-inline'; "
+            "font-src 'self' 'unsafe-inline' 'unsafe-eval' data: https:; "
+            "object-src 'none'; "
+            "connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com",
+            "Strict-Transport-Security": "max-age=31536000; "
+            "includeSubdomains; "
+            "preload",
+            "Referrer-Policy": "same-origin",
+            "X-XSS-Protection": "1; mode=block",
+            "X-Frame-Options": "DENY",
+            "X-Content-Type-Options": "nosniff",
+        }
+        assert obj.lambda_function_associations == []
+        assert obj.namespace == "test"
+        assert obj.non_spa is False
+        assert obj.oauth_scopes == [
+            "phone",
+            "email",
+            "profile",
+            "openid",
+            "aws.cognito.signin.user.admin",
+        ]
+        assert obj.redirect_path_auth_refresh == "/refreshauth"
+        assert obj.redirect_path_sign_in == "/parseauth"
+        assert obj.redirect_path_sign_out == "/"
+        assert not obj.required_group
+        assert not obj.rewrite_directory_index
+        assert not obj.role_boundary_arn
+        assert obj.sign_out_url == "/signout"
+        assert obj.supported_identity_providers == ["COGNITO"]
+        assert not obj.user_pool_arn
+        assert not obj.web_acl
+
+    def test_init_extra(self) -> None:
+        """Test init extra."""
+        obj = RunwayStaticSiteModuleParametersDataModel(namespace="test", invalid="val")
+        assert "invalid" not in obj.dict()
+
+    def test_init_required(self) -> None:
+        """Test init required."""
+        with pytest.raises(ValidationError):
+            RunwayStaticSiteModuleParametersDataModel.parse_obj({})
+
+    def test_init(self) -> None:
+        """Test init."""
+        data = {
+            "staticsite_acmcert_arn": "aws:arn:acm:us-east-1:cert:test",
+            "staticsite_additional_redirect_domains": ["github.com"],
+            "staticsite_aliases": ["test-alias"],
+            "staticsite_auth_at_edge": True,
+            "staticsite_cf_disable": True,
+            "staticsite_cookie_settings": {"test-cookie": "val"},
+            "staticsite_create_user_pool": True,
+            "staticsite_custom_error_responses": [{"ErrorCode": 404}],
+            "staticsite_enable_cf_logging": False,
+            "staticsite_http_headers": {"test-header": "val"},
+            "staticsite_lambda_function_associations": [
+                {
+                    "arn": "aws:arn:lambda:us-east-1:function:test",
+                    "type": "origin-request",
+                }
+            ],
+            "namespace": "test",
+            "staticsite_non_spa": True,
+            "staticsite_oauth_scopes": ["email"],
+            "staticsite_redirect_path_auth_refresh": "/test-refresh",
+            "staticsite_redirect_path_sign_in": "/test-sign-in",
+            "staticsite_redirect_path_sign_out": "/test-sign-out-redirect",
+            "staticsite_required_group": "any",
+            "staticsite_rewrite_directory_index": "test-rewrite-index",
+            "staticsite_role_boundary_arn": "arn:aws:iam:::role/test",
+            "staticsite_sign_out_url": "/test-sign-out",
+            "staticsite_supported_identity_providers": ["google"],
+            "staticsite_user_pool_arn": "arn:aws:cognito:::pool/test",
+            "staticsite_web_acl": "arn:aws::::acl/test",
+        }
+        obj = RunwayStaticSiteModuleParametersDataModel(**data)
+        assert obj.acmcert_arn == data["staticsite_acmcert_arn"]
+        assert (
+            obj.additional_redirect_domains
+            == data["staticsite_additional_redirect_domains"]
+        )
+        assert obj.aliases == data["staticsite_aliases"]
+        assert obj.auth_at_edge is data["staticsite_auth_at_edge"]
+        assert obj.cf_disable is data["staticsite_cf_disable"]
+        assert obj.cookie_settings == data["staticsite_cookie_settings"]
+        assert obj.create_user_pool is data["staticsite_create_user_pool"]
+        assert len(obj.custom_error_responses) == len(
+            data["staticsite_custom_error_responses"]
+        )
+        assert (
+            obj.custom_error_responses[0].dict(exclude_none=True)
+            == data["staticsite_custom_error_responses"][0]
+        )
+        assert obj.enable_cf_logging is data["staticsite_enable_cf_logging"]
+        assert obj.http_headers == data["staticsite_http_headers"]
+        assert len(obj.lambda_function_associations) == len(
+            data["staticsite_lambda_function_associations"]
+        )
+        assert (
+            obj.lambda_function_associations[0].dict()
+            == data["staticsite_lambda_function_associations"][0]
+        )
+        assert obj.namespace == data["namespace"]
+        assert obj.non_spa is data["staticsite_non_spa"]
+        assert obj.oauth_scopes == data["staticsite_oauth_scopes"]
+        assert (
+            obj.redirect_path_auth_refresh
+            == data["staticsite_redirect_path_auth_refresh"]
+        )
+        assert obj.redirect_path_sign_in == data["staticsite_redirect_path_sign_in"]
+        assert obj.redirect_path_sign_out == data["staticsite_redirect_path_sign_out"]
+        assert obj.required_group == data["staticsite_required_group"]
+        assert obj.rewrite_directory_index == data["staticsite_rewrite_directory_index"]
+        assert obj.role_boundary_arn == data["staticsite_role_boundary_arn"]
+        assert obj.sign_out_url == data["staticsite_sign_out_url"]
+        assert (
+            obj.supported_identity_providers
+            == data["staticsite_supported_identity_providers"]
+        )
+        assert obj.user_pool_arn == data["staticsite_user_pool_arn"]
+        assert obj.web_acl == data["staticsite_web_acl"]

--- a/tests/unit/module/staticsite/test_handler.py
+++ b/tests/unit/module/staticsite/test_handler.py
@@ -1,0 +1,37 @@
+"""Test runway.module.staticsite.handler."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from runway.module.staticsite.handler import StaticSite
+from runway.module.staticsite.options.components import StaticSiteOptions
+from runway.module.staticsite.parameters.models import (
+    RunwayStaticSiteModuleParametersDataModel,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from runway.context.runway import RunwayContext
+
+
+class TestStaticSite:
+    """Test StaticSite."""
+
+    def test_init(self, runway_context: RunwayContext, tmp_path: Path) -> None:
+        """Test init."""
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            options={"build_output": "./dist"},
+            parameters={"namespace": "test"},
+        )
+        assert obj.ctx == runway_context
+        assert isinstance(obj.options, StaticSiteOptions)
+        assert obj.options == StaticSiteOptions.parse_obj({"build_output": "./dist"})
+        assert isinstance(obj.parameters, RunwayStaticSiteModuleParametersDataModel)
+        assert obj.parameters == RunwayStaticSiteModuleParametersDataModel.parse_obj(
+            {"namespace": "test"}
+        )
+        assert obj.path == tmp_path


### PR DESCRIPTION
## Summary

Replace the old options & parameters parsing with objects that uses pydantic models.

## Why This Is Needed

resolves #315

## What Changed

### Added

- added pydantic models for parsing static site options & parameters
- added `runway.module.base.ModuleOptions.__eq__`

### Changed

- `runway.module.staticsite.StaticSite` is now `runway.module.staticsite.handler.StaticSite` but it's still importable from it's previous path
- `runway.module.staticsite.add_url_scheme` is now `runway.module.statesite.utils.add_url_scheme`
