### PR TITLE
remove profile field from cfngin config

### DIFF
--- a/runway/cfngin/actions/base.py
+++ b/runway/cfngin/actions/base.py
@@ -156,7 +156,7 @@ class BaseAction:
         """
         if not self.provider_builder:
             raise ValueError("ProviderBuilder required to build a provider")
-        return self.provider_builder.build(region=stack.region, profile=stack.profile)
+        return self.provider_builder.build(region=stack.region)
 
     def ensure_cfn_bucket(self) -> None:
         """CloudFormation bucket where templates will be stored."""

--- a/runway/cfngin/stack.py
+++ b/runway/cfngin/stack.py
@@ -57,7 +57,6 @@ class Stack:
         mappings: Cloudformation mappings passed to the blueprint.
         name: Name of the stack taken from the definition.
         outputs: CloudFormation Stack outputs.
-        profile: Profile name from the stack definition.
         protected: Whether this stack is protected.
         region: AWS region name.
         termination_protection: The state of termination protection
@@ -80,7 +79,6 @@ class Stack:
     mappings: Dict[str, Dict[str, Dict[str, Any]]]
     name: str
     outputs: Dict[str, Any]
-    profile: Optional[str]
     protected: bool
     region: Optional[str]
     termination_protection: bool
@@ -125,7 +123,6 @@ class Stack:
         self.logging = True
         self.mappings = mappings or {}
         self.outputs = {}
-        self.profile = definition.profile
         self.protected = protected
         self.region = definition.region
         self.termination_protection = definition.termination_protection

--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -86,7 +86,6 @@ class CfnginStackDefinitionModel(ConfigProperty):
     )
     locked: bool = Field(False, description="Whether to limit updating of the stack.")
     name: str = Field(..., title="Stack Name", description="Name of the stack.")
-    profile: Optional[str]  # TODO remove
     protected: bool = Field(
         False,
         description="Whether to force all updates to the stack to be performed interactively.",

--- a/tests/unit/config/models/cfngin/test_cfngin.py
+++ b/tests/unit/config/models/cfngin/test_cfngin.py
@@ -191,7 +191,6 @@ class TestCfnginStackDefinitionModel:
         assert not obj.in_progress_behavior
         assert not obj.locked
         assert obj.name == "stack-name"
-        assert not obj.profile
         assert not obj.protected
         assert not obj.region
         assert obj.required_by == []

--- a/tests/unit/core/providers/aws/test_cli.py
+++ b/tests/unit/core/providers/aws/test_cli.py
@@ -19,22 +19,20 @@ MODULE = "runway.core.providers.aws._cli"
 def test_cli(caplog: LogCaptureFixture, mocker: MockerFixture) -> None:
     """Test cli."""
     caplog.set_level(logging.DEBUG, logger="runway.core.providers.aws.cli")
-    mock_clidriver = mocker.patch(f"{MODULE}.create_clidriver")
+    mock_clidriver = mocker.patch("awscli.clidriver.create_clidriver")
     mock_clidriver.return_value = mock_clidriver
     mock_clidriver.main.return_value = 0
-
-        assert not cli(["test"])
-        assert "passing command to awscli: test" in caplog.messages
-        mock_clidriver.assert_called_once_with()
-        mock_clidriver.main.assert_called_once_with(["test"])
+    assert not cli(["test"])
+    assert "passing command to awscli: test" in caplog.messages
+    mock_clidriver.assert_called_once_with()
+    mock_clidriver.main.assert_called_once_with(["test"])
 
 
 def test_cli_non_zero(mocker: MockerFixture) -> None:
     """Test cli with non-zero exit code."""
-    mock_clidriver = mocker.patch(f"{MODULE}.create_clidriver")
+    mock_clidriver = mocker.patch("awscli.clidriver.create_clidriver")
     mock_clidriver.return_value = mock_clidriver
     mock_clidriver.main.return_value = 1
-
-        with pytest.raises(RuntimeError) as excinfo:
-            assert cli(["test"])
-        assert str(excinfo.value) == "AWS CLI exited with code 1"
+    with pytest.raises(RuntimeError) as excinfo:
+        assert cli(["test"])
+    assert str(excinfo.value) == "AWS CLI exited with code 1"


### PR DESCRIPTION
## Why This Is Needed

resolves #516

## What Changed

### Removed

- removed `stack.profile` field from CFNgin config
  - removed all remaining uses for this field
