### PR TITLE
refactor variable for improved typing, drop support for deprecated lookups

### DIFF
--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -598,7 +598,7 @@ A custom lookup must be in an executable, importable python package or standalon
 The lookup must be importable using your current ``sys.path``.
 This takes into account the :attr:`sys_path <cfngin.sys_path>` defined in the config file as well as any ``paths`` of :attr:`package_sources <cfngin.package_sources>`.
 
-The lookup must be a class, preferable with a base class of :class:`~runway.lookups.handlers.base.LookupHandler` with a ``@classmethod`` of handle that accepts four arguments - ``value``, ``context``,  ``provider``, ``**kwargs``.
+The lookup must be a subclass of :class:`~runway.lookups.handlers.base.LookupHandler` with a ``@classmethod`` of handle that accepts four arguments - ``value``, ``context``,  ``provider``, ``**kwargs``.
 There must be only one lookup per file.
 The file containing the lookup class must have a ``TYPE_NAME`` global variable with a value of the name that will be used to register the lookup.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ exclude_lines = [
     "raise AssertionError",  # defensive exceptions
     "raise NotImplimentedError",
     "from pathlib import Path",
+    "@overload",
 ]
 
 

--- a/runway/cfngin/lookups/__init__.py
+++ b/runway/cfngin/lookups/__init__.py
@@ -1,3 +1,5 @@
 """CFNgin lookups."""
 # export resolve_lookups at this level
-from .registry import register_lookup_handler  # noqa
+from .registry import register_lookup_handler, unregister_lookup_handler
+
+__all__ = ["register_lookup_handler", "unregister_lookup_handler"]

--- a/runway/exceptions.py
+++ b/runway/exceptions.py
@@ -76,8 +76,8 @@ class FailedVariableLookup(Exception):
 
     """
 
-    lookup: "Variable"
     cause: FailedLookup
+    variable: "Variable"
 
     def __init__(
         self,

--- a/runway/variables.py
+++ b/runway/variables.py
@@ -3,22 +3,26 @@ from __future__ import annotations
 
 import logging
 import re
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Dict,
+    Generic,
     Iterable,
     Iterator,
     List,
+    MutableMapping,
+    MutableSequence,
     Optional,
     Set,
     Type,
+    TypeVar,
     Union,
     cast,
     overload,
 )
+
+from typing_extensions import Literal
 
 from .cfngin.lookups.registry import CFNGIN_LOOKUP_HANDLERS
 from .exceptions import (
@@ -38,8 +42,10 @@ if TYPE_CHECKING:
     from .context.cfngin import CfnginContext
     from .context.runway import RunwayContext
 
-
 LOGGER = logging.getLogger(__name__)
+
+_LiteralValue = TypeVar("_LiteralValue", int, str)
+VariableTypeLiteralTypeDef = Literal["cfngin", "runway"]
 
 
 class Variable:
@@ -47,9 +53,12 @@ class Variable:
 
     name: str
 
-    _raw_value: Any
-
-    def __init__(self, name: str, value: Any, variable_type: str = "cfngin") -> None:
+    def __init__(
+        self,
+        name: str,
+        value: Any,
+        variable_type: VariableTypeLiteralTypeDef = "cfngin",
+    ) -> None:
         """Initialize class.
 
         Args:
@@ -60,7 +69,8 @@ class Variable:
         """
         self.name = name
         self._raw_value = value
-        self._value = VariableValue.parse(value, variable_type)
+        self._value = VariableValue.parse_obj(value, variable_type)
+        self.variable_type = variable_type
 
     @property
     def dependencies(self) -> Set[str]:
@@ -131,7 +141,7 @@ class Variable:
 
     def __repr__(self) -> str:
         """Return object representation."""
-        return "Variable<{}={}>".format(self.name, self._raw_value)
+        return f"Variable[{self.name}={self._raw_value}]"
 
 
 def resolve_variables(
@@ -151,14 +161,18 @@ def resolve_variables(
         variable.resolve(context=context, provider=provider)
 
 
+_VariableValue = TypeVar("_VariableValue", bound="VariableValue")
+
+
 class VariableValue:
     """Syntax tree base class to parse variable values."""
 
     _resolved: bool = False
-    _value: Any
+    _data: Any
+    variable_type: VariableTypeLiteralTypeDef
 
     @property
-    def dependencies(self) -> Set:
+    def dependencies(self) -> Set[Any]:
         """Stack names that this variable depends on."""
         return set()
 
@@ -217,60 +231,63 @@ class VariableValue:
             value: Resolved value of the variable.
 
         """
-        self._value = value
+        self._data = value
         self._resolved = True
 
     @overload
     @classmethod
-    def parse(  # noqa
-        cls, input_object: Dict[str, Any], variable_type: str = "cfngin"
-    ) -> VariableValueDict:
+    def parse_obj(
+        cls, obj: Dict[str, Any], variable_type: VariableTypeLiteralTypeDef = ...
+    ) -> VariableValue:
         ...
 
     @overload
     @classmethod
