### PR TITLE
variable: support concatenating int and str

### DIFF
--- a/runway/variables.py
+++ b/runway/variables.py
@@ -667,9 +667,11 @@ class VariableValueConcatenation(Generic[_VariableValue], VariableValue):
         values: List[str] = []
         for value in self:
             resolved_value = value.value
-            if not isinstance(resolved_value, str):
+            if isinstance(resolved_value, bool) or not isinstance(
+                resolved_value, (int, str)
+            ):
                 raise InvalidLookupConcatenation(value, self)
-            values.append(resolved_value)
+            values.append(str(resolved_value))
         return "".join(values)
 
     def resolve(

--- a/tests/unit/test_variables.py
+++ b/tests/unit/test_variables.py
@@ -45,7 +45,7 @@ class MockLookupHandler(LookupHandler):
     side_effect: ClassVar[Union[Any, List[Any]]] = None
 
     @classmethod
-    def handle(
+    def handle(  # pylint: disable=arguments-differ
         cls,
         value: str,
         context: Union[CfnginContext, RunwayContext],
@@ -481,13 +481,21 @@ class TestVariableValueConcatenation:
             ).value
             == "foobar"
         )
-        with pytest.raises(InvalidLookupConcatenation):
+        assert (
             VariableValueConcatenation(
-                [VariableValueLiteral("foo"), VariableValueLiteral(13)]  # type: ignore
+                [VariableValueLiteral(13), VariableValueLiteral("/test")]  # type: ignore
             ).value
+            == "13/test"
+        )
+        assert (
+            VariableValueConcatenation(
+                [VariableValueLiteral(5), VariableValueLiteral(13)]
+            ).value
+            == "513"
+        )
         with pytest.raises(InvalidLookupConcatenation):
             VariableValueConcatenation(
-                [VariableValueLiteral(5), VariableValueLiteral(13)]  # type: ignore
+                [VariableValueLiteral(True), VariableValueLiteral("test")]  # type: ignore
             ).value
 
     def test_value_single(self) -> None:


### PR DESCRIPTION
## Summary

Allows lookups that resolve to ints (account ids) and/or strings  to be joined with strings.

### Example

```yaml
deployments:
  - environments:
      example: ${var account_id.example}/us-east-1

variables:
  account_id:
    example: 123456789012
```

## What Changed

### Added

- added support for `VariableValueConcatenation` to join a `VariableValueLiteral[int]` and `VariableValueLiteral[str]`
	- `VariableValueLiteral[bool]` is filtered out (`isinstance(True, int) == True`) and still raises an exception