### PR TITLE
cfngin: change `pre_/post_build` to `pre_/post_deploy` to match terminology

### DIFF
--- a/docs/source/cfngin/configuration.rst
+++ b/docs/source/cfngin/configuration.rst
@@ -222,7 +222,7 @@ Top-Level Fields
     :type: Optional[str]
     :value: "-"
 
-    By default, ``-`` will be used as a delimiter between the :attr:`~cfngin.config.namespace` and the declared stack name to build the actual CloudFormation stack name that gets created.
+    By default, ``-`` will be used as a delimiter between the :attr:`~cfngin.config.namespace` and the declared stack name to deploy the actual CloudFormation stack name that gets created.
 
     If you prefer to not use a delimiter, an empty string can be used as the value of this field.
 
@@ -264,7 +264,7 @@ Top-Level Fields
 
       persistent_graph_key: unique-key.json
 
-  .. attribute:: post_build
+  .. attribute:: post_deploy
     :type: Union[Dict[str, cfngin.hook], List[cfngin.hook]]
     :value: []
 
@@ -276,14 +276,14 @@ Top-Level Fields
     .. code-block:: yaml
       :caption: using a dict
 
-      post_build:
+      post_deploy:
         do_something:
           path: do.something
 
     .. code-block:: yaml
       :caption: using a list
 
-      post_build:
+      post_deploy:
         - path: do.something
 
   .. attribute:: post_destroy
@@ -308,7 +308,7 @@ Top-Level Fields
       post_destroy:
         - path: do.something
 
-  .. attribute:: pre_build
+  .. attribute:: pre_deploy
     :type: Union[Dict[str, cfngin.hook], List[cfngin.hook]]
     :value: []
 
@@ -320,14 +320,14 @@ Top-Level Fields
     .. code-block:: yaml
       :caption: using a dict
 
-      pre_build:
+      pre_deploy:
         do_something:
           path: do.something
 
     .. code-block:: yaml
       :caption: using a list
 
-      pre_build:
+      pre_deploy:
         - path: do.something
 
   .. attribute:: pre_destroy
@@ -700,7 +700,7 @@ Variables
 ==========
 
 Variables are values that will be passed into a :ref:`Blueprint` before it is rendered.
-Variables can be any valid YAML data structure and can leverage :ref:`Lookups <cfngin-lookups>` to expand values at build time.
+Variables can be any valid YAML data structure and can leverage :ref:`Lookups <cfngin-lookups>` to expand values at runtime.
 
 The following concepts make working with variables within large templates easier:
 
@@ -766,7 +766,7 @@ To do so, use the :ref:`output lookup` in the :attr:`~cfngin.stack.variables` on
 
 For more information see :ref:`Lookups <cfngin-lookups>`.
 
-In this example config - when building things inside a VPC, you will need to pass the **VpcId** of the VPC that you want the resources to be located in.
+In this example config - when deploying things inside a VPC, you will need to pass the **VpcId** of the VPC that you want the resources to be located in.
 If the **vpc** stack provides an Output called **VpcId**, you can reference it easily.
 
 .. code-block:: yaml

--- a/docs/source/cfngin/hooks.rst
+++ b/docs/source/cfngin/hooks.rst
@@ -8,8 +8,8 @@ A :class:`~cfngin.hook` is a python function, class, or class method that is exe
 
 Only the following actions allow pre/post hooks:
 
-:build:
-  using fields :attr:`~cfngin.config.pre_build` and :attr:`~cfngin.config.post_build`
+:deploy:
+  using fields :attr:`~cfngin.config.pre_deploy` and :attr:`~cfngin.config.post_deploy`
 :destroy:
   using fields :attr:`~cfngin.config.pre_destroy` and :attr:`~cfngin.config.post_destroy`
 
@@ -49,7 +49,7 @@ Only the following actions allow pre/post hooks:
     .. rubric:: Example
     .. code-block:: yaml
 
-      pre_build:
+      pre_deploy:
         example-hook:
           enabled: ${enable_example_hook}
 
@@ -61,7 +61,7 @@ Only the following actions allow pre/post hooks:
     .. rubric:: Example
     .. code-block:: yaml
 
-      pre_build:
+      pre_deploy:
         example-hook:
           path: runway.cfngin.hooks.command.run_command
 
