### PR TITLE
update sls-tsc sample to use serialized compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `sls-tsc` sample to use individual, serialized package compilation via serverless-webpack v5.4
 
 ## [1.18.3] - 2021-02-27
 ### Fixed

--- a/runway/templates/sls-tsc/package.json
+++ b/runway/templates/sls-tsc/package.json
@@ -27,7 +27,7 @@
     "prettier": "^2.2.1",
     "serverless": "^2.15.0",
     "serverless-iam-roles-per-function": "^3.0.1",
-    "serverless-webpack": "^5.3.5",
+    "serverless-webpack": "^5.4.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.12",
     "ts-node": "^9.1.1",

--- a/runway/templates/sls-tsc/serverless.yml
+++ b/runway/templates/sls-tsc/serverless.yml
@@ -8,15 +8,12 @@ provider:
   name: aws
   runtime: nodejs12.x
 
-# After adding a few functions and associated dependencies, individual function
-# packages can be created to avoid a single massive zip file.
-# This comes at the cost of potential memory issues at build time:
-# https://github.com/serverless-heaven/serverless-webpack/issues/299
-# package:
-#   individually: true
+package:
+  individually: true
 
 custom:
   webpack:
+    serializedCompile: true
     excludeFiles:
       - "src/**/*.test.ts"
       - "src/**/__mocks__/*.ts"


### PR DESCRIPTION
New feature of serverless-webpack v5.4 allows for compilation to run in series, eliminating the memory exhaustion issue previously found in individual function packaging.