### PR TITLE
cli: deployment regions menu entry show lookup string if unresolved

### DIFF
--- a/runway/_cli/utils.py
+++ b/runway/_cli/utils.py
@@ -186,10 +186,12 @@ def select_deployments(
         choice = 1
         LOGGER.debug("only one deployment detected; no selection necessary")
     else:
-        click.secho("\nConfigured deployments\n", bold=True, underline=True)
-        click.echo(
-            yaml.safe_dump({i + 1: d.menu_entry for i, d in enumerate(deployments)})
+        # build the menu before displaying it so debug logs don't break up what is printed
+        deployment_menu = yaml.safe_dump(
+            {i + 1: d.menu_entry for i, d in enumerate(deployments)}
         )
+        click.secho("\nConfigured deployments\n", bold=True, underline=True)
+        click.echo(deployment_menu)
         if ctx.command.name == "destroy":
             click.echo(
                 '(operating in destroy mode -- "all" will destroy all '

--- a/runway/exceptions.py
+++ b/runway/exceptions.py
@@ -188,10 +188,11 @@ class UnresolvedVariable(Exception):
             variable: The unresolved variable.
 
         """
-        message = 'Attempted to use variable "{}" before it was resolved'.format(
-            variable.name
+        self.message = (
+            f'Attempted to use variable "{variable.name}" before it was resolved'
         )
-        super().__init__(message, *args, **kwargs)
+        self.variable = variable
+        super().__init__(self.message, *args, **kwargs)
 
 
 class UnresolvedVariableValue(Exception):

--- a/tests/unit/config/components/runway/test_deployment_def.py
+++ b/tests/unit/config/components/runway/test_deployment_def.py
@@ -57,6 +57,18 @@ class TestRunwayDeploymentDefinition:
                 },
                 "test - test-01.cfn, test-02.cfn (us-east-1)",
             ),
+            (
+                {"name": "test", "modules": ["test-01.cfn"], "regions": "${var test}"},
+                "test - test-01.cfn (${var test})",
+            ),
+            (
+                {
+                    "name": "test",
+                    "modules": ["test-01.cfn"],
+                    "parallel_regions": "${var test}",
+                },
+                "test - test-01.cfn (${var test})",
+            ),
         ],
     )
     def test_menu_entry(self, data: Dict[str, Any], expected: str) -> None:


### PR DESCRIPTION
## Summary

When `deployment.regions` or `deployment.parallel_regions` contains a lookup and Runway is used interactively, `UnresolvedVariable` is raised since we have not tried to resolve any of them yet. This solves the issue by displaying the lookup string as a literal value in place to its resolved value.

In the future, we can look into building out a better lookup resolution/dependency system that would allow us to reliably resolve this field earlier in the process.

### Example

The following config would result in an `UnresolvedVariable` exception.

```yaml

deployments:
  - modules:
      - missing-app-01.cfn
      - missing-app-02.cfn
    parameters:
      namespace: example
    regions: ${var regions.${env DEPLOY_ENVIRONMENT}}
  - modules:
      - missing-app-03.cfn
      - missing-app-04.cfn
    parameters:
      namespace: example
    regions: ${var regions.${env DEPLOY_ENVIRONMENT}}

variables:
  regions:
    example:
      - us-west-2
```

The new output (show with `--debug`).

```
DEBUG:runway.config.components.runway.deployment_def:Attempted to use variable "deployment_1.regions" before it was resolved; using literal value in menu entry
DEBUG:runway.config.components.runway.deployment_def:Attempted to use variable "deployment_2.regions" before it was resolved; using literal value in menu entry

Configured deployments

1: deployment_1 - missing-app-01.cfn, missing-app-02.cfn (${var regions.${env DEPLOY_ENVIRONMENT}})
2: deployment_2 - missing-app-03.cfn, missing-app-04.cfn (${var regions.${env DEPLOY_ENVIRONMENT}})
```

## What Changed

### Fixed

- CLI will no longer raise `UnresolvedVariable` when using a lookup to define deployment regions when displaying the selection menu