@@ -91,7 +91,7 @@ acm.Certificate
 
 Manage a DNS validated certificate in AWS Certificate Manager.
 
-When used in the :attr:`~cfngin.config.pre_build` or :attr:`~cfngin.config.post_build` stage this hook will create a CloudFormation stack containing a DNS validated certificate.
+When used in the :attr:`~cfngin.config.pre_deploy` or :attr:`~cfngin.config.post_deploy` stage this hook will create a CloudFormation stack containing a DNS validated certificate.
 It will automatically create a record in Route 53 to validate the certificate and wait for the stack to complete before returning the ``CertificateArn`` as hook data.
 The CloudFormation stack also outputs the ARN of the certificate as ``CertificateArn`` so that it can be referenced from other stacks.
 
@@ -138,7 +138,7 @@ Resources effected include the CloudFormation stack it creates, ACM certificate,
 
     sys_path: ./
 
-    pre_build:
+    pre_deploy:
       acm-cert:
         path: runway.cfngin.hooks.acm.Certificate
         required: true
@@ -287,7 +287,7 @@ to be skipped in subsequent runs.
 
 .. code-block:: yaml
 
-    pre_build:
+    pre_deploy:
       upload_functions:
         path: runway.cfngin.hooks.aws_lambda.upload_lambda_functions
         required: true
@@ -442,7 +442,7 @@ Run a custom command as a hook.
 
 .. code-block:: yaml
 
-    pre_build:
+    pre_deploy:
       command_copy_environment:
         path: runway.cfngin.hooks.command.run_command
         required: true
@@ -723,7 +723,7 @@ Example Hook Function
     namespace: example
     sys_path: ./
 
-    pre_build:
+    pre_deploy:
       my_hook_do_something:
         path: hooks.my_hook.do_something
         args:
@@ -757,7 +757,7 @@ Example Hook Class
         Example:
         .. code-block:: yaml
 
-          pre_build:
+          pre_deploy:
             my_hook_do_something:
               path: hooks.my_hook.MyClass
               args:
@@ -790,7 +790,7 @@ Example Hook Class
     namespace: example
     sys_path: ./
 
-    pre_build:
+    pre_deploy:
       my_hook_do_something:
         path: hooks.my_hook.MyClass
         args:

--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -158,8 +158,8 @@ value.
   an environment file. It does not support other embedded lookups to see
   if they exist. Only checking variables in the environment file are supported.
   If you attempt to have the default lookup perform any other lookup that
-  fails, CFNgin will throw an exception for that lookup and will stop your
-  build before it gets a chance to fall back to the default in your config.
+  fails, CFNgin will throw an exception for that lookup and will exit
+  before it gets a chance to fall back to the default in your config.
 
 .. _`kms lookup`:
 

--- a/docs/source/cfngin/migrating.rst
+++ b/docs/source/cfngin/migrating.rst
@@ -51,7 +51,7 @@ All hooks available in Stacker_ 1.7.0 are available in Runway's CFNgin at the sa
 .. rubric:: Example Definition
 .. code-block:: yaml
 
-    pre_build:
+    pre_deploy:
       what_use_to_be_this:
         path: stacker.hooks.commands.run_command
         args:

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -117,7 +117,7 @@ A graph is constructed for each execution of CFNgin from the contents of the
 lookup
 ======
 
-A method for expanding values in the :class:`~cfngin.config` at build time. By default
+A method for expanding values in the :class:`~cfngin.config` at runtime. By default
 lookups are used to reference Output values from other :class:`stacks <cfngin.stack>` within the
 same :attr:`~cfngin.config.namespace`.
 

--- a/integration_tests/test_cfngin/tests/fixtures/16_aws_lambda_hook.yaml
+++ b/integration_tests/test_cfngin/tests/fixtures/16_aws_lambda_hook.yaml
@@ -3,7 +3,7 @@ cfngin_bucket: ${CFNGIN_NAMESPACE}-${region}
 
 sys_path: ./
 
-pre_build:
+pre_deploy:
   upload_lambdas:
     path: runway.cfngin.hooks.aws_lambda.upload_lambda_functions
     required: true

