### PR TITLE
force multiprocessing to fork processes & disable parallel on non-posix systems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ good-names = [
     "j",
     "k",
     "ok",
+    "os",
     "ui",
     "v",
 ]

--- a/runway/context/base.py
+++ b/runway/context/base.py
@@ -10,6 +10,7 @@ from ..aws_sso_botocore.session import Session
 from ..cfngin.ui import ui
 from ..constants import BOTO3_CREDENTIAL_CACHE
 from ..type_defs import Boto3CredentialsTypeDef
+from .sys_info import SystemInfo
 
 if TYPE_CHECKING:
     from .._logging import PrefixAdaptor, RunwayLogger
@@ -24,6 +25,7 @@ class BaseContext:
 
     env: DeployEnvironment
     logger: Union[PrefixAdaptor, RunwayLogger]
+    sys_info: SystemInfo
 
     def __init__(
         self,
@@ -41,6 +43,7 @@ class BaseContext:
         """
         self.env = deploy_environment
         self.logger = logger
+        self.sys_info = SystemInfo()
 
     @property
     def boto3_credentials(self) -> Boto3CredentialsTypeDef:

--- a/runway/context/runway.py
+++ b/runway/context/runway.py
@@ -75,8 +75,13 @@ class RunwayContext(BaseContext):
 
         """
         if self.is_noninteractive:
+            if not self.sys_info.os.is_posix:
+                LOGGER.warning(
+                    "parallel execution disabled; only POSIX systems are supported currently"
+                )
+                return False
             return True
-        LOGGER.warning("Parallel execution disabled; not running in CI mode")
+        LOGGER.warning("parallel execution disabled; not running in CI mode")
         return False
 
     def copy(self) -> RunwayContext:

--- a/runway/context/sys_info.py
+++ b/runway/context/sys_info.py
@@ -1,0 +1,106 @@
+"""System Information."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from typing import Any, ClassVar, Optional, cast
+
+from ..compat import cached_property
+
+
+class OsInfo:
+    """Information about the operating system running on the current system."""
+
+    __instance: ClassVar[Optional[OsInfo]] = None
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> OsInfo:
+        """Create a new instance of class.
+
+        This class is a singleton so it will return always return the same instance.
+
+        """
+        if cls.__instance is None:
+            cls.__instance = cast(OsInfo, super().__new__(cls, *args, **kwargs))
+        return cls.__instance
+
+    @cached_property
+    def is_darwin(self) -> bool:
+        """Operating system is Darwin."""
+        return self.name == "darwin"
+
+    @cached_property
+    def is_linux(self) -> bool:
+        """Operating system is Linux."""
+        return self.name == "linux"
+
+    @cached_property
+    def is_macos(self) -> bool:
+        """Operating system is macOS.
+
+        Does not differentiate between macOS and Darwin.
+
+        """
+        return self.is_darwin
+
+    @cached_property
+    def is_posix(self) -> bool:
+        """Operating system is posix."""
+        return os.name == "posix"
+
+    @cached_property
+    def is_windows(self) -> bool:
+        """Operating system is Windows."""
+        return self.name == "windows"
+
+    @cached_property
+    def name(self) -> str:
+        """Operating system name set to lowercase for consistency."""
+        return platform.system().lower()
+
+    @classmethod
+    def clear_singleton(cls) -> None:
+        """Clear singleton instances.
+
+        Intended to only be used for running tests.
+
+        """
+        cls.__instance = None
+
+
+class SystemInfo:
+    """Information about the system running Runway."""
+
+    __instance: ClassVar[Optional[SystemInfo]] = None
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> SystemInfo:
+        """Create a new instance of class.
+
+        This class is a singleton so it will return always return the same instance.
+
+        """
+        if cls.__instance is None:
+            cls.__instance = cast(SystemInfo, super().__new__(cls, *args, **kwargs))
+        return cls.__instance
+
+    @cached_property
+    def is_frozen(self) -> bool:
+        """Whether or not Runway is running from a frozen package (Pyinstaller)."""
+        if getattr(sys, "frozen", False):
+            return True
+        return False
+
+    @cached_property
+    def os(self) -> OsInfo:
+        """Operating system information."""
+        return OsInfo()
+
+    @classmethod
+    def clear_singleton(cls) -> None:
+        """Clear singleton instances.
+
+        Intended to only be used for running tests.
+
+        """
+        cls.__instance = None

--- a/runway/context/sys_info.py
+++ b/runway/context/sys_info.py
@@ -18,7 +18,7 @@ class OsInfo:
     def __new__(cls, *args: Any, **kwargs: Any) -> OsInfo:
         """Create a new instance of class.
 
-        This class is a singleton so it will return always return the same instance.
+        This class is a singleton so it will always return the same instance.
 
         """
         if cls.__instance is None:
@@ -77,7 +77,7 @@ class SystemInfo:
     def __new__(cls, *args: Any, **kwargs: Any) -> SystemInfo:
         """Create a new instance of class.
 
-        This class is a singleton so it will return always return the same instance.
+        This class is a singleton so it will always return the same instance.
 
         """
         if cls.__instance is None:

--- a/runway/core/components/_deployment.py
+++ b/runway/core/components/_deployment.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import multiprocessing
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -231,7 +232,8 @@ class Deployment:
             "processing regions in parallel... (output will be interwoven)"
         )
         executor = concurrent.futures.ProcessPoolExecutor(
-            max_workers=self.ctx.env.max_concurrent_regions
+            max_workers=self.ctx.env.max_concurrent_regions,
+            mp_context=multiprocessing.get_context("fork"),
         )
         futures = [
             executor.submit(self.run, *[action, region]) for region in self.regions

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import concurrent.futures
 import json
 import logging
+import multiprocessing
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
@@ -251,7 +252,8 @@ class Module:
         # we need to be able to do things like `cd` which is not
         # thread safe.
         executor = concurrent.futures.ProcessPoolExecutor(
-            max_workers=self.ctx.env.max_concurrent_modules
+            max_workers=self.ctx.env.max_concurrent_modules,
+            mp_context=multiprocessing.get_context("fork"),
         )
         futures = [
             executor.submit(child.run, *[action]) for child in self.child_modules

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from _pytest.python import Module
     from docker import DockerClient
     from pytest import FixtureRequest, MonkeyPatch
+    from pytest_mock import MockerFixture
 
 LOG = logging.getLogger(__name__)
 TEST_ROOT = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -135,15 +136,21 @@ def patch_time(monkeypatch: MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def platform_darwin(monkeypatch: MonkeyPatch) -> None:
+def platform_darwin(mocker: MockerFixture) -> None:
     """Patch platform.system to always return "Darwin"."""
-    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    mocker.patch("platform.system", return_value="Darwin")
 
 
 @pytest.fixture
-def platform_windows(monkeypatch: MonkeyPatch) -> None:
+def platform_linux(mocker: MockerFixture) -> None:
+    """Patch platform.system to always return "Linux"."""
+    mocker.patch("platform.system", return_value="Linux")
+
+
+@pytest.fixture
+def platform_windows(mocker: MockerFixture) -> None:
     """Patch platform.system to always return "Windows"."""
-    monkeypatch.setattr("platform.system", lambda: "Windows")
+    mocker.patch("platform.system", return_value="Windows")
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/context/test_base.py
+++ b/tests/unit/context/test_base.py
@@ -10,6 +10,7 @@ import pytest
 from mock import MagicMock
 
 from runway.context.base import BaseContext
+from runway.context.sys_info import SystemInfo
 from runway.core.components import DeployEnvironment
 
 if TYPE_CHECKING:
@@ -160,3 +161,7 @@ class TestBaseContext:
             region_name="us-east-2",
             profile_name=None,
         )
+
+    def test_sys_info(self) -> None:
+        """Test sys_info."""
+        assert isinstance(BaseContext(deploy_environment=self.env).sys_info, SystemInfo)

--- a/tests/unit/context/test_runway.py
+++ b/tests/unit/context/test_runway.py
@@ -9,6 +9,7 @@ import pytest
 from mock import MagicMock
 
 from runway.context.runway import RunwayContext
+from runway.context.sys_info import OsInfo
 from runway.core.components import DeployEnvironment
 
 if TYPE_CHECKING:
@@ -89,8 +90,17 @@ class TestRunwayContext:
         mocker.patch.object(self.env, "vars", {"RUNWAY_COLORIZE": "invalid"})
         assert not RunwayContext(deploy_environment=self.env).no_color
 
-    def test_use_concurrent(self, mocker: MockerFixture) -> None:
+    def test_use_concurrent_not_posix(self, mocker: MockerFixture) -> None:
         """Test use_concurrent."""
+        mocker.patch.object(OsInfo, "is_posix", False)
+        mocker.patch.object(self.env, "ci", False)
+        assert not RunwayContext(deploy_environment=self.env).use_concurrent
+        mocker.patch.object(self.env, "ci", True)
+        assert not RunwayContext(deploy_environment=self.env).use_concurrent
+
+    def test_use_concurrent_posix(self, mocker: MockerFixture) -> None:
+        """Test use_concurrent."""
+        mocker.patch.object(OsInfo, "is_posix", True)
         mocker.patch.object(self.env, "ci", False)
         assert not RunwayContext(deploy_environment=self.env).use_concurrent
         mocker.patch.object(self.env, "ci", True)

--- a/tests/unit/context/test_sys_info.py
+++ b/tests/unit/context/test_sys_info.py
@@ -1,0 +1,114 @@
+"""Test runway.context.sys_info."""
+# pylint: disable=invalid-name,no-self-use,redefined-outer-name,unused-argument
+# pyright: basic
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from runway.context.sys_info import OsInfo, SystemInfo
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+MODULE = "runway.context.sys_info"
+
+
+@pytest.fixture(scope="function")
+def clear_OsInfo() -> None:  # noqa
+    """Clear OsInfo singleton."""
+    OsInfo.clear_singleton()
+
+
+@pytest.fixture(scope="function")
+def clear_SystemInfo() -> None:  # noqa
+    """Clear OsInfo singleton."""
+    SystemInfo.clear_singleton()
+
+
+@pytest.mark.usefixtures("clear_OsInfo")
+class TestOsInfo:
+    """Test OsInfo."""
+
+    def test_is_darwin_false(self, platform_linux: None) -> None:
+        """Test is_darwin False."""
+        assert not OsInfo().is_darwin
+
+    def test_is_darwin(self, platform_darwin: None) -> None:
+        """Test is_darwin."""
+        assert OsInfo().is_darwin
+
+    def test_is_linux_false(self, platform_darwin: None) -> None:
+        """Test is_linux False."""
+        assert not OsInfo().is_linux
+
+    def test_is_linux(self, platform_linux: None) -> None:
+        """Test is_linux."""
+        assert OsInfo().is_linux
+
+    def test_is_macos_false(self, platform_linux: None) -> None:
+        """Test is_macos False."""
+        assert not OsInfo().is_macos
+
+    def test_is_macos(self, platform_darwin: None) -> None:
+        """Test is_macos."""
+        assert OsInfo().is_macos
+
+    def test_is_posix_false(self, mocker: MockerFixture) -> None:
+        """Test is_posix False."""
+        mock_os = mocker.patch(f"{MODULE}.os")
+        mock_os.name = "nt"
+        assert not OsInfo().is_posix
+
+    def test_is_posix(self, mocker: MockerFixture) -> None:
+        """Test is_posix."""
+        mock_os = mocker.patch(f"{MODULE}.os")
+        mock_os.name = "posix"
+        assert OsInfo().is_posix
+
+    def test_is_windows_false(self, platform_linux: None) -> None:
+        """Test is_windows False."""
+        assert not OsInfo().is_windows
+
+    def test_is_windows(self, platform_windows: None) -> None:
+        """Test is_windows."""
+        assert OsInfo().is_windows
+
+    def test_name_darwin(self, platform_darwin: None) -> None:
+        """Test name darwin."""
+        assert OsInfo().name == "darwin"
+
+    def test_name_linux(self, platform_linux: None) -> None:
+        """Test name linux."""
+        assert OsInfo().name == "linux"
+
+    def test_name_windows(self, platform_windows: None) -> None:
+        """Test name windows."""
+        assert OsInfo().name == "windows"
+
+    def test_singleton(self) -> None:
+        """Test singleton."""
+        assert id(OsInfo()) == id(OsInfo())
+
+
+@pytest.mark.usefixtures("clear_SystemInfo")
+class TestSystemInfo:
+    """Test SystemInfo."""
+
+    def test_is_frozen_false(self) -> None:
+        """Test is_frozen False."""
+        assert not SystemInfo().is_frozen
+
+    def test_is_frozen(self, mocker: MockerFixture) -> None:
+        """Test is_frozen."""
+        mocker.patch(f"{MODULE}.sys.frozen", True, create=True)
+        assert SystemInfo().is_frozen
+
+    def test_os(self) -> None:
+        """Test os."""
+        assert isinstance(SystemInfo().os, OsInfo)
+
+    def test_singleton(self) -> None:
+        """Test singleton."""
+        assert id(SystemInfo()) == id(SystemInfo())

--- a/tests/unit/core/components/test_module.py
+++ b/tests/unit/core/components/test_module.py
@@ -357,6 +357,7 @@ class TestModule:
         executor = MagicMock()
         mock_futures.ProcessPoolExecutor.return_value = executor
         mocker.patch.object(Module, "use_async", True)
+        mock_mp_context = mocker.patch("multiprocessing.get_context")
 
         obj = Module(
             context=runway_context,
@@ -367,8 +368,10 @@ class TestModule:
             "parallel_parent:processing modules in parallel... (output "
             "will be interwoven)" in caplog.messages
         )
+        mock_mp_context.assert_called_once_with("fork")
         mock_futures.ProcessPoolExecutor.assert_called_once_with(
-            max_workers=runway_context.env.max_concurrent_modules
+            max_workers=runway_context.env.max_concurrent_modules,
+            mp_context=mock_mp_context.return_value,
         )
         executor.submit.assert_has_calls(
             [


### PR DESCRIPTION
## Summary

Forcing multiprocessing to fork processes instead of spawn new ones ensures that all necessary modules and configuration (such as logging) is loaded into memory in each child processes. There have been issues identified were processes that were spawned instead of forked do not have required configurations in place.

Forking processes is only supported on posix systems so parallel execution has been disabled for the time being. We plan to reenable it in the future after we are able to implement proper support for spawned child processes.

## Why This Is Needed

resolves #509

## What Changed

### Added

- added classes for easy access to system information and asserting various values
  - access to the info is made available on context objects

### Changed

- child processes created using the `concurrent.futures` library are now forked from the parent process
- asynchronous deployment of deployments and modules has been disabled on non-posix (e.g. windows) systems 

### Removed

- fixed an issues causing log messages to be delayed or skipped during parallel execution on macOS and Windows systems
