### PR TITLE
sls-tsc sample: drop legacy aws-sdk and bump node version

### DIFF
--- a/runway/templates/sls-tsc/package.json
+++ b/runway/templates/sls-tsc/package.json
@@ -13,7 +13,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.811.0",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/runway/templates/sls-tsc/serverless.yml
+++ b/runway/templates/sls-tsc/serverless.yml
@@ -6,7 +6,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs12.x
 
 # After adding a few functions and associated dependencies, individual function
 # packages can be created to avoid a single massive zip file.
@@ -20,12 +20,6 @@ custom:
     excludeFiles:
       - "src/**/*.test.ts"
       - "src/**/__mocks__/*.ts"
-    # We could exclude aws-sdk here to trim down the deployment package via
-    # webpack-node-externals (see webpack.config.js), but instead we'll
-    # include it so the sdk version used is predictable.
-    # includeModules:
-    #   forceExclude:
-    #     - aws-sdk
 
 functions:
   helloWorld:

--- a/runway/templates/sls-tsc/webpack.config.js
+++ b/runway/templates/sls-tsc/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = {
     },
     // Can externalize dependencies if needed (see comment on webpack-node-externals above):
     // externals: [nodeExternals()],
-    // or alternatively the aws sdk can be ommitted from the package without webpack-node-externals:
+    // or alternatively specific packages can be omitted from the archive without webpack-node-externals:
     // externals: ['aws-sdk'],
     devtool: 'source-map'
 };


### PR DESCRIPTION
New functions will use sdk v3 instead, with individual packages installed per-service.