### PR TITLE
avoid awscli instantiation during kbenv

### DIFF
--- a/runway/_cli/commands/_run_aws.py
+++ b/runway/_cli/commands/_run_aws.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any, Tuple  # noqa pylint: disable=unused-import
 
 import click
-from awscli.clidriver import create_clidriver
 
 from ...util import SafeHaven
 from .. import options
@@ -31,6 +30,13 @@ def run_aws(ctx, args, **_):
     before the awscli command.
 
     """
+    # Ensure runway awscli v1 is not instantiated during `runway kbenv` executions,
+    # which may in turn invoke system awscli v2 via kubeconfigs causing a
+    # "'Namespace' object has no attribute 'cli_binary_format'" error
+    from awscli.clidriver import (  # pylint: disable=import-outside-toplevel
+        create_clidriver,
+    )
+
     if not ctx.obj.debug:
         # suppress awscli debug logs
         for name, logger in logging.getLogger("awscli").manager.loggerDict.items():

--- a/runway/core/providers/aws/_cli.py
+++ b/runway/core/providers/aws/_cli.py
@@ -2,8 +2,6 @@
 import logging
 from typing import List  # pylint: disable=W
 
-from awscli.clidriver import create_clidriver
-
 from ....util import SafeHaven
 
 LOGGER = logging.getLogger(__name__.replace("._", "."))
@@ -20,6 +18,13 @@ def cli(cmd):
         RuntimeError: awscli returned a non-zero exit code.
 
     """
+    # Ensure runway awscli v1 is not instantiated during `runway kbenv` executions,
+    # which may in turn invoke system awscli v2 via kubeconfigs causing a
+    # "'Namespace' object has no attribute 'cli_binary_format'" error
+    from awscli.clidriver import (  # pylint: disable=import-outside-toplevel
+        create_clidriver,
+    )
+
     LOGGER.debug("passing command to awscli: %s", " ".join(cmd))
     with SafeHaven(argv=cmd, environ={"LC_CTYPE": "en_US.UTF"}):
         exit_code = create_clidriver().main(cmd)

--- a/tests/unit/core/providers/aws/test_cli.py
+++ b/tests/unit/core/providers/aws/test_cli.py
@@ -6,28 +6,26 @@ from mock import patch
 
 from runway.core.providers.aws import cli
 
-MODULE = "runway.core.providers.aws._cli"
 
-
-@patch(MODULE + ".create_clidriver")
-def test_cli(mock_clidriver, caplog):
+def test_cli(caplog):
     """Test cli."""
-    caplog.set_level(logging.DEBUG, logger="runway.core.providers.aws.cli")
-    mock_clidriver.return_value = mock_clidriver
-    mock_clidriver.main.return_value = 0
+    with patch("awscli.clidriver.create_clidriver") as mock_clidriver:
+        caplog.set_level(logging.DEBUG, logger="runway.core.providers.aws.cli")
+        mock_clidriver.return_value = mock_clidriver
+        mock_clidriver.main.return_value = 0
 
-    assert not cli(["test"])
-    assert "passing command to awscli: test" in caplog.messages
-    mock_clidriver.assert_called_once_with()
-    mock_clidriver.main.assert_called_once_with(["test"])
+        assert not cli(["test"])
+        assert "passing command to awscli: test" in caplog.messages
+        mock_clidriver.assert_called_once_with()
+        mock_clidriver.main.assert_called_once_with(["test"])
 
 
-@patch(MODULE + ".create_clidriver")
-def test_cli_non_zero(mock_clidriver):
+def test_cli_non_zero():
     """Test cli with non-zero exit code."""
-    mock_clidriver.return_value = mock_clidriver
-    mock_clidriver.main.return_value = 1
+    with patch("awscli.clidriver.create_clidriver") as mock_clidriver:
+        mock_clidriver.return_value = mock_clidriver
+        mock_clidriver.main.return_value = 1
 
-    with pytest.raises(RuntimeError) as excinfo:
-        assert cli(["test"])
-    assert str(excinfo.value) == "AWS CLI exited with code 1"
+        with pytest.raises(RuntimeError) as excinfo:
+            assert cli(["test"])
+        assert str(excinfo.value) == "AWS CLI exited with code 1"


### PR DESCRIPTION
This feels a tiny bit gross, but shouldn't have any performance issues at any point we'd care about and doesn't break any functionality that I can find.

Avoids weird interactions with runway awscli v1 and system installs of awscli v2.

Fixes: #548