-    def parse(  # noqa
-        cls, input_object: List[Any], variable_type: str = "cfngin"
+    def parse_obj(
+        cls, obj: List[Any], variable_type: VariableTypeLiteralTypeDef = ...
     ) -> VariableValueList:
         ...
 
     @overload
     @classmethod
-    def parse(  # noqa
-        cls, input_object: str, variable_type: str = "cfngin"
-    ) -> Union[
-        VariableValueConcatenation, VariableValueLiteral, VariableValueLookup,
+    def parse_obj(
+        cls, obj: int, variable_type: VariableTypeLiteralTypeDef = ...
+    ) -> VariableValueLiteral[int]:
+        ...
+
+    @overload
+    @classmethod
+    def parse_obj(
+        cls, obj: str, variable_type: VariableTypeLiteralTypeDef = ...
+    ) -> VariableValueConcatenation[
+        Union[VariableValueLiteral[str], VariableValueLookup]
     ]:
         ...
 
     @classmethod
-    def parse(
-        cls, input_object: Any, variable_type: str = "cfngin"
-    ) -> Union[
-        VariableValueConcatenation,
-        VariableValueDict,
-        VariableValueList,
-        VariableValueLiteral,
-        VariableValueLookup,
-    ]:
+    def parse_obj(
+        cls, obj: Any, variable_type: VariableTypeLiteralTypeDef = "cfngin"
+    ) -> VariableValue:
         """Parse complex variable structures using type appropriate subclasses.
 
         Args:
-            input_object: The objected defined as the value of a variable.
+            obj: The objected defined as the value of a variable.
             variable_type: Type of variable (cfngin|runway).
 
         """
-        if isinstance(input_object, list):
-            return VariableValueList.parse(input_object, variable_type)
-        if isinstance(input_object, dict):
-            return VariableValueDict.parse(input_object, variable_type)
-        if not isinstance(input_object, str):
-            return VariableValueLiteral(input_object)
+        if isinstance(obj, dict):
+            return VariableValueDict(obj, variable_type=variable_type)  # type: ignore
+        if isinstance(obj, list):
+            return VariableValueList(obj, variable_type=variable_type)  # type: ignore
+        if not isinstance(obj, str):
+            return VariableValueLiteral(obj, variable_type=variable_type)  # type: ignore
 
-        tokens = VariableValueConcatenation(
+        tokens: VariableValueConcatenation[
+            Union[VariableValueLiteral[str], VariableValueLookup]
+        ] = VariableValueConcatenation(
             [
-                VariableValueLiteral(t)
-                for t in re.split(r"(\$\{|\}|\s+)", input_object)  # ${ or space or }
+                VariableValueLiteral(t, variable_type=variable_type)
+                for t in re.split(r"(\$\{|\}|\s+)", obj)  # ${ or space or }
             ]
         )
 
@@ -283,7 +300,6 @@ class VariableValue:
             for i, tok in enumerate(tokens):
                 if not isinstance(tok, VariableValueLiteral):
                     continue
-
                 if tok.value == opener:
                     last_open = i
                     next_close = None
@@ -292,16 +308,17 @@ class VariableValue:
 
             if next_close is not None:
                 lookup_query = VariableValueConcatenation(
-                    tokens[(cast(int, last_open) + len(opener) + 1) : next_close]
+                    tokens[(cast(int, last_open) + len(opener) + 1) : next_close],
+                    variable_type=variable_type,
                 )
                 lookup = VariableValueLookup(
-                    lookup_name=tokens[cast(int, last_open) + 1],
+                    lookup_name=tokens[cast(int, last_open) + 1],  # type: ignore
                     lookup_query=lookup_query,
                     variable_type=variable_type,
                 )
-                tokens[last_open : (next_close + 1)] = [lookup]
+                tokens[last_open : (next_close + 1)] = [lookup]  # type: ignore
             else:
-                break
+                break  # cov: ignore
 
         return tokens.simplified
 
@@ -324,39 +341,118 @@ class VariableValue:
         raise NotImplementedError
 
 
-class VariableValueLiteral(VariableValue):
-    """The literal value of a variable as provided."""
+class VariableValueDict(VariableValue, MutableMapping[str, VariableValue]):
+    """A dict variable value."""
 
-    def __init__(self, value: Any) -> None:
-        """Initialize class."""
-        self._value = value
+    def __init__(
+        self, data: Dict[str, Any], variable_type: VariableTypeLiteralTypeDef = "cfngin"
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            data: Data to be stored in the object.
+            variable_type: Type of variable (cfngin|runway).
+
+        """
+        self._data = {
+            k: self.parse_obj(v, variable_type=variable_type) for k, v in data.items()
+        }
+        self.variable_type = variable_type
+
+    @property
+    def dependencies(self) -> Set[str]:
+        """Stack names that this variable depends on."""
+        deps = set()
+        for item in self.values():  # pylint: disable=no-member
+            deps.update(item.dependencies)
+        return deps
 
     @property
     def resolved(self) -> bool:
-        """Use to check if the variable value has been resolved.
-
-        The ValueLiteral will always appear as resolved because it does
-        not "resolve" since it is the literal definition of the value.
-
-        """
-        return True
+        """Use to check if the variable value has been resolved."""
+        accumulator: bool = True
+        for item in self.values():  # pylint: disable=no-member
+            accumulator = accumulator and item.resolved
+        return accumulator
 
     @property
-    def value(self) -> Any:
-        """Value of the variable."""
-        return self._value
+    def simplified(self) -> Dict[str, Any]:
+        """Return a simplified version of the value.
 
-    def __iter__(self) -> Iterator[Any]:
+        This can be used to concatenate two literals into one literal or
+        flatten nested concatenations.
+
+        """
+        return {k: v.simplified for k, v in self.items()}  # pylint: disable=no-member
+
+    @property
+    def value(self) -> Dict[str, Any]:
+        """Value of the variable. Can be resolved or unresolved."""
+        return {k: v.value for k, v in self.items()}  # pylint: disable=no-member
+
+    def resolve(
+        self,
+        context: Union[CfnginContext, RunwayContext],
+        provider: Optional[BaseProvider] = None,
+        variables: Optional[RunwayVariablesDefinition] = None,
+        **kwargs: Any
+    ) -> None:
+        """Resolve the variable value.
+
+        Args:
+            context: The current context object.
+            provider: Subclass of the base provider.
+            variables: Object containing variables passed to Runway.
+
+        """
+        for item in self.values():  # pylint: disable=no-member
+            item.resolve(context, provider=provider, variables=variables, **kwargs)
+
+    def __delitem__(self, __key: str) -> None:
+        """Delete item by index."""
+        del self._data[__key]
+
+    def __getitem__(self, __key: str) -> VariableValue:
+        """Get item by index."""
+        return self._data[__key]
+
+    def __iter__(self) -> Iterator[str]:
         """How the object is iterated."""
-        yield self
+        yield from iter(self._data)
+
+    def __len__(self) -> int:
+        """Length of the object."""
+        return len(self._data)
 
     def __repr__(self) -> str:
         """Return object representation."""
-        return "Literal<{}>".format(repr(self._value))
+        # pylint: disable=no-member
+        return f"Dict[{', '.join(f'{k}={v}' for k, v in self.items())}]"
+
+    def __setitem__(self, __key: str, __value: VariableValue) -> None:
+        """Set item by index."""
+        self._data[__key] = __value
 
 
-class VariableValueList(VariableValue, list):
-    """A list variable value."""
+class VariableValueList(VariableValue, MutableSequence[VariableValue]):
+    """List variable value."""
+
+    def __init__(
+        self,
+        iterable: Iterable[Any],
+        variable_type: VariableTypeLiteralTypeDef = "cfngin",
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            iterable: Data to store in the iterable.
+            variable_type: Type of variable (cfngin|runway).
+
+        """
+        self._data: List[VariableValue] = [
+            self.parse_obj(i, variable_type=variable_type) for i in iterable
+        ]
+        self.variable_type = variable_type
 
     @property
     def dependencies(self) -> Set[str]:
@@ -369,7 +465,7 @@ class VariableValueList(VariableValue, list):
     @property
     def resolved(self) -> bool:
         """Use to check if the variable value has been resolved."""
-        accumulator = True
+        accumulator: bool = True
         for item in self:
             accumulator = accumulator and item.resolved
         return accumulator
@@ -389,6 +485,10 @@ class VariableValueList(VariableValue, list):
         """Value of the variable. Can be resolved or unresolved."""
         return [item.value for item in self]
 
+    def insert(self, index: int, value: VariableValue) -> None:
+        """Insert a value at a specific index."""
+        self._data.insert(index, value)
+
     def resolve(
         self,
         context: Union[CfnginContext, RunwayContext],
@@ -407,160 +507,143 @@ class VariableValueList(VariableValue, list):
         for item in self:
             item.resolve(context, provider=provider, variables=variables, **kwargs)
 
-    @classmethod
-    def parse(
-        cls, input_object: Iterable[Any], variable_type: str = "cfngin"
-    ) -> "VariableValueList":
-        """Parse list variable structure.
+    def __delitem__(self, __index: int) -> None:
+        """Delete item by index."""
+        del self._data[__index]
+
+    @overload
+    def __getitem__(self, __index: int) -> VariableValue:
+        ...
+
+    @overload
+    def __getitem__(self, __index: slice) -> List[VariableValue]:
+        ...
+
+    def __getitem__(self, __index: int) -> VariableValue:
+        """Get item by index."""
+        return self._data[__index]
+
+    @overload
+    def __setitem__(self, __index: int, __value: List[VariableValue]) -> None:
+        ...
+
+    @overload
+    def __setitem__(self, __index: slice, __value: List[VariableValue]) -> None:
+        ...
+
+    def __setitem__(self, __index: int, __value: VariableValue) -> None:
+        """Set item by index."""
+        self._data[__index] = __value
+
+    def __iter__(self) -> Iterator[VariableValue]:
+        """Object iteration."""
+        yield from iter(self._data)
+
+    def __len__(self) -> int:
+        """Length of the object."""
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        """Object string representation."""
+        return f"List[{', '.join(repr(i) for i in self._data)}]"
+
+
+class VariableValueLiteral(Generic[_LiteralValue], VariableValue):
+    """The literal value of a variable as provided."""
+
+    def __init__(
+        self, value: _LiteralValue, variable_type: VariableTypeLiteralTypeDef = "cfngin"
+    ) -> None:
+        """Instantiate class.
 
         Args:
-            input_object: The objected defined as the value of a variable.
+            value: Data to store in the object.
             variable_type: Type of variable (cfngin|runway).
 
         """
-        acc = [VariableValue.parse(obj, variable_type) for obj in input_object]
-        return cls(acc)
+        self._data = value
+        self.variable_type = variable_type
+
+    @property
+    def resolved(self) -> bool:
+        """Use to check if the variable value has been resolved.
+
+        The ValueLiteral will always appear as resolved because it does
+        not "resolve" since it is the literal definition of the value.
+
+        """
+        return True
+
+    @property
+    def value(self) -> _LiteralValue:
+        """Value of the variable."""
+        return self._data
 
     def __iter__(self) -> Iterator[Any]:
         """How the object is iterated."""
-        yield from list.__iter__(self)
+        yield self
 
     def __repr__(self) -> str:
         """Return object representation."""
-        return "List[{}]".format(", ".join(repr(value) for value in self))
+        return f"Literal[{self._data}]"
 
 
-class VariableValueDict(VariableValue, dict):
-    """A dict variable value."""
+class VariableValueConcatenation(Generic[_VariableValue], VariableValue):
+    """A concatinated variable values."""
+
+    def __init__(
+        self,
+        iterable: Iterable[_VariableValue],
+        variable_type: VariableTypeLiteralTypeDef = "cfngin",
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            iterable: Data to store in the iterable.
+            variable_type: Type of variable (cfngin|runway).
+
+        """
+        self._data = list(iterable)
+        self.variable_type = variable_type
 
     @property
     def dependencies(self) -> Set[str]:
         """Stack names that this variable depends on."""
         deps = set()
-        for item in self.values():
+        for item in self:
             deps.update(item.dependencies)
         return deps
 
     @property
     def resolved(self) -> bool:
         """Use to check if the variable value has been resolved."""
-        accumulator = True
-        for item in self.values():
+        accumulator: bool = True
+        for item in self:
             accumulator = accumulator and item.resolved
         return accumulator
 
     @property
-    def simplified(self) -> Dict[str, Any]:
+    def simplified(self) -> VariableValue:
         """Return a simplified version of the value.
 
-        This can be used to concatenate two literals into one literal or
-        flatten nested concatenations.
+        This can be used to concatenate two literals into one literal or flatten
+        nested concatentations.
 
         """
-        return {k: v.simplified for k, v in self.items()}
-
-    @property
-    def value(self) -> Dict[str, Any]:
-        """Value of the variable. Can be resolved or unresolved."""
-        return {k: v.value for k, v in self.items()}
-
-    def resolve(
-        self,
-        context: Union[CfnginContext, RunwayContext],
-        provider: Optional[BaseProvider] = None,
-        variables: Optional[RunwayVariablesDefinition] = None,
-        **kwargs: Any
-    ) -> None:
-        """Resolve the variable value.
-
-        Args:
-            context: The current context object.
-            provider: Subclass of the base provider.
-            variables: Object containing variables passed to Runway.
-
-        """
-        for item in self.values():
-            item.resolve(context, provider=provider, variables=variables, **kwargs)
-
-    @classmethod
-    def parse(
-        cls, input_object: Any, variable_type: str = "cfngin"
-    ) -> "VariableValueDict":
-        """Parse list variable structure.
-
-        Args:
-            input_object: The objected defined as the value of a variable.
-            variable_type: Type of variable (cfngin|runway).
-
-        """
-        acc = {
-            k: VariableValue.parse(v, variable_type) for k, v in input_object.items()
-        }
-        return cls(acc)
-
-    def __iter__(self) -> Iterator[Any]:
-        """How the object is iterated."""
-        yield from dict.__iter__(self)
-
-    def __repr__(self) -> str:
-        """Return object representation."""
-        return "Dict[{}]".format(
-            ", ".join("{}={}".format(k, repr(v)) for k, v in self.items())
-        )
-
-
-class VariableValueConcatenation(VariableValue, list):
-    """A concatinated variable value."""
-
-    @property
-    def dependencies(self) -> Set[str]:
-        """Stack names that this variable depends on."""
-        deps = set()
-        for item in self:
-            deps.update(item.dependencies)
-        return deps
-
-    @property
-    def resolved(self) -> bool:
-        """Use to check if the variable value has been resolved."""
-        accumulator = True
-        for item in self:
-            accumulator = bool(accumulator and item.resolved)
-        return accumulator
-
-    @property
-    def simplified(
-        self,
-    ) -> Union[
-        VariableValueConcatenation, VariableValueLiteral, VariableValueLookup,
-    ]:
-        """Return a simplified version of the value.
-
-        This can be used to concatenate two literals into one literal or
-        flatten nested concatenations.
-
-        """
-        concat: List[
-            Union[
-                VariableValueConcatenation, VariableValueLiteral, VariableValueLookup,
-            ]
-        ] = []
+        concat: List[VariableValue] = []
         for item in self:
             if isinstance(item, VariableValueLiteral) and item.value == "":
                 pass
-
             elif (
                 isinstance(item, VariableValueLiteral)
                 and concat
                 and isinstance(concat[-1], VariableValueLiteral)
             ):
-                # join the literals together
-                concat[-1] = VariableValueLiteral(concat[-1].value + item.value)
-
-            elif isinstance(item, VariableValueConcatenation):
-                # flatten concatenations
-                concat.extend(item.simplified.__iter__())
-
+                concat[-1] = VariableValueLiteral(
+                    str(concat[-1].value) + str(item.value)  # type: ignore
+                )
+            elif isinstance(item, VariableValueConcatenation):  # type: ignore
+                concat.extend(iter(item.simplified))
             else:
                 concat.append(item.simplified)
 
@@ -607,35 +690,62 @@ class VariableValueConcatenation(VariableValue, list):
         for value in self:
             value.resolve(context, provider=provider, variables=variables, **kwargs)
 
-    def __iter__(
-        self,
-    ) -> Iterator[
-        Union[VariableValueConcatenation, VariableValueLiteral, VariableValueLookup]
-    ]:
-        """How the object is iterated."""
-        yield from list.__iter__(self)
+    def __delitem__(self, __index: int) -> None:
+        """Delete item by index."""
+        del self._data[__index]
+
+    @overload
+    def __getitem__(self, __index: int) -> _VariableValue:
+        ...
+
+    @overload
+    def __getitem__(self, __index: slice) -> List[_VariableValue]:
+        ...
+
+    def __getitem__(self, __index: int) -> _VariableValue:
+        """Get item by index."""
+        return self._data[__index]
+
+    @overload
+    def __setitem__(self, __index: int, __value: _VariableValue) -> None:
+        ...
+
+    @overload
+    def __setitem__(self, __index: slice, __value: List[_VariableValue]) -> None:
+        ...
+
+    def __setitem__(self, __index: int, __value: _VariableValue) -> None:
+        """Set item by index."""
+        self._data[__index] = __value
+
+    def __iter__(self) -> Iterator[_VariableValue]:
+        """Object iteration."""
+        yield from iter(self._data)
+
+    def __len__(self) -> int:
+        """Length of the object."""
+        return len(self._data)
 
     def __repr__(self) -> str:
         """Return object representation."""
-        return "Concatenation[{}]".format(", ".join(repr(value) for value in self))
+        return f"Concatenation[{', '.join(repr(v) for v in self)}]"
 
 
 class VariableValueLookup(VariableValue):
     """A lookup variable value."""
 
-    handler: Union[Callable[..., Any], Type[LookupHandler]]
-    lookup_name: VariableValueLiteral
+    handler: Type[LookupHandler]
+    lookup_name: VariableValueLiteral[str]
     lookup_query: VariableValue
 
     _resolved: bool
-    _value: Any
 
     def __init__(
         self,
-        lookup_name: VariableValueLiteral,
+        lookup_name: VariableValueLiteral[str],
         lookup_query: Union[str, VariableValue],
-        handler: Optional[Union[Callable[..., Any], Type[LookupHandler]]] = None,
-        variable_type: str = "cfngin",
+        handler: Optional[Type[LookupHandler]] = None,
+        variable_type: VariableTypeLiteralTypeDef = "cfngin",
     ) -> None:
         """Initialize class.
 
@@ -651,16 +761,17 @@ class VariableValueLookup(VariableValue):
 
         """
         self._resolved = False
-        self._value = None
+        self._data = None
 
         self.lookup_name = lookup_name
+        self.variable_type = variable_type
 
         if isinstance(lookup_query, str):
             lookup_query = VariableValueLiteral(lookup_query)
         self.lookup_query = lookup_query
 
         if handler is None:
-            lookup_name_resolved = cast(str, lookup_name.value)
+            lookup_name_resolved = lookup_name.value
             try:
                 if variable_type == "cfngin":
                     handler = CFNGIN_LOOKUP_HANDLERS[lookup_name_resolved]
@@ -677,9 +788,7 @@ class VariableValueLookup(VariableValue):
     @property
     def dependencies(self) -> Set[str]:
         """Stack names that this variable depends on."""
-        if not isinstance(self.handler, FunctionType) and hasattr(
-            self.handler, "dependencies"
-        ):
+        if hasattr(self.handler, "dependencies"):
             return self.handler.dependencies(self.lookup_query)
         return set()
 
@@ -707,7 +816,7 @@ class VariableValueLookup(VariableValue):
 
         """
         if self._resolved:
-            return self._value
+            return self._data
         raise UnresolvedVariableValue(self)
 
     def resolve(
@@ -729,73 +838,19 @@ class VariableValueLookup(VariableValue):
 
         """
         self.lookup_query.resolve(
-            context, provider=provider, variables=variables, **kwargs
+            context=context, provider=provider, variables=variables, **kwargs
         )
         try:
-            if not isinstance(self.handler, FunctionType):
-                result = self.handler.handle(
-                    self.lookup_query.value,
-                    context=context,
-                    provider=provider,
-                    variables=variables,
-                    **kwargs
-                )
-            else:
-                result = self._resolve_legacy(context=context, provider=provider)
+            result = self.handler.handle(
+                self.lookup_query.value,
+                context=context,
+                provider=provider,
+                variables=variables,
+                **kwargs
+            )
             return self._resolve(result)
         except Exception as err:
-            if isinstance(err, TypeError):
-                # handle lookups that don't accept all the args we want
-                # to pass to it
-                LOGGER.debug(
-                    "encountered %s: %s - trying legacy resolver", type(err), err
-                )
-                try:
-                    return self._resolve(
-                        self._resolve_legacy(context=context, provider=provider)
-                    )
-                except Exception as err2:
-                    raise FailedLookup(self, err2) from err2
             raise FailedLookup(self, err) from err
-
-    def _resolve(self, value: Any) -> None:
-        """Set _value and _resolved from the result of resolve().
-
-        Args:
-            value: Resolved value of the variable.
-
-        """
-        self._value = value
-        self._resolved = True
-
-    # TODO Remove during the next major release.
-    def _resolve_legacy(
-        self,
-        context: Union[CfnginContext, RunwayContext],
-        provider: Optional[BaseProvider],
-    ) -> Any:
-        """Resolve legacy lookups.
-
-        Stacker style custom lookups only take 3 args (value, provider,
-        context). In combining CFNgin and Runway Variable/LookupHandler classes
-        we need to be able to pass more arguments. The built-in lookups have
-        been updated but, any custom lookups designed for Stacker would fail
-        when trying to pass the arguments that now get passed. That is where
-        this method comes it. It can handle legacy Stacker function lookups
-        and those that don't support accept more then 3 args.
-
-        """
-        if not isinstance(self.handler, FunctionType):
-            LOGGER.warning(
-                "Old style lookup in use. Please upgrade to use "
-                'the new style of Lookups that accepts "**kwargs".'
-            )
-            return self.handler.handle(
-                value=self.lookup_query.value, context=context, provider=provider
-            )
-        return self.handler(
-            value=self.lookup_query.value, context=context, provider=provider
-        )
 
     def __iter__(self) -> Iterator[VariableValueLookup]:
         """How the object is iterated."""
@@ -804,13 +859,11 @@ class VariableValueLookup(VariableValue):
     def __repr__(self) -> str:
         """Return object representation."""
         if self._resolved:
-            return "Lookup<{r} ({t} {d})>".format(
-                r=self._value, t=self.lookup_name, d=repr(self.lookup_query),
+            return (
+                f"Lookup[{self._data} ({self.lookup_name} {repr(self.lookup_query)})]"
             )
-        return "Lookup<{t} {d}>".format(t=self.lookup_name, d=repr(self.lookup_query),)
+        return f"Lookup[{self.lookup_name} {repr(self.lookup_query)}]"
 
     def __str__(self) -> str:
         """Object displayed as a string."""
-        return "${{{type} {data}}}".format(
-            type=self.lookup_name.value, data=self.lookup_query.value,
-        )
+        return f"${{{self.lookup_name.value} {self.lookup_query.value}}}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,4 +36,5 @@ extend-ignore =
     E203,
     # line break before operator
     W503
+ignore-decorators = overload
 max-line-length = 98

--- a/tests/unit/cfngin/test_plan.py
+++ b/tests/unit/cfngin/test_plan.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 import mock
 
@@ -28,6 +28,7 @@ from runway.cfngin.status import COMPLETE, FAILED, SKIPPED, SUBMITTED
 from runway.cfngin.util import stack_template_key_name
 from runway.config import CfnginConfig
 from runway.context.cfngin import CfnginContext
+from runway.lookups.handlers.base import LookupHandler
 
 from .factories import generate_definition, mock_context
 
@@ -149,7 +150,16 @@ class TestPlan(unittest.TestCase):
         self.count = 0
         self.config = CfnginConfig.parse_obj({"namespace": "namespace"})
         self.context = CfnginContext(config=self.config)
-        register_lookup_handler("noop", lambda **kwargs: "test")
+
+        class FakeLookup(LookupHandler):
+            """False Lookup."""
+
+            @classmethod
+            def handle(cls, value: str, *__args: Any, **__kwargs: Any) -> str:  # type: ignore
+                """Perform the lookup."""
+                return "test"
+
+        register_lookup_handler("noop", FakeLookup)
 
     def tearDown(self) -> None:
         """Run after tests."""

--- a/tests/unit/test_variables.py
+++ b/tests/unit/test_variables.py
@@ -1,282 +1,883 @@
-"""Tests for variables."""
-# pylint: disable=protected-access,unused-argument
+"""Tests for runway.variables."""
+# pylint: disable=expression-not-assigned,no-self-use,protected-access,unused-argument
 from __future__ import annotations
 
-from typing import Any, cast
-from unittest import TestCase
+from typing import TYPE_CHECKING, Any, ClassVar, List, Union
 
-from mock import MagicMock
-from troposphere import s3
+import pytest
+from mock import MagicMock, call
 
-from runway.cfngin.blueprints.variables.types import TroposphereType
-from runway.cfngin.lookups import register_lookup_handler
-from runway.cfngin.providers.aws.default import Provider
-from runway.cfngin.stack import Stack
 from runway.context import CfnginContext, RunwayContext
-from runway.core.components import DeployEnvironment
-from runway.exceptions import UnresolvedVariable
-from runway.variables import Variable
-
-from .cfngin.factories import generate_definition
-
-VALUE = {
-    "test": "success",
-    "what": "test",
-    "bool_val": False,
-    "dict_val": {"test": "success"},
-    "list_val": ["success"],
-}
-CONTEXT = cast(
-    RunwayContext,
-    MagicMock(
-        autospec=RunwayContext, env=MagicMock(autospec=DeployEnvironment, vars=VALUE)
-    ),
+from runway.exceptions import (
+    FailedLookup,
+    FailedVariableLookup,
+    InvalidLookupConcatenation,
+    UnknownLookupType,
+    UnresolvedVariable,
+    UnresolvedVariableValue,
+)
+from runway.lookups.handlers.base import LookupHandler
+from runway.variables import (
+    CFNGIN_LOOKUP_HANDLERS,
+    RUNWAY_LOOKUP_HANDLERS,
+    Variable,
+    VariableTypeLiteralTypeDef,
+    VariableValue,
+    VariableValueConcatenation,
+    VariableValueDict,
+    VariableValueList,
+    VariableValueLiteral,
+    VariableValueLookup,
+    resolve_variables,
 )
 
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
-class TestCfnginVariables(TestCase):
-    """Tests for runway.cfngin.variables."""
+    from .factories import MockCFNginContext
 
-    def setUp(self) -> None:
-        """Run before tests."""
-        self.provider = cast(Provider, MagicMock(autospec=Provider))
-        self.context = cast(CfnginContext, MagicMock(autospec=CfnginContext))
 
-    def test_variable_replace_no_lookups(self) -> None:
-        """Test variable replace no lookups."""
-        var = Variable("Param1", "2")
-        self.assertEqual(var.value, "2")
+class MockLookupHandler(LookupHandler):
+    """Mock lookup handler."""
 
-    def test_variable_replace_simple_lookup(self) -> None:
-        """Test variable replace simple lookup."""
-        var = Variable("Param1", "${output fakeStack::FakeOutput}")
-        var._value._resolve("resolved")
-        self.assertEqual(var.value, "resolved")
+    return_value: ClassVar[Any] = "resolved"
+    side_effect: ClassVar[Union[Any, List[Any]]] = None
 
-    def test_variable_resolve_simple_lookup(self) -> None:
-        """Test variable resolve simple lookup."""
-        stack = Stack(definition=generate_definition("vpc", 1), context=self.context)
-        stack.set_outputs({"FakeOutput": "resolved", "FakeOutput2": "resolved2"})
+    @classmethod
+    def handle(
+        cls,
+        value: str,
+        context: Union[CfnginContext, RunwayContext],
+        *__args: Any,
+        **__kwargs: Any
+    ) -> Any:
+        """Perform the lookup."""
+        if cls.side_effect is None:
+            return cls.return_value
+        if isinstance(cls.side_effect, list):
+            return cls._handle_side_effect(cls.side_effect.pop(0))
+        return cls._handle_side_effect(cls.side_effect)
 
-        self.context.get_stack.return_value = stack
+    @classmethod
+    def _handle_side_effect(cls, side_effect: Any):
+        """Handle side_effect."""
+        if isinstance(side_effect, BaseException):
+            raise side_effect
+        return side_effect
 
-        var = Variable("Param1", "${output fakeStack::FakeOutput}")
-        var.resolve(self.context, self.provider)
-        self.assertTrue(var.resolved)
-        self.assertEqual(var.value, "resolved")
 
-    def test_variable_resolve_default_lookup_empty(self) -> None:
-        """Test variable resolve default lookup empty."""
-        var = Variable("Param1", "${default fakeStack::}")
-        var.resolve(self.context, self.provider)
-        self.assertTrue(var.resolved)
-        self.assertEqual(var.value, "")
+@pytest.fixture(autouse=True, scope="function")
+def patch_lookups(mocker: MockerFixture) -> None:
+    """Patch registered lookups."""
+    for registry in [CFNGIN_LOOKUP_HANDLERS, RUNWAY_LOOKUP_HANDLERS]:
+        # mocked = {k: MockLookupHandler for k in registry}
+        # mocked["test"] = MockLookupHandler
+        # mocker.patch.dict(registry, mocked)
+        mocker.patch.dict(registry, {"test": MockLookupHandler})
 
-    def test_variable_replace_multiple_lookups_string(self) -> None:
-        """Test variable replace multiple lookups string."""
-        var = Variable(
-            "Param1",
-            "url://"  # 0
-            "${output fakeStack::FakeOutput}"  # 1
-            "@"  # 2
-            "${output fakeStack::FakeOutput2}",  # 3
+
+def test_resolve_variables(cfngin_context: MockCFNginContext) -> None:
+    """Test resolve_variables."""
+    variable = MagicMock()
+    assert not resolve_variables([variable], cfngin_context)
+    variable.resolve.assert_called_once_with(context=cfngin_context, provider=None)
+
+
+class TestVariables:
+    """Test runway.variables.Variables."""
+
+    def test_dependencies(self, mocker: MockerFixture) -> None:
+        """Test dependencies."""
+        assert Variable("Param", "val").dependencies == set()
+        mocker.patch.object(
+            VariableValue, "parse_obj", return_value=MagicMock(dependencies={"test"})
         )
-        var._value[1]._resolve("resolved")
-        var._value[3]._resolve("resolved2")
-        self.assertEqual(var.value, "url://resolved@resolved2")
+        assert Variable("Param", "val").dependencies == {"test"}
 
-    def test_variable_resolve_multiple_lookups_string(self) -> None:
-        """Test variable resolve multiple lookups string."""
-        var = Variable(
-            "Param1",
-            "url://${output fakeStack::FakeOutput}@" "${output fakeStack::FakeOutput2}",
+    def test_get(self, mocker: MockerFixture) -> None:
+        """Test get."""
+        obj = Variable("Para", {"key": "val"})
+        assert obj.get("missing") is None
+        assert obj.get("missing", "default") == "default"
+
+    @pytest.mark.parametrize("variable_type", ["cfngin", "runway"])
+    def test_init(self, variable_type: VariableTypeLiteralTypeDef) -> None:
+        """Test __init__."""
+        obj = Variable("Param", "val", variable_type)
+        assert obj.name == "Param"
+        assert obj.variable_type == variable_type
+        assert obj._raw_value == "val"
+        assert obj._value.value == "val"
+        assert obj._value.variable_type == variable_type
+
+    def test_multiple_lookup_dict(self, mocker: MockerFixture) -> None:
+        """Test multiple lookup dict."""
+        mocker.patch.object(
+            MockLookupHandler, "side_effect", ["resolved0", "resolved1"]
         )
+        value = {
+            "something": "${test query0}",
+            "other": "${test query1}",
+        }
+        var = Variable("Param1", value)
+        assert isinstance(var._value, VariableValueDict)
+        var.resolve(MagicMock(), MagicMock())
+        assert var.value == {"something": "resolved0", "other": "resolved1"}
 
-        stack = Stack(definition=generate_definition("vpc", 1), context=self.context)
-        stack.set_outputs({"FakeOutput": "resolved", "FakeOutput2": "resolved2"})
-
-        self.context.get_stack.return_value = stack
-        var.resolve(self.context, self.provider)
-        self.assertTrue(var.resolved)
-        self.assertEqual(var.value, "url://resolved@resolved2")
-
-    def test_variable_replace_no_lookups_list(self) -> None:
-        """Test variable replace no lookups list."""
-        var = Variable("Param1", ["something", "here"])
-        self.assertEqual(var.value, ["something", "here"])
-
-    def test_variable_replace_lookups_list(self) -> None:
-        """Test variable replace lookups list."""
+    def test_multiple_lookup_list(self, mocker: MockerFixture) -> None:
+        """Test multiple lookup list."""
+        mocker.patch.object(
+            MockLookupHandler, "side_effect", ["resolved0", "resolved1"]
+        )
         value = [
-            "something",  # 0
-            "${output fakeStack::FakeOutput}",  # 1
-            "${output fakeStack::FakeOutput2}",  # 2
+            "something",
+            "${test query0}",
+            "${test query1}",
         ]
         var = Variable("Param1", value)
+        assert isinstance(var._value, VariableValueList)
+        var.resolve(MagicMock(), MagicMock())
+        assert var.value == ["something", "resolved0", "resolved1"]
 
-        var._value[1]._resolve("resolved")
-        var._value[2]._resolve("resolved2")
-        self.assertEqual(var.value, ["something", "resolved", "resolved2"])
-
-    def test_variable_replace_lookups_dict(self) -> None:
-        """Test variable replace lookups dict."""
+    def test_multiple_lookup_mixed(self) -> None:
+        """Test multiple lookup mixed."""
         value = {
-            "something": "${output fakeStack::FakeOutput}",
-            "other": "${output fakeStack::FakeOutput2}",
-        }
-        var = Variable("Param1", value)
-        var._value["something"]._resolve("resolved")
-        var._value["other"]._resolve("resolved2")
-        self.assertEqual(var.value, {"something": "resolved", "other": "resolved2"})
-
-    def test_variable_replace_lookups_mixed(self) -> None:
-        """Test variable replace lookups mixed."""
-        value = {
-            "something": ["${output fakeStack::FakeOutput}", "other"],
+            "something": ["${test query}", "other"],
             "here": {
-                "other": "${output fakeStack::FakeOutput2}",
-                "same": "${output fakeStack::FakeOutput}",
-                "mixed": "something:${output fakeStack::FakeOutput3}",
+                "other": "${test query}",
+                "same": "${test query}",
+                "mixed": "something:${test query}",
             },
         }
         var = Variable("Param1", value)
-        var._value["something"][0]._resolve("resolved")
-        var._value["here"]["other"]._resolve("resolved2")
-        var._value["here"]["same"]._resolve("resolved")
-        var._value["here"]["mixed"][1]._resolve("resolved3")
-        self.assertEqual(
-            var.value,
-            {
-                "something": ["resolved", "other"],
-                "here": {
-                    "other": "resolved2",
-                    "same": "resolved",
-                    "mixed": "something:resolved3",
-                },
+        assert isinstance(var._value, VariableValueDict)
+        var.resolve(MagicMock(), MagicMock())
+        assert var.value == {
+            "something": ["resolved", "other"],
+            "here": {
+                "other": "resolved",
+                "same": "resolved",
+                "mixed": "something:resolved",
             },
+        }
+
+    def test_multiple_lookup_string(self, mocker: MockerFixture) -> None:
+        """Test multiple lookup string."""
+        var = Variable("Param1", "url://${test query0}@${test query1}")
+        assert isinstance(var._value, VariableValueConcatenation)
+        mocker.patch.object(
+            MockLookupHandler, "side_effect", ["resolved0", "resolved1"]
+        )
+        var.resolve(MagicMock(), MagicMock())
+        assert var.resolved is True
+        assert var.value == "url://resolved0@resolved1"
+
+    def test_nested_lookups(self, mocker: MockerFixture) -> None:
+        """Test nested lookups."""
+        context = MagicMock()
+        provider = MagicMock()
+        mock_handler = mocker.patch.object(
+            MockLookupHandler, "handle", side_effect=["resolved0", "resolved1"]
+        )
+        var = Variable("Param1", "${test ${test query0}.query1}")
+        var.resolve(context, provider)
+        mock_handler.assert_has_calls(
+            [  # type: ignore
+                call("query0", context=context, provider=provider, variables=None),
+                call(
+                    "resolved0.query1",
+                    context=context,
+                    provider=provider,
+                    variables=None,
+                ),
+            ]
+        )
+        assert var.value == "resolved1"
+
+    def test_no_lookup_list(self) -> None:
+        """Test no lookup list."""
+        var = Variable("Param1", ["something", "here"])
+        assert isinstance(var._value, VariableValueList)
+        assert var.value == ["something", "here"]
+
+    def test_no_lookup_str(self) -> None:
+        """Test no lookup str."""
+        var = Variable("Param1", "2")
+        assert isinstance(var._value, VariableValueLiteral)
+        assert var.value == "2"
+
+    @pytest.mark.parametrize("resolved", [False, True])
+    def test_resolved(self, mocker: MockerFixture, resolved: bool) -> None:
+        """Test resolved."""
+        mocker.patch.object(
+            VariableValue, "parse_obj", return_value=MagicMock(resolved=resolved)
+        )
+        assert Variable("Param", "val").resolved is resolved
+
+    def test_resolve_failed(self, mocker: MockerFixture) -> None:
+        """Test resolve FailedLookup."""
+        context = MagicMock()
+        provider = MagicMock()
+        obj = Variable("Param", "val")
+        lookup_error = FailedLookup("something", KeyError("cause"))  # type: ignore
+        mocker.patch.object(obj._value, "resolve", side_effect=lookup_error)
+        with pytest.raises(FailedVariableLookup) as excinfo:
+            obj.resolve(context, provider, kwarg="something")
+        assert excinfo.value.cause == lookup_error
+        assert excinfo.value.variable == obj
+
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        assert repr(Variable("Param", "val")) == "Variable[Param=val]"
+
+    def test_resolve(self, mocker: MockerFixture) -> None:
+        """Test resolve."""
+        context = MagicMock()
+        provider = MagicMock()
+        obj = Variable("Param", "val")
+        mock_resolve = mocker.patch.object(obj._value, "resolve")
+        assert not obj.resolve(context, provider, kwarg="something")
+        mock_resolve.assert_called_once_with(
+            context, provider=provider, variables=None, kwarg="something"
         )
 
-    def test_variable_resolve_nested_lookup(self) -> None:
-        """Test variable resolve nested lookup."""
-        stack = Stack(definition=generate_definition("vpc", 1), context=self.context)
-        stack.set_outputs({"FakeOutput": "resolved", "FakeOutput2": "resolved2"})
+    def test_simple_lookup(self) -> None:
+        """Test simple lookup."""
+        var = Variable("Param1", "${test query}")
+        assert isinstance(var._value, VariableValueLookup)
+        var.resolve(MagicMock(), MagicMock())
+        assert var.resolved is True
+        assert var.value == "resolved"
 
-        def mock_handler(value: str, **_: Any) -> str:
-            return "looked up: {}".format(value)
-
-        register_lookup_handler("lookup", mock_handler)
-        self.context.get_stack.return_value = stack
-        var = Variable("Param1", "${lookup ${lookup ${output fakeStack::FakeOutput}}}",)
-        var.resolve(self.context, self.provider)
-        self.assertTrue(var.resolved)
-        self.assertEqual(var.value, "looked up: looked up: resolved")
-
-    def test_troposphere_type_no_from_dict(self) -> None:
-        """Test troposphere type no from dict."""
-        with self.assertRaises(ValueError):
-            TroposphereType(object)  # type: ignore
-
-        with self.assertRaises(ValueError):
-            TroposphereType(object, many=True)  # type: ignore
-
-    def test_troposphere_type_create(self) -> None:
-        """Test troposphere type create."""
-        troposphere_type = TroposphereType(s3.Bucket)
-        created = troposphere_type.create({"MyBucket": {"BucketName": "test-bucket"}})
-        self.assertTrue(isinstance(created, s3.Bucket))
-        self.assertTrue(created.properties["BucketName"], "test-bucket")
-
-    def test_troposphere_type_create_multiple(self) -> None:
-        """Test troposphere type create multiple."""
-        troposphere_type = TroposphereType(s3.Bucket, many=True)
-        created = troposphere_type.create(
-            {
-                "FirstBucket": {"BucketName": "test-bucket"},
-                "SecondBucket": {"BucketName": "other-test-bucket"},
-            }
-        )
-        self.assertTrue(isinstance(created, list))
-
-
-class TestRunwayVariables(TestCase):
-    """Test for variable resolution."""
-
-    def test_value_simple_str(self) -> None:
-        """Test value for a simple string without lookups."""
-        var = Variable("test", "success")
-
-        self.assertTrue(
-            var.resolved,
-            msg="when no lookup is used, it should "
-            "be automatically marked as resolved",
-        )
-        self.assertEqual(var.value, "success")
-
-    def test_value_simple_str_lookup(self) -> None:
-        """Test value for simple str lookup."""
-        var = Variable("test", "${env test}", "runway")
-
-        self.assertFalse(var.resolved)
-
-        var.resolve(CONTEXT)
-
-        self.assertTrue(var.resolved)
-        self.assertEqual(var.value, VALUE["test"])
-
-    def test_value_complex_str(self) -> None:
-        """Multiple lookups should be usable within a single string."""
-        var = Variable("test", "the ${env what} was ${env test}ful", "runway")
-        var.resolve(CONTEXT)
-
-        self.assertEqual(
-            var.value, "the {} was {}ful".format(VALUE["what"], VALUE["test"])
+    def test_value_unresolved(self, mocker: MockerFixture):
+        """Test value UnresolvedVariable."""
+        mocker.patch.object(
+            VariableValue, "parse_obj", return_value=MagicMock(value="value")
         )
 
-    def test_value_nested_str(self) -> None:
-        """Variable lookups should be resolvable within each other."""
-        var = Variable("test", "${env ${env what}}", "runway")
-        var.resolve(CONTEXT)
+    def test_value(self) -> None:
+        """Test value."""
+        with pytest.raises(UnresolvedVariable):
+            Variable("Param", "${test query}").value
 
-        self.assertEqual(var.value, VALUE["test"])
 
-    def test_value_lookup_in_dict(self) -> None:
-        """Variable lookups should be resolvable when used in a dict."""
-        var = Variable("test", {"my_dict": "${env test}"}, "runway")
-        var.resolve(CONTEXT)
+class TestVariableValue:
+    """Test runway.variables.VariableValue."""
 
-        self.assertEqual(var.value, {"my_dict": VALUE["test"]})
+    def test_dependencies(self) -> None:
+        """Test dependencies."""
+        obj = VariableValue()
+        assert obj.dependencies == set()
 
-    def test_value_lookup_in_list(self) -> None:
-        """Variable lookups should be resolvable when used in a list."""
-        var = Variable("test", ["${env test}"], "runway")
-        var.resolve(CONTEXT)
+    def test_iter(self) -> None:
+        """Test __iter__."""
+        with pytest.raises(NotImplementedError):
+            iter(VariableValue())
 
-        self.assertEqual(var.value, [VALUE["test"]])
+    def test_parse_obj_dict_empty(self) -> None:
+        """Test parse_obj dict empty."""
+        assert isinstance(VariableValue.parse_obj({}), VariableValueDict)
 
-    def test_value_lookup_to_bool(self) -> None:
-        """Variable lookups should be resolvable to a bool."""
-        var = Variable("test", "${env bool_val}", "runway")
-        var.resolve(CONTEXT)
+    def test_parse_obj_list_empty(self) -> None:
+        """Test parse_obj list empty."""
+        assert isinstance(VariableValue.parse_obj([]), VariableValueList)
 
-        self.assertFalse(var.value)
+    @pytest.mark.parametrize("value", [False, True])
+    def test_parse_obj_literal_bool(self, value: bool) -> None:
+        """Test parse_obj literal bool."""
+        obj = VariableValue.parse_obj(value)
+        assert isinstance(obj, VariableValueLiteral)
+        assert obj.value is value
 
-    def test_value_lookup_to_dict(self) -> None:
-        """Variable lookups should be resolvable to a dict value."""
-        var = Variable("test", "${env dict_val}", "runway")
-        var.resolve(CONTEXT)
+    def test_parse_obj_literal_int(self) -> None:
+        """Test parse_obj literal int."""
+        obj = VariableValue.parse_obj(13)
+        assert isinstance(obj, VariableValueLiteral)
+        assert obj.value == 13
 
-        self.assertEqual(var.value, VALUE["dict_val"])
+    def test_parse_obj_literal_str(self) -> None:
+        """Test parse_obj literal str."""
+        obj = VariableValue.parse_obj("test")
+        assert obj.value == "test"
+        assert isinstance(obj, VariableValueLiteral)
 
-    def test_value_lookup_to_list(self) -> None:
-        """Variable lookups should be resolvable to a list value."""
-        var = Variable("test", "${env list_val}", "runway")
-        var.resolve(CONTEXT)
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        with pytest.raises(NotImplementedError):
+            repr(VariableValue())
 
-        self.assertEqual(var.value, VALUE["list_val"])
+    def test_resolved(self) -> None:
+        """Test resolved."""
+        with pytest.raises(NotImplementedError):
+            VariableValue().resolved  # pylint: disable=expression-not-assigned
 
-    def test_value_unresolved(self) -> None:
-        """Should raise `UnresolvedVariable`."""
-        var = Variable("test", "${env test}", "runway")
+    def test_resolve(self, cfngin_context: MockCFNginContext) -> None:
+        """Test resolve."""
+        assert not VariableValue().resolve(context=cfngin_context)
 
-        with self.assertRaises(UnresolvedVariable):
-            print(var.value)
+    def test_simplified(self) -> None:
+        """Test simplified."""
+        obj = VariableValue()
+        assert obj.simplified == obj
+
+    def test_value(self) -> None:
+        """Test value."""
+        with pytest.raises(NotImplementedError):
+            VariableValue().value  # pylint: disable=expression-not-assigned
+
+
+class TestVariableValueConcatenation:
+    """Test runway.variables.VariableValueConcatenation."""
+
+    def test_delitem(self) -> None:
+        """Test __delitem__."""
+        obj = VariableValueConcatenation(["val0", "val1"])  # type: ignore
+        assert "val1" in obj._data
+        del obj[1]
+        assert "val1" not in obj._data
+
+    def test_dependencies(self) -> None:
+        """Test dependencies."""
+        data = [MagicMock(dependencies={"test"})]
+        obj = VariableValueConcatenation(data)
+        assert obj.dependencies == {"test"}
+
+    def test_getitem(self) -> None:
+        """Test __getitem__."""
+        obj = VariableValueConcatenation(["val0", "val1"])  # type: ignore
+        assert obj[1] == "val1"
+        assert obj[:2] == ["val0", "val1"]
+
+    def test_init(self) -> None:
+        """Test __init__."""
+        data = [VariableValueLiteral("test")]
+        obj = VariableValueConcatenation(data)
+        assert obj._data == data
+        assert obj.variable_type == "cfngin"
+
+    def test_iter(self) -> None:
+        """Test __iter__."""
+        obj = VariableValueConcatenation(["val0", "val1"])  # type: ignore
+        assert list(iter(obj)) == ["val0", "val1"]  # type: ignore
+
+    def test_len(self) -> None:
+        """Test __len__."""
+        obj = VariableValueConcatenation(["val0", "val1"])  # type: ignore
+        assert len(obj) == 2  # type: ignore
+
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        obj = VariableValueConcatenation(["val0", "val1"])  # type: ignore
+        assert repr(obj) == "Concatenation['val0', 'val1']"  # type: ignore
+
+    def test_resolved(self) -> None:
+        """Test resolved."""
+        assert VariableValueConcatenation([MagicMock(resolved=True)]).resolved is True
+        assert VariableValueConcatenation([MagicMock(resolved=False)]).resolved is False
+        assert (
+            VariableValueConcatenation(
+                [MagicMock(resolved=True), MagicMock(resolved=False)]
+            ).resolved
+            is False
+        )
+
+    def test_resolve(
+        self, cfngin_context: MockCFNginContext, mocker: MockerFixture
+    ) -> None:
+        """Test resolve."""
+        mock_provider = MagicMock()
+        mock_resolve = mocker.patch.object(
+            VariableValueLiteral, "resolve", return_value=None
+        )
+        obj = VariableValueConcatenation([VariableValueLiteral("val0")])
+        assert not obj.resolve(
+            cfngin_context,
+            provider=mock_provider,
+            variables={"var": "something"},  # type: ignore
+            kwarg="test",
+        )
+        mock_resolve.assert_called_once_with(
+            cfngin_context,
+            provider=mock_provider,
+            variables={"var": "something"},
+            kwarg="test",
+        )
+
+    def test_setitem(self) -> None:
+        """Test __setitem__."""
+        obj = VariableValueConcatenation(["test-val0", "test-val1"])  # type: ignore
+        obj[0] = "val0"  # type: ignore
+        assert obj[0] == "val0"
+        obj[:2] = ["val0", "val1"]  # type: ignore
+        assert obj[1] == "val1"
+
+    def test_simplified_concat(self) -> None:
+        """Test simplified concatenation."""
+        assert (
+            VariableValueConcatenation(
+                [
+                    VariableValueLiteral("foo"),
+                    VariableValueConcatenation(
+                        [VariableValueLiteral("bar"), VariableValueLiteral("foo")]
+                    ),
+                ]
+            ).simplified.value
+            == "foobarfoo"
+        )
+
+    def test_simplified_list(self) -> None:
+        """Test simplified list."""
+        assert [
+            i.value
+            for i in VariableValueConcatenation(
+                [VariableValueList(["foo", "bar"])]
+            ).simplified
+        ] == ["foo", "bar"]
+
+    def test_simplified_literal_bool(self) -> None:
+        """Test simplified literal bool."""
+        assert (
+            VariableValueConcatenation([VariableValueLiteral(True)]).simplified.value
+            is True
+        )
+        assert (
+            VariableValueConcatenation([VariableValueLiteral(False)]).simplified.value
+            is False
+        )
+
+    def test_simplified_literal_empty(self) -> None:
+        """Test simplified literal empty."""
+        assert (
+            VariableValueConcatenation([VariableValueLiteral("")]).simplified.value
+            == ""
+        )
+
+    def test_simplified_literal_int(self) -> None:
+        """Test simplified literal int."""
+        assert (
+            VariableValueConcatenation([VariableValueLiteral(13)]).simplified.value
+            == 13
+        )
+
+    def test_simplified_literal_str(self) -> None:
+        """Test simplified literal str."""
+        assert (
+            VariableValueConcatenation([VariableValueLiteral("foo")]).simplified.value
+            == "foo"
+        )
+        assert (
+            VariableValueConcatenation(
+                [VariableValueLiteral("foo"), VariableValueLiteral("bar")]
+            ).simplified.value
+            == "foobar"
+        )
+
+    def test_value_multiple(self) -> None:
+        """Test multiple."""
+        assert (
+            VariableValueConcatenation(
+                [VariableValueLiteral("foo"), VariableValueLiteral("bar")]
+            ).value
+            == "foobar"
+        )
+        with pytest.raises(InvalidLookupConcatenation):
+            VariableValueConcatenation(
+                [VariableValueLiteral("foo"), VariableValueLiteral(13)]  # type: ignore
+            ).value
+        with pytest.raises(InvalidLookupConcatenation):
+            VariableValueConcatenation(
+                [VariableValueLiteral(5), VariableValueLiteral(13)]  # type: ignore
+            ).value
+
+    def test_value_single(self) -> None:
+        """Test value single."""
+        assert VariableValueConcatenation([VariableValueLiteral("foo")]).value == "foo"
+        assert VariableValueConcatenation([VariableValueLiteral(13)]).value == 13
+
+
+class TestVariableValueDict:
+    """Test runway.variables.VariableValueDict."""
+
+    def test_delitem(self) -> None:
+        """Test __delitem__."""
+        obj = VariableValueDict({"key": "val"})
+        assert "key" in obj
+        del obj["key"]
+        assert "key" not in obj
+
+    def test_dependencies(self, mocker: MockerFixture) -> None:
+        """Test dependencies."""
+        mock_literal = MagicMock(dependencies=set("test"))
+        mocker.patch.object(VariableValueDict, "parse_obj", return_value=mock_literal)
+        obj = VariableValueDict({"key": "val"})
+        assert obj.dependencies == set("test")
+
+    def test_getitem(self, mocker: MockerFixture) -> None:
+        """Test __getitem__."""
+        mocker.patch.object(VariableValueDict, "parse_obj", return_value="parsed_val")
+        obj = VariableValueDict({"key": "val"})
+        assert obj["key"] == "parsed_val"
+
+    def test_init(self, mocker: MockerFixture) -> None:
+        """Test __init__."""
+        mock_parse_obj = mocker.patch.object(
+            VariableValueDict, "parse_obj", return_value="parsed_val"
+        )
+        obj = VariableValueDict({"key": "val"})
+        assert obj._data == {"key": mock_parse_obj.return_value}
+        mock_parse_obj.assert_called_once_with("val", variable_type="cfngin")
+        assert obj.variable_type == "cfngin"
+
+    def test_iter(self) -> None:
+        """Test __iter__."""
+        obj = VariableValueDict({"key": "val"})
+        assert list(iter(obj)) == ["key"]
+
+    def test_len(self) -> None:
+        """Test __len__."""
+        obj = VariableValueDict({"key0": "val0", "key1": "val1"})
+        assert len(obj) == 2
+
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        obj = VariableValueDict({"key0": "val0", "key1": "val1"})
+        assert repr(obj) == "Dict[key0=Literal[val0], key1=Literal[val1]]"
+
+    @pytest.mark.parametrize("resolved", [False, True])
+    def test_resolved(self, mocker: MockerFixture, resolved: bool) -> None:
+        """Test resolved."""
+        mock_literal = MagicMock(resolved=resolved)
+        mocker.patch.object(VariableValueDict, "parse_obj", return_value=mock_literal)
+        obj = VariableValueDict({"key": "val"})
+        assert obj.resolved is resolved
+
+    def test_resolve(
+        self, cfngin_context: MockCFNginContext, mocker: MockerFixture
+    ) -> None:
+        """Test resolve."""
+        mock_literal = MagicMock()
+        mock_provider = MagicMock()
+        mocker.patch.object(VariableValueDict, "parse_obj", return_value=mock_literal)
+        obj = VariableValueDict({"key": "val"})
+        assert not obj.resolve(
+            cfngin_context,
+            provider=mock_provider,
+            variables={"var": "something"},  # type: ignore
+            kwarg="test",
+        )
+        mock_literal.resolve.assert_called_once_with(
+            cfngin_context,
+            provider=mock_provider,
+            variables={"var": "something"},
+            kwarg="test",
+        )
+
+    def test_setitem(self, mocker: MockerFixture) -> None:
+        """Test __setitem__."""
+        mocker.patch.object(VariableValueDict, "parse_obj", return_value="parsed_val")
+        obj = VariableValueDict({"key": "val"})
+        obj["key"] = "new"  # type: ignore
+        assert obj["key"] == "new"
+
+    def test_simplified(self, mocker: MockerFixture) -> None:
+        """Test simplified."""
+        mock_literal = MagicMock(simplified="simplified")
+        mocker.patch.object(VariableValueDict, "parse_obj", return_value=mock_literal)
+        obj = VariableValueDict({"key": "val"})
+        assert obj.simplified == {"key": "simplified"}
+
+    def test_value(self, mocker: MockerFixture) -> None:
+        """Test value."""
+        mock_literal = MagicMock(value="value")
+        mocker.patch.object(VariableValueDict, "parse_obj", return_value=mock_literal)
+        obj = VariableValueDict({"key": "val"})
+        assert obj.value == {"key": "value"}
+
+
+class TestVariableValueList:
+    """Test runway.variables.VariableValueList."""
+
+    def test_delitem(self) -> None:
+        """Test __delitem__."""
+        obj = VariableValueList(["val0", "val1"])
+        assert "val1" in [i._data for i in obj]
+        del obj[1]
+        assert "val1" not in [i._data for i in obj]
+
+    def test_dependencies(self, mocker: MockerFixture) -> None:
+        """Test dependencies."""
+        mock_literal = MagicMock(dependencies=set("test"))
+        mocker.patch.object(VariableValueList, "parse_obj", return_value=mock_literal)
+        obj = VariableValueList(["val0"])
+        assert obj.dependencies == set("test")
+
+    def test_getitem(self) -> None:
+        """Test __getitem__."""
+        obj = VariableValueList(["val0", "val1"])
+        assert obj[1].value == "val1"
+        assert [i.value for i in obj[:2]] == ["val0", "val1"]
+
+    def test_init(self, mocker: MockerFixture) -> None:
+        """Test __init__."""
+        mock_parse_obj = mocker.patch.object(
+            VariableValueList, "parse_obj", return_value="parsed_val"
+        )
+        obj = VariableValueList(["val"])
+        assert obj._data == ["parsed_val"]
+        mock_parse_obj.assert_called_once_with("val", variable_type="cfngin")
+        assert obj.variable_type == "cfngin"
+
+    def test_insert(self) -> None:
+        """Test insert."""
+        obj = VariableValueList(["val0", "val1"])
+        obj.insert(1, VariableValueLiteral("val2"))
+        assert [i.value for i in obj] == ["val0", "val2", "val1"]
+
+    def test_iter(self) -> None:
+        """Test __iter__."""
+        obj = VariableValueList(["val0", "val1"])
+        assert [i.value for i in iter(obj)] == ["val0", "val1"]
+
+    def test_len(self) -> None:
+        """Test __len__."""
+        obj = VariableValueList(["val0", "val1"])
+        assert len(obj) == 2
+
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        obj = VariableValueList(["val0", "val1"])
+        assert repr(obj) == "List[Literal[val0], Literal[val1]]"
+
+    @pytest.mark.parametrize("resolved", [False, True])
+    def test_resolved(self, mocker: MockerFixture, resolved: bool) -> None:
+        """Test resolved."""
+        mock_literal = MagicMock(resolved=resolved)
+        mocker.patch.object(VariableValueList, "parse_obj", return_value=mock_literal)
+        obj = VariableValueList(["val0"])
+        assert obj.resolved is resolved
+
+    def test_resolve(
+        self, cfngin_context: MockCFNginContext, mocker: MockerFixture
+    ) -> None:
+        """Test resolve."""
+        mock_literal = MagicMock()
+        mock_provider = MagicMock()
+        mocker.patch.object(VariableValueList, "parse_obj", return_value=mock_literal)
+        obj = VariableValueList(["val0"])
+        assert not obj.resolve(
+            cfngin_context,
+            provider=mock_provider,
+            variables={"var": "something"},  # type: ignore
+            kwarg="test",
+        )
+        mock_literal.resolve.assert_called_once_with(
+            cfngin_context,
+            provider=mock_provider,
+            variables={"var": "something"},
+            kwarg="test",
+        )
+
+    def test_setitem(self) -> None:
+        """Test __setitem__."""
+        obj = VariableValueList(["val0", "val1"])
+        obj[0] = "val0"  # type: ignore
+        assert obj[0] == "val0"
+        assert obj[1] != "val1"
+        obj[:2] = ["val0", "val1"]  # type: ignore
+        assert obj[1] == "val1"
+
+    def test_simplified(self, mocker: MockerFixture) -> None:
+        """Test simplified."""
+        mock_literal = MagicMock(simplified="simplified")
+        mocker.patch.object(VariableValueList, "parse_obj", return_value=mock_literal)
+        obj = VariableValueList(["val0"])
+        assert obj.simplified == ["simplified"]
+
+    def test_value(self, mocker: MockerFixture) -> None:
+        """Test value."""
+        mock_literal = MagicMock(value="value")
+        mocker.patch.object(VariableValueList, "parse_obj", return_value=mock_literal)
+        obj = VariableValueList(["val0"])
+        assert obj.value == ["value"]
+
+
+class TestVariableValueLiteral:
+    """Test runway.variables.VariableValueLiteral."""
+
+    @pytest.mark.parametrize("value", [False, True, 13, "test"])
+    def test_init(self, value: Union[int, str]) -> None:
+        """Test __init__."""
+        obj = VariableValueLiteral(value)  # type: ignore
+        assert obj._data == value
+
+    @pytest.mark.parametrize("value", [False, True, 13, "test"])
+    def test_iter(self, value: Union[int, str]) -> None:
+        """Test __iter__."""
+        obj = VariableValueLiteral(value)  # type: ignore
+        assert list(iter(obj)) == [obj]  # type: ignore
+
+    @pytest.mark.parametrize("value", [False, True, 13, "test"])
+    def test_repr(self, value: Union[int, str]) -> None:
+        """Test __repr__."""
+        obj = VariableValueLiteral(value)  # type: ignore
+        assert repr(obj) == f"Literal[{value}]"  # type: ignore
+
+    @pytest.mark.parametrize("value", [False, True, 13, "test"])
+    def test_resolved(self, value: Union[int, str]) -> None:
+        """Test resolved."""
+        obj = VariableValueLiteral(value)  # type: ignore
+        assert obj.resolved
+
+    @pytest.mark.parametrize("value", [False, True, 13, "test"])
+    def test_value(self, value: Union[int, str]) -> None:
+        """Test value."""
+        obj = VariableValueLiteral(value)  # type: ignore
+        assert obj.value == value
+
+
+class TestVariableValueLookup:
+    """Test runway.variables.VariableValueLookup."""
+
+    def test_dependencies_no_attr(self) -> None:
+        """Test dependencies class has no attr."""
+
+        class FakeLookup:
+            """Fake lookup."""
+
+        obj = VariableValueLookup(
+            VariableValueLiteral("test"), "query", FakeLookup  # type: ignore
+        )
+        assert obj.dependencies == set()
+
+    def test_dependencies(self, mocker: MockerFixture) -> None:
+        """Test dependencies."""
+        mocker.patch.object(MockLookupHandler, "dependencies", return_value={"test"})
+        obj = VariableValueLookup(
+            VariableValueLiteral("test"), "query", MockLookupHandler
+        )
+        assert obj.dependencies == {"test"}
+
+    def test_init_convert_query(self) -> None:
+        """Test __init__ convert query."""
+        obj = VariableValueLookup(
+            VariableValueLiteral("test"), "query", MockLookupHandler, "runway"
+        )
+        assert isinstance(obj.lookup_query, VariableValueLiteral)
+        assert obj.lookup_query.value == "query"
+
+    def test_init_find_handler_cfngin(self, mocker: MockerFixture) -> None:
+        """Test __init__ find handler cfngin."""
+        mocker.patch.dict(CFNGIN_LOOKUP_HANDLERS, {"test": "success"})
+        obj = VariableValueLookup(
+            VariableValueLiteral("test"), VariableValueLiteral("query")
+        )
+        assert obj.handler == "success"
+
+    def test_init_find_handler_runway(self, mocker: MockerFixture) -> None:
+        """Test __init__ find handler runway."""
+        mocker.patch.dict(RUNWAY_LOOKUP_HANDLERS, {"test": "success"})
+        obj = VariableValueLookup(
+            VariableValueLiteral("test"),
+            VariableValueLiteral("query"),
+            variable_type="runway",
+        )
+        assert obj.handler == "success"
+
+    def test_init_find_handler_value_error(self) -> None:
+        """Test __init__ fund handler ValueError."""
+        with pytest.raises(ValueError):
+            VariableValueLookup(
+                VariableValueLiteral("test"),
+                VariableValueLiteral("query"),
+                variable_type="invalid",  # type: ignore
+            )
+
+    def test_init_find_handler_unknown_lookup_type(self) -> None:
+        """Test __init__ fund handler UnknownLookupType."""
+        with pytest.raises(UnknownLookupType):
+            VariableValueLookup(
+                VariableValueLiteral("invalid"), VariableValueLiteral("query"),
+            )
+
+    def test_init(self) -> None:
+        """Test __init__."""
+        name = VariableValueLiteral("test")
+        query = VariableValueLiteral("query")
+        obj = VariableValueLookup(name, query, MockLookupHandler, "runway")
+        assert obj.handler == MockLookupHandler
+        assert obj.lookup_name == name
+        assert obj.lookup_query == query
+        assert obj.variable_type == "runway"
+
+    def test_iter(self) -> None:
+        """Test __iter__."""
+        obj = VariableValueLookup(VariableValueLiteral("test"), "query")
+        assert list(iter(obj)) == [obj]
+
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        obj = VariableValueLookup(VariableValueLiteral("test"), "query")
+        assert repr(obj) == "Lookup[Literal[test] Literal[query]]"
+        obj._resolve("resolved")
+        assert repr(obj) == "Lookup[resolved (Literal[test] Literal[query])]"
+
+    def test_resolved(self) -> None:
+        """Test resolved."""
+        obj = VariableValueLookup(VariableValueLiteral("test"), "query")
+        assert obj.resolved is False
+        obj._resolved = True
+        assert obj.resolved is True
+
+    def test_resolve_exception(self, mocker: MockerFixture) -> None:
+        """Test resolve raise Exception."""
+        mocker.patch.object(MockLookupHandler, "handle", side_effect=Exception)
+        obj = VariableValueLookup(VariableValueLiteral("test"), "query")
+        with pytest.raises(FailedLookup) as excinfo:
+            obj.resolve(MagicMock(), MagicMock())
+        assert isinstance(excinfo.value.cause, Exception)
+        assert excinfo.value.lookup == obj
+
+    def test_resolve(self, mocker: MockerFixture) -> None:
+        """Test resolve."""
+        kwargs = {
+            "context": MagicMock(),
+            "provider": MagicMock(),
+            "variables": MagicMock(),
+            "kwarg": "something",
+        }
+        mock_handle = mocker.patch.object(
+            MockLookupHandler, "handle", return_value="resolved"
+        )
+        mock_resolve = mocker.patch.object(
+            VariableValueLookup, "_resolve", return_value=None
+        )
+        mock_resolve_query = mocker.patch.object(VariableValueLiteral, "resolve")
+        obj = VariableValueLookup(
+            VariableValueLiteral("test"), VariableValueLiteral("query")
+        )
+        assert not obj.resolve(**kwargs)
+        mock_resolve_query.assert_called_once_with(**kwargs)
+        mock_handle.assert_called_once_with("query", **kwargs)
+        mock_resolve.assert_called_once_with("resolved")
+
+    def test_simplified(self) -> None:
+        """Test simplified."""
+        obj = VariableValueLookup(VariableValueLiteral("test"), "query")
+        assert obj.simplified == obj
+
+    def test_str(self) -> None:
+        """Test __str__."""
+        assert (
+            str(VariableValueLookup(VariableValueLiteral("test"), "query"))
+            == "${test query}"
+        )
+
+    def test_value(self) -> None:
+        """Test value."""
+        obj = VariableValueLookup(VariableValueLiteral("test"), "query")
+        assert obj.resolved is False
+        with pytest.raises(UnresolvedVariableValue):
+            obj.value  # pylint: disable=pointless-statement
+        obj._resolve("success")
+        assert obj.resolved is True
+        assert obj.value == "success"


### PR DESCRIPTION
## Summary

Refactor `runway.variables` for improved typing. In doing this, support for deprecated lookups (functions and classes that don't subclass `runway.lookups.handlers.base.LookupHandler`) was removed.

## Why This Is Needed

Improved typing.

## What Changed

### Changed

- added typing to `runway.variables`
- `runway.variables.VariableValue.parse` is now `.parse_obj`
  - subclasses no longer have their own parsing method, it is now part of `__init__`
- `runway.variables.VariableValueDict` now inherits from `typing.MutableMap` instead of `dict`
- `runway.variable.VariableValueList` now inherits from `typing.MutableSequence` instead of `list`
- `runway.variables.VariableValueLiteral` is now a generic
- `runway.variables.VariableValueConcatenation` is now a generic
- lookup registries will now raise an error if the lookup is not a subclass of `runway.lookups.handlers.base.LookupHandler`

### Removed

- removed support for lookups that are not a subclass of `runway.lookups.handlers.base.LookupHandler`