### PR TITLE
config: replace module type enum with literal, update type annotations

### DIFF
--- a/runway/config/components/runway/_module_def.py
+++ b/runway/config/components/runway/_module_def.py
@@ -9,7 +9,11 @@ from ...models.runway import RunwayModuleDefinitionModel
 from .base import ConfigComponentDefinition
 
 if TYPE_CHECKING:
-    from ...models.runway import RunwayEnvironmentsType, RunwayEnvVarsType
+    from ...models.runway import (
+        RunwayEnvironmentsType,
+        RunwayEnvVarsType,
+        RunwayModuleTypeTypeDef,
+    )
 
 
 class RunwayModuleDefinition(ConfigComponentDefinition):
@@ -23,7 +27,7 @@ class RunwayModuleDefinition(ConfigComponentDefinition):
     parameters: Dict[str, Any]
     path: Optional[Union[str, Path]]
     tags: List[str]
-    type: Optional[str]  # TODO add enum
+    type: Optional[RunwayModuleTypeTypeDef]
 
     _data: RunwayModuleDefinitionModel
     _supports_vars: Tuple[str, ...] = (

--- a/runway/config/models/runway/__init__.py
+++ b/runway/config/models/runway/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from enum import Enum
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -22,6 +21,7 @@ from typing import (
 import yaml
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pydantic import Extra, Field, Protocol, root_validator, validator
+from typing_extensions import Literal
 
 from .. import utils
 from ..base import ConfigProperty
@@ -47,28 +47,31 @@ RunwayEnvironmentsType = Dict[str, Union[bool, List[str], str]]
 RunwayEnvironmentsUnresolvedType = Union[Dict[str, Union[bool, List[str], str]], str]
 RunwayEnvVarsType = Dict[str, Union[List[str], str]]
 RunwayEnvVarsUnresolvedType = Union[RunwayEnvVarsType, str]
+RunwayModuleTypeTypeDef = Literal[
+    "cdk", "cloudformation", "kubernetes", "serverless", "static", "terraform"
+]
 
 __all__ = [
+    "CfnLintRunwayTestArgs",
+    "CfnLintRunwayTestDefinitionModel",
     "RUNWAY_LOOKUP_STRING_ERROR",
     "RUNWAY_LOOKUP_STRING_REGEX",
-    "CfnLintRunwayTestDefinitionModel",
-    "CfnLintRunwayTestArgs",
     "RunwayAssumeRoleDefinitionModel",
     "RunwayConfigDefinitionModel",
-    "RunwayDeploymentRegionDefinitionModel",
     "RunwayDeploymentDefinitionModel",
+    "RunwayDeploymentRegionDefinitionModel",
     "RunwayEnvironmentsType",
     "RunwayEnvironmentsUnresolvedType",
     "RunwayEnvVarsType",
     "RunwayEnvVarsUnresolvedType",
     "RunwayFutureDefinitionModel",
     "RunwayModuleDefinitionModel",
+    "RunwayModuleTypeTypeDef",
     "RunwayTestDefinitionModel",
     "RunwayVariablesDefinitionModel",
     "RunwayVersionField",
-    "ScriptRunwayTestDefinitionModel",
     "ScriptRunwayTestArgs",
-    "ValidRunwayModuleTypeValues",
+    "ScriptRunwayTestDefinitionModel",
     "ValidRunwayTestTypeValues",
     "YamlLintRunwayTestDefinitionModel",
 ]
@@ -363,29 +366,6 @@ class RunwayFutureDefinitionModel(ConfigProperty):
         title = "Runway Future Definition"
 
 
-class ValidRunwayModuleTypeValues(Enum):
-    """Valid Runway module types."""
-
-    cdk = "cdk"
-    cloudformation = "cloudformation"
-    serverless = "serverless"
-    terraform = "terraform"
-    kubernetes = "kubernetes"
-    static = "static"
-
-    @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
-        """Mutate the field schema in place.
-
-        This is only called when output JSON schema from a model.
-
-        """
-        field_schema.update(  # cov: ignore
-            title="Module Type",
-            description="Explicitly define the type of IaC contained within the directory.",
-        )
-
-
 class RunwayModuleDefinitionModel(ConfigProperty):
     """Model for a Runway module definition."""
 
@@ -452,7 +432,7 @@ class RunwayModuleDefinitionModel(ConfigProperty):
         "This field is only used by the `--tag` CLI option.",
         examples=[["type:network", "app:sampleapp"]],
     )
-    type: Optional[ValidRunwayModuleTypeValues] = None
+    type: Optional[RunwayModuleTypeTypeDef] = None
     # needs to be last
     parallel: List[RunwayModuleDefinitionModel] = Field(
         [],

--- a/runway/core/components/__init__.py
+++ b/runway/core/components/__init__.py
@@ -3,7 +3,7 @@ from ._deploy_environment import DeployEnvironment
 from ._deployment import Deployment
 from ._module import Module
 from ._module_path import ModulePath
-from ._module_type import RunwayModuleType
+from ._module_type import RunwayModuleType, RunwayModuleTypeExtensionsTypeDef
 
 __all__ = [
     "DeployEnvironment",
@@ -11,4 +11,5 @@ __all__ = [
     "Module",
     "ModulePath",
     "RunwayModuleType",
+    "RunwayModuleTypeExtensionsTypeDef",
 ]

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -159,8 +159,8 @@ class Module:
         """Determine Runway module type."""
         return RunwayModuleType(
             path=self.path.module_root,
-            class_path=self.payload.get("class_path"),
-            type_str=self.payload.get("type"),
+            class_path=self.definition.class_path,
+            type_str=self.definition.type,
         )
 
     @cached_property

--- a/runway/core/components/_module_type.py
+++ b/runway/core/components/_module_type.py
@@ -5,14 +5,20 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Type, cast
+from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Type, cast
+
+from typing_extensions import Literal
 
 from ...util import load_object_from_string
 
 if TYPE_CHECKING:
+    from ...config.models.runway import RunwayModuleTypeTypeDef
     from ...module.base import RunwayModule
 
 LOGGER = logging.getLogger(__name__)
+
+
+RunwayModuleTypeExtensionsTypeDef = Literal["cdk", "cfn", "k8s", "sls", "tf", "web"]
 
 
 class RunwayModuleType:
@@ -53,29 +59,29 @@ class RunwayModuleType:
 
     """
 
-    EXTENSION_MAP = {
+    EXTENSION_MAP: ClassVar[Dict[str, str]] = {
+        "cdk": "runway.module.cdk.CloudDevelopmentKit",
+        "cfn": "runway.module.cloudformation.CloudFormation",
+        "k8s": "runway.module.k8s.K8s",
         "sls": "runway.module.serverless.Serverless",
         "tf": "runway.module.terraform.Terraform",
-        "cdk": "runway.module.cdk.CloudDevelopmentKit",
-        "k8s": "runway.module.k8s.K8s",
-        "cfn": "runway.module.cloudformation.CloudFormation",
         "web": "runway.module.staticsite.handler.StaticSite",
     }
 
-    TYPE_MAP = {
-        "serverless": EXTENSION_MAP["sls"],
-        "terraform": EXTENSION_MAP["tf"],
+    TYPE_MAP: ClassVar[Dict[str, str]] = {
         "cdk": EXTENSION_MAP["cdk"],
-        "kubernetes": EXTENSION_MAP["k8s"],
         "cloudformation": EXTENSION_MAP["cfn"],
+        "kubernetes": EXTENSION_MAP["k8s"],
+        "serverless": EXTENSION_MAP["sls"],
         "static": EXTENSION_MAP["web"],
+        "terraform": EXTENSION_MAP["tf"],
     }
 
     def __init__(
         self,
         path: Path,
         class_path: Optional[str] = None,
-        type_str: Optional[str] = None,
+        type_str: Optional[RunwayModuleTypeTypeDef] = None,
     ) -> None:
         """Instantiate class.
 

--- a/tests/unit/core/components/test_module.py
+++ b/tests/unit/core/components/test_module.py
@@ -279,7 +279,7 @@ class TestModule:
             context=runway_context,
             definition=fx_deployments.load("min_required").modules[0],
         )
-        mocker.patch.object(mod, "payload", {})
+        mod.definition.class_path = None
 
         assert mod.type == mock_type
         mock_type.assert_called_once_with(
@@ -287,7 +287,7 @@ class TestModule:
         )
         del mod.type
 
-        mod.payload.update({"class_path": "parent.dir.class"})
+        mod.definition.class_path = "parent.dir.class"
         assert mod.type == mock_type
         mock_type.assert_called_with(
             path=cast("Path", mock_path.module_root),
@@ -296,12 +296,12 @@ class TestModule:
         )
         del mod.type
 
-        mod.payload.update({"type": "test-type"})
+        mod.definition.type = "kubernetes"
         assert mod.type == mock_type
         mock_type.assert_called_with(
             path=cast("Path", mock_path.module_root),
             class_path="parent.dir.class",
-            type_str="test-type",
+            type_str="kubernetes",
         )
         del mod.type
 

--- a/tests/unit/core/components/test_module_type.py
+++ b/tests/unit/core/components/test_module_type.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from pytest import LogCaptureFixture
 
+    from runway.config.models.runway import RunwayModuleTypeTypeDef
     from runway.module.base import RunwayModule
 
 
@@ -110,7 +111,10 @@ class TestRunwayModuleType:
         ],
     )
     def test_from_type_str(
-        self, type_str: str, expected: Type[RunwayModule], cd_tmp_path: Path
+        self,
+        type_str: RunwayModuleTypeTypeDef,
+        expected: Type[RunwayModule],
+        cd_tmp_path: Path,
     ) -> None:
         """Test from type_str."""
         result = RunwayModuleType(cd_tmp_path, type_str=type_str)


### PR DESCRIPTION
## Summary

Replace `Enum` that was being used for `module.type` field typing with `typing_extentions/typing.Literal`. Update annotations that were using `str` for this value to use the new type variable.

## What Changed

### Added

- added type variable for Runway Module `type` field