--- a/runway/cfngin/actions/destroy.py
+++ b/runway/cfngin/actions/destroy.py
@@ -25,8 +25,8 @@ class Action(BaseAction):
     """Responsible for destroying CloudFormation stacks.
 
     Generates a destruction plan based on stack dependencies. Stack
-    dependencies are reversed from the build action. For example, if a Stack B
-    requires Stack A during build, during destroy Stack A requires Stack B be
+    dependencies are reversed from the deploy action. For example, if a Stack B
+    requires Stack A during deploy, during destroy Stack A requires Stack B be
     destroyed first.
 
     The plan defaults to printing an outline of what will be destroyed. If

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -29,7 +29,7 @@ from ..status import (
     SkippedStatus,
 )
 from ..status import StackDoesNotExist as StackDoesNotExistStatus
-from . import build
+from . import deploy
 from .base import build_walker
 
 if TYPE_CHECKING:
@@ -175,10 +175,10 @@ def diff_parameters(
     return diff
 
 
-class Action(build.Action):
+class Action(deploy.Action):
     """Responsible for diffing CloudFormation stacks in AWS and locally.
 
-    Generates the build plan based on stack dependencies (these dependencies
+    Generates the deploy plan based on stack dependencies (these dependencies
     are determined automatically based on references to output values from
     other stacks).
 
@@ -202,16 +202,16 @@ class Action(build.Action):
         if self.cancel.wait(0):
             return INTERRUPTED
 
-        if not build.should_submit(stack):
+        if not deploy.should_submit(stack):
             return NotSubmittedStatus()
 
         provider = self.build_provider(stack)
 
-        if not build.should_update(stack):
+        if not deploy.should_update(stack):
             stack.set_outputs(provider.get_outputs(stack.fqn))
             return NotUpdatedStatus()
 
-        tags = build.build_stack_tags(stack)
+        tags = deploy.build_stack_tags(stack)
 
         try:
             stack.resolve(self.context, provider)

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -14,7 +14,7 @@ from runway.util import MutableMap, SafeHaven, cached_property
 
 from ..config import CfnginConfig
 from ..context.cfngin import CfnginContext
-from .actions import build, destroy, diff
+from .actions import deploy, destroy, diff
 from .environment import parse_environment
 from .providers.aws.default import ProviderBuilder
 
@@ -124,7 +124,7 @@ class CFNgin:
                 logger.notice("deploy (in progress)")
                 with SafeHaven(sys_modules_exclude=["awacs", "troposphere"],):
                     ctx = self.load(config_path)
-                    action = build.Action(
+                    action = deploy.Action(
                         context=ctx,
                         provider_builder=self._get_provider_builder(
                             ctx.config.service_role

--- a/runway/cfngin/hooks/acm.py
+++ b/runway/cfngin/hooks/acm.py
@@ -69,7 +69,7 @@ class Certificate(Hook):
     Example:
     .. code-block: yaml
 
-        pre_build:
+        pre_deploy:
           example-wildcard-cert:
             path: runway.cfngin.hooks.acm.Certificate
             required: true

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -1027,7 +1027,7 @@ def upload_lambda_functions(context: CfnginContext, provider: Provider, **kwargs
         .. Hook configuration.
         .. code-block:: yaml
 
-            pre_build:
+            pre_deploy:
               upload_functions:
                 path: runway.cfngin.hooks.aws_lambda.upload_lambda_functions
                 required: true

--- a/runway/cfngin/hooks/base.py
+++ b/runway/cfngin/hooks/base.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from troposphere import Tags
 
 from ...config.models.cfngin import CfnginStackDefinitionModel
-from ..actions import build
+from ..actions import deploy
 from ..exceptions import StackFailed
 from ..stack import Stack
 from ..status import COMPLETE, FAILED, PENDING, SKIPPED, SUBMITTED
@@ -91,7 +91,7 @@ class Hook:
         self.args.tags.update(context.tags)
         self.context = context
         self.provider = provider
-        self._deploy_action = HookBuildAction(self.context, self.provider)
+        self._deploy_action = HookDeployAction(self.context, self.provider)
         self._destroy_action = HookDestroyAction(self.context, self.provider)
 
     @property
@@ -193,7 +193,7 @@ class Hook:
 
     def _run_stack_action(
         self,
-        action: Union[HookBuildAction, HookDestroyAction],
+        action: Union[HookDeployAction, HookDestroyAction],
         stack: Optional[Stack] = None,
         wait: bool = False,
     ) -> Status:
@@ -222,7 +222,7 @@ class Hook:
 
     def _wait_for_stack(
         self,
-        action: Union[HookBuildAction, HookDestroyAction],
+        action: Union[HookDeployAction, HookDestroyAction],
         last_status: Optional[Status] = None,
         stack: Optional[Stack] = None,
         till_reason: Optional[str] = None,
@@ -267,8 +267,8 @@ class Hook:
         return status
 
 
-class HookBuildAction(build.Action):
-    """Build action that can be used from hooks."""
+class HookDeployAction(deploy.Action):
+    """Deploy action that can be used from hooks."""
 
     def __init__(self, context: CfnginContext, provider: Provider):
         """Instantiate class.
@@ -296,8 +296,8 @@ class HookBuildAction(build.Action):
 
 
 # the build action has logic to destroy stacks so we can just extend the
-# HookBuildAction and change `run` in use the `_destroy_stack` method instead
-class HookDestroyAction(HookBuildAction):
+# HookDeployAction and change `run` in use the `_destroy_stack` method instead
+class HookDestroyAction(HookDeployAction):
     """Destroy action that can be used from hooks."""
 
     def run(self, **kwargs: Any) -> Status:

--- a/runway/cfngin/hooks/command.py
+++ b/runway/cfngin/hooks/command.py
@@ -58,7 +58,7 @@ def run_command(
     Examples:
         .. code-block:: yaml
 
-            pre_build:
+            pre_deploy:
               command_copy_environment:
                 path: runway.cfngin.hooks.command.run_command
                 required: true

--- a/runway/cfngin/hooks/docker/_login.py
+++ b/runway/cfngin/hooks/docker/_login.py
@@ -49,7 +49,7 @@ username (str)
 .. rubric:: Example
 .. code-block:: yaml
 
-    pre_build:
+    pre_deploy:
       - path: runway.cfngin.hooks.docker.login
         args:
           ecr: true

--- a/runway/cfngin/hooks/docker/image/_build.py
+++ b/runway/cfngin/hooks/docker/image/_build.py
@@ -94,7 +94,7 @@ image (DockerImage)
 .. rubric:: Example
 .. code-block:: yaml
 
-    pre_build:
+    pre_deploy:
       - path: runway.cfngin.hooks.docker.login
         args:
           ecr: true

--- a/runway/cfngin/hooks/docker/image/_push.py
+++ b/runway/cfngin/hooks/docker/image/_push.py
@@ -41,7 +41,7 @@ tags (Optional[List[str]])
 .. rubric:: Example
 .. code-block:: yaml
 
-    pre_build:
+    pre_deploy:
       - path: runway.cfngin.hooks.docker.login
         args:
           ecr: true

--- a/runway/cfngin/hooks/docker/image/_remove.py
+++ b/runway/cfngin/hooks/docker/image/_remove.py
@@ -45,7 +45,7 @@ tags (Optional[List[str]])
 .. rubric:: Example
 .. code-block:: yaml
 
-    pre_build:
+    pre_deploy:
       - path: runway.cfngin.hooks.docker.login
         args:
           ecr: true
@@ -67,7 +67,7 @@ tags (Optional[List[str]])
     stacks:
       ...
 
-    post_build:
+    post_deploy:
       - path: runway.cfngin.hooks.docker.image.remove
         args:
           image: ${hook_data docker.image}

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -39,10 +39,10 @@ def handle_hooks(  # pylint: disable=too-many-statements
     provider: Provider,
     context: CfnginContext,
 ):
-    """Handle pre/post_build hooks.
+    """Handle pre/post_deploy hooks.
 
-    These are pieces of code that we want to run before/after the builder
-    builds the stacks.
+    These are pieces of code that we want to run before/after deploying
+    stacks.
 
     Args:
         stage: The current stage (pre_run, post_run, etc).
@@ -63,7 +63,6 @@ def handle_hooks(  # pylint: disable=too-many-statements
             raise ValueError("%s hook #%d missing path." % (stage, i))
 
     LOGGER.info("executing %s hooks: %s", stage, ", ".join(hook_paths))
-    stage = stage.replace("build", "deploy")
     for hook in hooks:
         if not hook.enabled:
             LOGGER.debug("hook with method %s is disabled; skipping", hook.path)
@@ -79,7 +78,7 @@ def handle_hooks(  # pylint: disable=too-many-statements
 
         if hook.args:
             args = [Variable(k, v) for k, v in hook.args.items()]
-            try:  # handling for output or similar being used in pre_build
+            try:  # handling for output or similar being used in pre_deploy
                 resolve_variables(args, context, provider)
             except FailedVariableLookup:
                 if "pre" in stage:

--- a/runway/cfngin/plan.py
+++ b/runway/cfngin/plan.py
@@ -334,8 +334,8 @@ class Graph:
 
     Example:
         >>> dag = DAG()
-        >>> a = Step("a", fn=build)
-        >>> b = Step("b", fn=build)
+        >>> a = Step("a", fn=deploy)
+        >>> b = Step("b", fn=deploy)
         >>> dag.add_step(a)
         >>> dag.add_step(b)
         >>> dag.connect(a, b)

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -853,7 +853,7 @@ class Provider(BaseProvider):
         fqn = self.get_stack_name(stack)
         LOGGER.debug("%s:attempting to delete stack", fqn)
 
-        if action == "build":
+        if action == "deploy":
             LOGGER.info(
                 "%s:removed from the CFNgin config file; it is being destroyed", fqn
             )

--- a/runway/cfngin/stack.py
+++ b/runway/cfngin/stack.py
@@ -102,7 +102,7 @@ class Stack:
 
         Args:
             definition: A stack definition.
-            context: Current context for building the stack.
+            context: Current context for deploying the stack.
             variables: Variables for the stack.
             mappings: Cloudformation mappings passed to the blueprint.
             locked: Whether or not the stack is locked.

--- a/runway/config/__init__.py
+++ b/runway/config/__init__.py
@@ -123,7 +123,7 @@ class CfnginConfig(BaseConfig):
 
     This is used internally by CFNgin to parse and validate a YAML formatted
     CFNgin configuration file, but can also be used in scripts to generate a
-    CFNgin config file before handing it off to CFNgin to build/destroy.
+    CFNgin config file before handing it off to CFNgin to deploy/destroy.
 
     Example::
 
@@ -163,11 +163,11 @@ class CfnginConfig(BaseConfig):
     persistent_graph_key: Optional[  #: S3 object key were the persistent graph is stored.
         str
     ] = None
-    post_build: List[CfnginHookDefinitionModel]  #: Hooks to run after a build action.
+    post_deploy: List[CfnginHookDefinitionModel]  #: Hooks to run after a deploy action.
     post_destroy: List[  #: Hooks to run after a destroy action.
         CfnginHookDefinitionModel
     ]
-    pre_build: List[CfnginHookDefinitionModel]  #: Hooks to run before a build action.
+    pre_deploy: List[CfnginHookDefinitionModel]  #: Hooks to run before a deploy action.
     pre_destroy: List[  #: Hooks to run before a destroy action.
         CfnginHookDefinitionModel
     ]
@@ -202,11 +202,11 @@ class CfnginConfig(BaseConfig):
         self.namespace_delimiter = self._data.namespace_delimiter
         self.package_sources = self._data.package_sources
         self.persistent_graph_key = self._data.persistent_graph_key
-        self.post_build = cast(List[CfnginHookDefinitionModel], self._data.post_build)
+        self.post_deploy = cast(List[CfnginHookDefinitionModel], self._data.post_deploy)
         self.post_destroy = cast(
             List[CfnginHookDefinitionModel], self._data.post_destroy
         )
-        self.pre_build = cast(List[CfnginHookDefinitionModel], self._data.pre_build)
+        self.pre_deploy = cast(List[CfnginHookDefinitionModel], self._data.pre_deploy)
         self.pre_destroy = cast(List[CfnginHookDefinitionModel], self._data.pre_destroy)
         self.service_role = self._data.service_role
         self.stacks = cast(List[CfnginStackDefinitionModel], self._data.stacks)

--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -234,7 +234,7 @@ class CfnginConfigDefinitionModel(ConfigProperty):
         description="Key for an AWS S3 object used to track a graph of stacks "
         "between executions.",
     )
-    post_build: Union[
+    post_deploy: Union[
         List[CfnginHookDefinitionModel],  # final type after parsing
         Dict[str, CfnginHookDefinitionModel],  # recommended when writing config
     ] = Field([], title="Post Deploy Hooks")
@@ -242,7 +242,7 @@ class CfnginConfigDefinitionModel(ConfigProperty):
         List[CfnginHookDefinitionModel],  # final type after parsing
         Dict[str, CfnginHookDefinitionModel],  # recommended when writing config
     ] = Field([], title="Pre Destroy Hooks")
-    pre_build: Union[
+    pre_deploy: Union[
         List[CfnginHookDefinitionModel],  # final type after parsing
         Dict[str, CfnginHookDefinitionModel],  # recommended when writing config
     ] = Field([], title="Pre Deploy Hooks")
@@ -286,7 +286,7 @@ class CfnginConfigDefinitionModel(ConfigProperty):
         utils.resolve_path_field
     )
 
-    @validator("post_build", "post_destroy", "pre_build", "pre_destroy", pre=True)
+    @validator("post_deploy", "post_destroy", "pre_deploy", "pre_destroy", pre=True)
     def _convert_hook_definitions(
         cls, v: Union[Dict[str, Any], List[Dict[str, Any]]]  # noqa: N805
     ) -> List[Dict[str, Any]]:

--- a/runway/lookups/handlers/ecr.py
+++ b/runway/lookups/handlers/ecr.py
@@ -35,7 +35,7 @@ This Lookup does not support any arguments.
 .. code-block:: yaml
     :caption: cfngin.yml
 
-    pre_build:
+    pre_deploy:
       - path: runway.cfngin.hooks.docker.login
         args:
           password: ${ecr login-password}

--- a/runway/module/cloudformation.py
+++ b/runway/module/cloudformation.py
@@ -62,16 +62,16 @@ class CloudFormation(RunwayModule):
         self.logger = PrefixAdaptor(self.name, LOGGER)
 
     def deploy(self) -> None:
-        """Run stacker build."""
+        """Run deploy."""
         cfngin = CFNgin(self.ctx, parameters=self.parameters, sys_path=self.path,)
         cfngin.deploy(force=bool(self.parameters or self.explicitly_enabled))
 
     def destroy(self) -> None:
-        """Run stacker destroy."""
+        """Run destroy."""
         cfngin = CFNgin(self.ctx, parameters=self.parameters, sys_path=self.path,)
         cfngin.destroy(force=bool(self.parameters or self.explicitly_enabled))
 
     def plan(self) -> None:
-        """Run stacker diff."""
+        """Run diff."""
         cfngin = CFNgin(self.ctx, parameters=self.parameters, sys_path=self.path,)
         cfngin.plan(force=bool(self.parameters or self.explicitly_enabled))

--- a/runway/templates/k8s-cfn-repo/k8s-master.cfn/stacks.yaml
+++ b/runway/templates/k8s-cfn-repo/k8s-master.cfn/stacks.yaml
@@ -15,7 +15,7 @@ stacks:
       EksVersion: ${EksVersion}
       VPC: ${VPCid}
 
-post_build:
+post_deploy:
   - path: k8s_hooks.bootstrap.create_runway_environments
     required: true
     args:

--- a/runway/templates/k8s-cfn-repo/k8s-workers.cfn/stacks.yaml
+++ b/runway/templates/k8s-cfn-repo/k8s-workers.cfn/stacks.yaml
@@ -6,7 +6,7 @@ lookups:
   bootstrap_value: local_lookups.bootstrap_value.bootstrap_value
 
 # Could specify a SSH keypair to allow access to the instances
-# pre_build:
+# pre_deploy:
 #   - path: stacker.hooks.keypair.ensure_keypair_exists
 #     required: true
 #     args:

--- a/runway/templates/k8s-tf-repo/gen-kubeconfig.cfn/hooks.yaml
+++ b/runway/templates/k8s-tf-repo/gen-kubeconfig.cfn/hooks.yaml
@@ -2,7 +2,7 @@ namespace: ${namespace}
 cfngin_bucket: ""  # not uploading any CFN templates
 sys_path: ./
 
-pre_build:
+pre_deploy:
   - path: k8s_hooks.awscli.aws_eks_update_kubeconfig
     required: true
     args:

--- a/tests/unit/cfngin/fixtures/vpc-bastion-db-web-pre-1.0.yaml
+++ b/tests/unit/cfngin/fixtures/vpc-bastion-db-web-pre-1.0.yaml
@@ -1,6 +1,6 @@
 namespace: test
 
-pre_build:
+pre_deploy:
   - path: runway.cfngin.hooks.route53.create_domain
     required: true
     enabled: true

--- a/tests/unit/cfngin/fixtures/vpc-bastion-db-web.yaml
+++ b/tests/unit/cfngin/fixtures/vpc-bastion-db-web.yaml
@@ -1,6 +1,6 @@
 namespace: test
 
-pre_build:
+pre_deploy:
   - path: runway.cfngin.hooks.route53.create_domain
     required: true
     enabled: true

--- a/tests/unit/cfngin/hooks/test_utils.py
+++ b/tests/unit/cfngin/hooks/test_utils.py
@@ -86,7 +86,7 @@ class TestHooks(unittest.TestCase):
                 }
             ),
         ]
-        handle_hooks("pre_build", hooks, self.provider, self.context)
+        handle_hooks("pre_deploy", hooks, self.provider, self.context)
         assert mock_load.call_count == 2
         mock_load.assert_has_calls(
             [call(hooks[0].path, try_reload=True), call(hooks[1].path, try_reload=True)]

--- a/tests/unit/cfngin/test_cfngin.py
+++ b/tests/unit/cfngin/test_cfngin.py
@@ -91,7 +91,7 @@ class TestCFNgin:
         )
         assert result.env_file["test_value"] == "lab-ca-central-1"
 
-    @patch("runway.cfngin.actions.build.Action")
+    @patch("runway.cfngin.actions.deploy.Action")
     def test_deploy(
         self,
         mock_action: MagicMock,

--- a/tests/unit/cfngin/test_util.py
+++ b/tests/unit/cfngin/test_util.py
@@ -124,15 +124,15 @@ class TestUtil(unittest.TestCase):
     def test_yaml_to_ordered_dict(self) -> None:
         """Test yaml to ordered dict."""
         raw_config = """
-        pre_build:
+        pre_deploy:
           hook2:
             path: foo.bar
           hook1:
             path: foo1.bar1
         """
         config = yaml_to_ordered_dict(raw_config)
-        self.assertEqual(list(config["pre_build"].keys())[0], "hook2")
-        self.assertEqual(config["pre_build"]["hook2"]["path"], "foo.bar")
+        self.assertEqual(list(config["pre_deploy"].keys())[0], "hook2")
+        self.assertEqual(config["pre_deploy"]["hook2"]["path"], "foo.bar")
 
     def test_get_client_region(self) -> None:
         """Test get client region."""

--- a/tests/unit/config/models/cfngin/test_cfngin.py
+++ b/tests/unit/config/models/cfngin/test_cfngin.py
@@ -19,7 +19,7 @@ class TestCfnginConfigDefinitionModel:
     """Test runway.config.models.cfngin.CfnginConfigDefinitionModel."""
 
     @pytest.mark.parametrize(
-        "field", ["post_build", "post_destroy", "pre_build", "pre_destroy"],
+        "field", ["post_deploy", "post_destroy", "pre_deploy", "pre_destroy"],
     )
     def test_convert_hook_definitions(self, field: str) -> None:
         """Test _convert_hook_definitions."""
@@ -75,9 +75,9 @@ class TestCfnginConfigDefinitionModel:
         assert obj.namespace_delimiter == "-"
         assert obj.package_sources == CfnginPackageSourcesDefinitionModel()
         assert not obj.persistent_graph_key
-        assert obj.post_build == []
+        assert obj.post_deploy == []
         assert obj.post_destroy == []
-        assert obj.pre_build == []
+        assert obj.pre_deploy == []
         assert obj.pre_destroy == []
         assert not obj.service_role
         assert obj.stacks == []


### PR DESCRIPTION
## Summary

Update terminology for consistency.

## What Changed

### Changed

- renamed `runway.cfngin.actions.build` to `runway.cfngin.actions.deploy`
- rename CFNgin hook stages from `pre_build` & `post_build` to `pre_deploy` & `post_deploy`