### PR TITLE
update pyright to <1.1.120

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "tar": "^4.4.10"
       },
       "devDependencies": {
-        "pyright": "1.1.112"
+        "pyright": "<1.1.120"
       }
     },
     "node_modules/chownr": {
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/pyright": {
-      "version": "1.1.112",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.112.tgz",
-      "integrity": "sha512-/pwzJWmGo3s7gETYq9CUcPP5F4ZxFBe9u8sQpEJDHD//YFi97EQjhBkOT4M6sNEKpG8u/nyoVRK9ZlGFBHZtcQ==",
+      "version": "1.1.119",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.119.tgz",
+      "integrity": "sha512-0qimTDltFCheQzVqhHdFQhbC3bpQ/+OC3+D5M0c9HAI8hSybFGRvm3ojlriHOhRi0QOIqF6RyBew81kEu1CVUg==",
       "dev": true,
       "bin": {
         "pyright": "index.js",
@@ -166,9 +166,9 @@
       }
     },
     "pyright": {
-      "version": "1.1.112",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.112.tgz",
-      "integrity": "sha512-/pwzJWmGo3s7gETYq9CUcPP5F4ZxFBe9u8sQpEJDHD//YFi97EQjhBkOT4M6sNEKpG8u/nyoVRK9ZlGFBHZtcQ==",
+      "version": "1.1.119",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.119.tgz",
+      "integrity": "sha512-0qimTDltFCheQzVqhHdFQhbC3bpQ/+OC3+D5M0c9HAI8hSybFGRvm3ojlriHOhRi0QOIqF6RyBew81kEu1CVUg==",
       "dev": true
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "pyright": "1.1.112"
+    "pyright": "<1.1.120"
   }
 }

--- a/runway/_cli/logs.py
+++ b/runway/_cli/logs.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger("runway")
 
 LOG_FORMAT = "[%(programname)s] %(message)s"
 LOG_FORMAT_VERBOSE = logging.BASIC_FORMAT
-LOG_FIELD_STYLES = {
+LOG_FIELD_STYLES: Dict[str, Dict[str, Any]] = {
     "asctime": {},
     "hostname": {},
     "levelname": {},
@@ -23,7 +23,7 @@ LOG_FIELD_STYLES = {
     "prefix": {},
     "programname": {},
 }
-LOG_LEVEL_STYLES = {
+LOG_LEVEL_STYLES: Dict[str, Dict[str, Any]] = {
     "critical": {"color": "red", "bold": True},
     "debug": {"color": "green"},
     "error": {"color": "red"},
@@ -96,7 +96,11 @@ class LogSettings:
 
         result = LOG_FIELD_STYLES.copy()
         if self.ENV["field_styles"]:
-            result.update(coloredlogs.parse_encoded_styles(self.ENV["field_styles"]))
+            result.update(
+                coloredlogs.parse_encoded_styles(  # type: ignore
+                    self.ENV["field_styles"]
+                )
+            )
         return result
 
     @cached_property
@@ -112,7 +116,11 @@ class LogSettings:
 
         result = LOG_LEVEL_STYLES.copy()
         if self.ENV["level_styles"]:
-            result.update(coloredlogs.parse_encoded_styles(self.ENV["level_styles"]))
+            result.update(
+                coloredlogs.parse_encoded_styles(  # type: ignore
+                    self.ENV["level_styles"]
+                )
+            )
         return result
 
     @cached_property

--- a/runway/_cli/utils.py
+++ b/runway/_cli/utils.py
@@ -272,9 +272,9 @@ def select_modules_using_tags(
         List of selected deployments with selected modules.
 
     """
-    deployments_to_run = []
+    deployments_to_run: List[RunwayDeploymentDefinition] = []
     for deployment in deployments:
-        modules_to_run = []
+        modules_to_run: List[RunwayModuleDefinition] = []
         for module in deployment.modules:
             if module.child_modules:
                 module.child_modules = [

--- a/runway/cfngin/actions/deploy.py
+++ b/runway/cfngin/actions/deploy.py
@@ -116,7 +116,7 @@ def _resolve_parameters(
         The resolved parameters.
 
     """
-    params = {}
+    params: Dict[str, Any] = {}
     param_defs = blueprint.get_parameter_definitions()
 
     for key, value in parameters.items():
@@ -247,7 +247,7 @@ class Action(BaseAction):
             resolved, all_parameters, required_parameters, provider_stack
         )
 
-        param_list = []
+        param_list: List[ParameterTypeDef] = []
 
         for key, value in parameters:
             param_dict: ParameterTypeDef = {"ParameterKey": key}
@@ -486,7 +486,7 @@ class Action(BaseAction):
 
         graph = Graph()
         config_stack_names = [stack.name for stack in self.context.stacks]
-        inverse_steps = []
+        inverse_steps: List[Step] = []
         persist_graph = self.context.persistent_graph.transposed()
 
         for ind_node, dep_nodes in persist_graph.dag.graph.items():

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -70,7 +70,7 @@ class DictValue(Generic[_OV, _NV]):
             Representation of the change (if any) between old and new value.
 
         """
-        output = []
+        output: List[str] = []
         if self.status() is self.UNMODIFIED:
             output = [self.formatter % (" ", self.key, self.old_value)]
         elif self.status() is self.ADDED:
@@ -115,7 +115,7 @@ def diff_dictionaries(
     common_set = old_set & new_set
 
     changes = 0
-    output = []
+    output: List[DictValue[Any, Any]] = []
     for key in added_set:
         changes += 1
         output.append(DictValue(key, None, new_dict[key]))

--- a/runway/cfngin/blueprints/base.py
+++ b/runway/cfngin/blueprints/base.py
@@ -255,7 +255,7 @@ def parse_user_data(
             is not given in the blueprint
 
     """
-    variable_values = {}
+    variable_values: Dict[str, Any] = {}
 
     for key, value in variables.items():
         if isinstance(value, CFNParameter):
@@ -337,7 +337,7 @@ class Blueprint:
             containing key/values for various parameter properties.
 
         """
-        output = {}
+        output: Dict[str, BlueprintVariableTypeDef] = {}
         for var_name, attrs in self.defined_variables().items():
             var_type = attrs.get("type")
             if isinstance(var_type, CFNType):
@@ -379,7 +379,7 @@ class Blueprint:
 
         """
         variables = self.get_variables()
-        output = {}
+        output: Dict[str, Any] = {}
         for key, value in variables.items():
             try:
                 output[key] = value.to_parameter_value()
@@ -497,7 +497,7 @@ class Blueprint:
             variables: Dictionary providing/overriding variable values.
 
         """
-        variables_to_resolve = []
+        variables_to_resolve: List[Variable] = []
         if variables:
             for key, value in variables.items():
                 variables_to_resolve.append(Variable(key, value, "cfngin"))

--- a/runway/cfngin/blueprints/testutil.py
+++ b/runway/cfngin/blueprints/testutil.py
@@ -130,7 +130,7 @@ class YamlDirTestGenerator:
     ) -> Iterator[BlueprintTestCase]:
         """Test generator."""
         # Search for tests in given paths
-        configs = []
+        configs: List[str] = []
         for directory in self.yaml_dirs:
             configs.extend(
                 glob("%s/%s/%s" % (self.classdir, directory, self.yaml_filename))

--- a/runway/cfngin/blueprints/variables/types.py
+++ b/runway/cfngin/blueprints/variables/types.py
@@ -71,19 +71,19 @@ class TroposphereType(Generic[_TroposphereType]):
         return str(getattr(self._type, "resource_name", None) or self._type.__name__)
 
     @overload
-    def create(self, value: Dict[str, Any]) -> _TroposphereType:  # noqa
+    def create(self, value: Dict[str, Any]) -> _TroposphereType:
         ...
 
     @overload
-    def create(self, value: List[Dict[str, Any]]) -> List[_TroposphereType]:  # noqa
+    def create(self, value: List[Dict[str, Any]]) -> List[_TroposphereType]:
         ...
 
     @overload
-    def create(self, value: None) -> None:  # noqa
+    def create(self, value: None) -> None:
         ...
 
     def create(
-        self, value: Union[Dict[str, Any], List[Dict[str, Any]]]
+        self, value: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]
     ) -> Optional[Union[_TroposphereType, List[_TroposphereType]]]:
         """Create the troposphere type from the value.
 

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -86,7 +86,7 @@ class CFNgin:
     @cached_property
     def env_file(self) -> MutableMap:
         """Contents of a CFNgin environment file."""
-        result = {}
+        result: Dict[str, Any] = {}
         supported_names = [
             "{}.env".format(self.__ctx.env.name),
             "{}-{}.env".format(self.__ctx.env.name, self.region),

--- a/runway/cfngin/dag/__init__.py
+++ b/runway/cfngin/dag/__init__.py
@@ -187,7 +187,7 @@ class DAG:
             combinations += [[node, edge] for edge in edges]
 
         while True:
-            new_combinations = []
+            new_combinations: List[List[str]] = []
             for comb1 in combinations:
                 for comb2 in combinations:
                     if comb1[-1] != comb2[0]:
@@ -360,7 +360,7 @@ class DAG:
             if value == 0:
                 queue.appendleft(node)
 
-        sorted_graph = []
+        sorted_graph: List[str] = []
         while queue:
             node = queue.pop()
             sorted_graph.append(node)
@@ -427,7 +427,7 @@ class ThreadedWalker:
         nodes.reverse()
 
         # This maps a node name to a thread of execution.
-        threads = {}
+        threads: Dict[str, Any] = {}
 
         # Blocks until all of the given nodes have completed execution (whether
         # successfully, or errored). Returns True if all nodes returned True.

--- a/runway/cfngin/environment.py
+++ b/runway/cfngin/environment.py
@@ -9,7 +9,7 @@ def parse_environment(raw_environment: str) -> Dict[str, Any]:
         raw_environment: Environment file read into a string.
 
     """
-    environment = {}
+    environment: Dict[str, Any] = {}
     for line in raw_environment.split("\n"):
         line = line.strip()
         if not line:

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -486,7 +486,7 @@ def dockerized_pip(
 
     LOGGER.info('using docker image "%s" to build deployment package...', docker_image)
 
-    docker_run_args = {}
+    docker_run_args: Dict[str, Any] = {}
     if python_dontwritebytecode:
         docker_run_args["environment"] = "1"
 
@@ -627,7 +627,7 @@ def _zip_package(  # pylint: disable=too-many-locals,too-many-statements
             "--no-color",
         ]
 
-        subprocess_args = {}
+        subprocess_args: Dict[str, Any] = {}
         if python_dontwritebytecode:
             subprocess_args["env"] = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
 
@@ -1115,7 +1115,7 @@ def upload_lambda_functions(context: CfnginContext, provider: Provider, **kwargs
 
     # Check for S3 object acl. Valid values from:
     # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
-    payload_acl = kwargs.get("payload_acl", "private")
+    payload_acl = cast(PayloadAclTypeDef, kwargs.get("payload_acl", "private"))
 
     # Always use the global client for s3
     session = context.get_session(region=bucket_region)
@@ -1125,7 +1125,7 @@ def upload_lambda_functions(context: CfnginContext, provider: Provider, **kwargs
 
     prefix = kwargs.get("prefix", "")
 
-    results = {}
+    results: Dict[str, Any] = {}
     for name, options in kwargs["functions"].items():
         sys_path = (
             os.path.dirname(context.config_path)

--- a/runway/cfngin/hooks/docker/data_models.py
+++ b/runway/cfngin/hooks/docker/data_models.py
@@ -133,10 +133,10 @@ class BaseModel:
     @classmethod
     def _validate_dict(
         cls,
-        value: Union[Dict[str, Any], Any],
+        value: Optional[Union[Dict[str, Any], Any]],
         optional: bool = False,
         required: bool = False,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[Union[Dict[str, Any], NoReturn]]:
         """Validate a Dict type attribute."""
         if not value:
             if required:

--- a/runway/cfngin/hooks/ecr/_purge_repository.py
+++ b/runway/cfngin/hooks/ecr/_purge_repository.py
@@ -54,7 +54,7 @@ def list_ecr_images(
     client: ECRClient, repository_name: str,
 ) -> List[ImageIdentifierTypeDef]:
     """List all images in an ECR repository."""
-    image_ids = []
+    image_ids: List[ImageIdentifierTypeDef] = []
     try:
         response = client.list_images(
             repositoryName=repository_name, filter={"tagStatus": "ANY"}

--- a/runway/cfngin/hooks/ecs.py
+++ b/runway/cfngin/hooks/ecs.py
@@ -40,7 +40,7 @@ def create_clusters(
     if isinstance(clusters, str):
         clusters = [clusters]
 
-    cluster_info = {}
+    cluster_info: Dict[str, Any] = {}
     for cluster in clusters:
         LOGGER.debug("creating ECS cluster: %s", cluster)
         response = conn.create_cluster(clusterName=cluster)

--- a/runway/cfngin/hooks/keypair.py
+++ b/runway/cfngin/hooks/keypair.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 from botocore.exceptions import ClientError
 from typing_extensions import Literal, TypedDict
@@ -108,7 +108,7 @@ def create_key_pair_in_ssm(
     keypair = create_key_pair(ec2, keypair_name)
     try:
         kms_key_label = "default"
-        kms_args = {}
+        kms_args: Dict[str, Any] = {}
         if kms_key_id:
             kms_key_label = kms_key_id
             kms_args = {"KeyId": kms_key_id}

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -5,7 +5,7 @@ import collections.abc
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Any, List, Mapping, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, cast
 
 from ...exceptions import FailedVariableLookup
 from ...util import load_object_from_string
@@ -55,7 +55,7 @@ def handle_hooks(  # pylint: disable=too-many-statements
         LOGGER.debug("no %s hooks defined", stage)
         return
 
-    hook_paths = []
+    hook_paths: List[str] = []
     for i, hook in enumerate(hooks):
         try:
             hook_paths.append(hook.path)
@@ -90,7 +90,7 @@ def handle_hooks(  # pylint: disable=too-many-statements
                         "does not exist yet"
                     )
                 raise
-            kwargs = {v.name: v.value for v in args}
+            kwargs: Dict[str, Any] = {v.name: v.value for v in args}
         else:
             kwargs = {}
 

--- a/runway/cfngin/lookups/handlers/ami.py
+++ b/runway/cfngin/lookups/handlers/ami.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import operator
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict
 
 from ....lookups.handlers.base import LookupHandler
 from ...util import read_value_from_path
@@ -77,8 +77,8 @@ class AmiLookup(LookupHandler):
 
         ec2 = context.get_session(region=region).client("ec2")
 
-        values = {}
-        describe_args = {}
+        values: Dict[str, Any] = {}
+        describe_args: Dict[str, Any] = {}
 
         # now find any other arguments that can be filters
         matches = re.findall(r"([0-9a-zA-z_-]+:[^\s$]+)", value)

--- a/runway/cfngin/lookups/handlers/dynamodb.py
+++ b/runway/cfngin/lookups/handlers/dynamodb.py
@@ -197,7 +197,7 @@ def _convert_ddb_list_to_list(conversion_list: List[Dict[str, Any]]) -> List[Any
         Returns A sanitized list without the datatypes.
 
     """
-    ret_list = []
+    ret_list: List[Any] = []
     for val in conversion_list:
         for v in val:
             ret_list.append(val[v])

--- a/runway/cfngin/lookups/handlers/file.py
+++ b/runway/cfngin/lookups/handlers/file.py
@@ -175,7 +175,7 @@ def _parameterize_string(raw: str) -> GenericHelperFn:
         are found, and a composition of CloudFormation calls otherwise.
 
     """
-    parts = []
+    parts: List[Any] = []
     s_index = 0
 
     for match in _PARAMETER_PATTERN.finditer(raw):

--- a/runway/cfngin/plan.py
+++ b/runway/cfngin/plan.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    NoReturn,
     Optional,
     OrderedDict,
     Set,
@@ -51,6 +52,11 @@ _T = TypeVar("_T")
 
 @overload
 def json_serial(obj: Set[_T]) -> List[_T]:
+    ...
+
+
+@overload
+def json_serial(obj: Union[Dict[Any, Any], int, List[Any], str]) -> NoReturn:
     ...
 
 

--- a/runway/cfngin/stack.py
+++ b/runway/cfngin/stack.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, cast
 
 from typing_extensions import Literal
 
@@ -164,8 +164,7 @@ class Stack:
     def blueprint(self) -> Blueprint:
         """Return the blueprint associated with this stack."""
         if not self._blueprint:
-            kwargs = {}
-            blueprint_class = None
+            kwargs: Dict[str, Any] = {}
             if self.definition.class_path:
                 class_path = self.definition.class_path
                 blueprint_class = load_object_from_string(class_path)
@@ -183,12 +182,15 @@ class Stack:
                     "Stack does not have a defined class or " "template path."
                 )
 
-            self._blueprint = blueprint_class(
-                name=self.name,
-                context=self.context,
-                mappings=self.mappings,
-                description=self.definition.description,
-                **kwargs
+            self._blueprint = cast(
+                "Blueprint",
+                blueprint_class(
+                    name=self.name,
+                    context=self.context,
+                    mappings=self.mappings,
+                    description=self.definition.description,
+                    **kwargs
+                ),
             )
         return self._blueprint
 

--- a/runway/cfngin/tokenize_userdata.py
+++ b/runway/cfngin/tokenize_userdata.py
@@ -40,7 +40,7 @@ def cf_tokenize(raw_userdata: str) -> List[str]:
             Base64(Join('', cf_tokenize(userdata_string)))
 
     """
-    result = []
+    result: List[str] = []
     parts = SPLIT_RE.split(raw_userdata)
     for part in parts:
         cf_func = REPLACE_RE.search(part)

--- a/runway/cfngin/util.py
+++ b/runway/cfngin/util.py
@@ -19,6 +19,7 @@ from typing import (
     ClassVar,
     Dict,
     Iterator,
+    List,
     Optional,
     OrderedDict,
     Type,
@@ -265,7 +266,7 @@ def yaml_to_ordered_dict(
         ) -> None:
             """Check mapping node for dupe children keys."""
             if isinstance(node, yaml.MappingNode):
-                mapping = {}
+                mapping: Dict[str, Any] = {}
                 for val in node.value:
                     a = val[0]
                     b = mapping.get(a.value, None)
@@ -589,7 +590,7 @@ class SourceProcessor:
         self.cache_dir = cache_dir
         self.package_cache_dir = cache_dir / "packages"
         self.sources = sources
-        self.configs_to_merge = []
+        self.configs_to_merge: List[Path] = []
         self.create_cache_directories()
 
     def create_cache_directories(self) -> None:
@@ -657,7 +658,7 @@ class SourceProcessor:
             )
 
         session = get_session(region=None)
-        extra_s3_args = {}
+        extra_s3_args: Dict[str, Any] = {}
         if config.requester_pays:
             extra_s3_args["RequestPayer"] = "requester"
 
@@ -670,7 +671,7 @@ class SourceProcessor:
                     session.client("s3")
                     .head_object(Bucket=config.bucket, Key=config.key, **extra_s3_args)[
                         "LastModified"
-                    ]
+                    ]  # type: ignore
                     .astimezone(dateutil.tz.tzutc())  # type: ignore
                 )
             except botocore.exceptions.ClientError as client_error:

--- a/runway/config/__init__.py
+++ b/runway/config/__init__.py
@@ -246,7 +246,7 @@ class CfnginConfig(BaseConfig):
             return [path]
 
         exclude = exclude or []
-        result = []
+        result: List[Path] = []
         exclude.extend(cls.EXCLUDE_LIST)
 
         yml_files = list(path.glob("*.yml"))
@@ -354,7 +354,7 @@ class CfnginConfig(BaseConfig):
         config = yaml.safe_load(raw_data) or {}
         processor = SourceProcessor(
             sources=CfnginPackageSourcesDefinitionModel.parse_obj(
-                config.get("package_sources", {})
+                config.get("package_sources", {})  # type: ignore
             ),
             cache_dir=config.get("cfngin_cache_dir"),
         )

--- a/runway/config/components/runway/_deployment_def.py
+++ b/runway/config/components/runway/_deployment_def.py
@@ -127,7 +127,7 @@ class RunwayDeploymentDefinition(ConfigComponentDefinition):
             raise TypeError(
                 f"expected List[RunwayModuleDefinition]; got {type(modules)}"
             )
-        sanitized = []
+        sanitized: List[RunwayModuleDefinitionModel] = []
         for i, mod in enumerate(modules):
             if isinstance(mod, RunwayModuleDefinition):
                 sanitized.append(RunwayModuleDefinitionModel.parse_obj(mod.data))
@@ -177,7 +177,7 @@ class RunwayDeploymentDefinition(ConfigComponentDefinition):
         ...
 
     @classmethod
-    def parse_obj(
+    def parse_obj(  # type: ignore
         cls, obj: Any
     ) -> Union[RunwayDeploymentDefinition, List[RunwayDeploymentDefinition]]:
         """Parse a python object into this class.

--- a/runway/config/components/runway/_module_def.py
+++ b/runway/config/components/runway/_module_def.py
@@ -66,7 +66,7 @@ class RunwayModuleDefinition(ConfigComponentDefinition):
             raise TypeError(
                 f"expected List[RunwayModuleDefinition]; got {type(modules)}"
             )
-        sanitized = []
+        sanitized: List[RunwayModuleDefinitionModel] = []
         for i, mod in enumerate(modules):
             if isinstance(mod, RunwayModuleDefinition):
                 sanitized.append(RunwayModuleDefinitionModel.parse_obj(mod.data))

--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -301,7 +301,7 @@ class CfnginConfigDefinitionModel(ConfigProperty):
         """Convert stacks defined as a dict to a list."""
         if isinstance(v, list):
             return v
-        result = []
+        result: List[Dict[str, Any]] = []
         for name, stack in copy.deepcopy(v).items():
             stack["name"] = name
             result.append(stack)

--- a/runway/config/models/runway/__init__.py
+++ b/runway/config/models/runway/__init__.py
@@ -480,7 +480,7 @@ class RunwayModuleDefinitionModel(ConfigProperty):
         """Validate parallel."""
         if v and values.get("path"):
             raise ValueError("only one of parallel or path can be defined")
-        result = []
+        result: List[Dict[str, Any]] = []
         for mod in v:
             if isinstance(mod, str):
                 result.append({"path": mod})

--- a/runway/constants.py
+++ b/runway/constants.py
@@ -1,10 +1,11 @@
 """Runway constants."""
 from pathlib import Path
+from typing import Any, Dict
 
 # A global credential cache that can be shared among boto3 sessions. This is
 # inherently threadsafe thanks to the GIL:
 # https://docs.python.org/3/glossary.html#term-global-interpreter-lock
-BOTO3_CREDENTIAL_CACHE = {}
+BOTO3_CREDENTIAL_CACHE: Dict[str, Any] = {}
 
 DOT_RUNWAY_DIR = Path.cwd() / ".runway"
 

--- a/runway/core/__init__.py
+++ b/runway/core/__init__.py
@@ -94,7 +94,7 @@ class Runway:
 
         """
         deployments = deployments or self.deployments
-        result = {}
+        result: Dict[str, str] = {}
         for deployment in deployments:
             obj = components.Deployment(
                 context=self.ctx, definition=deployment, variables=self.variables
@@ -129,7 +129,7 @@ class Runway:
             Deployments and modules in reverse order.
 
         """
-        result = []
+        result: List[RunwayDeploymentDefinition] = []
         for deployment in deployments:
             deployment.reverse()
             result.insert(0, deployment)
@@ -163,7 +163,7 @@ class Runway:
             _sys.exit(1)
         self.ctx.command = "test"
 
-        failed_tests = []
+        failed_tests: List[str] = []
 
         LOGGER.info("found %i test(s)", len(self.tests))
         for tst in self.tests:

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -134,7 +134,7 @@ class Module:
     @cached_property
     def payload(self) -> Dict[str, Any]:  # lazy load the payload
         """Return payload to be passed to module class handler class."""
-        payload = {}
+        payload: Dict[str, Any] = {}
         if self.__deployment:
             payload.update(
                 {

--- a/runway/core/providers/aws/_account.py
+++ b/runway/core/providers/aws/_account.py
@@ -29,7 +29,7 @@ class AccountDetails:
         # Super overkill here using pagination when an account can only
         # have a single alias, but at least this implementation should be
         # future-proof.
-        aliases = []
+        aliases: List[str] = []
         paginator = self.__session.client("iam").get_paginator("list_account_aliases")
         response_iterator = paginator.paginate()
         for page in response_iterator:

--- a/runway/core/providers/aws/_response.py
+++ b/runway/core/providers/aws/_response.py
@@ -99,5 +99,5 @@ class BaseResponse:
             ResponseMetadata: Information about the request.
 
         """
-        self.error = ResponseError(**kwargs.pop("Error", {}))
-        self.metadata = ResponseMetadata(**kwargs.pop("ResponseMetadata", {}))
+        self.error = ResponseError(**kwargs.pop("Error", {}))  # type: ignore
+        self.metadata = ResponseMetadata(**kwargs.pop("ResponseMetadata", {}))  # type: ignore

--- a/runway/hooks/staticsite/auth_at_edge/domain_updater.py
+++ b/runway/hooks/staticsite/auth_at_edge/domain_updater.py
@@ -27,15 +27,15 @@ def update(
     session = context.get_session()
     cognito_client = session.client("cognito-idp")
 
-    context_dict = {}
+    context_dict: Dict[str, Any] = {}
 
     user_pool_id = context.hook_data["aae_user_pool_id_retriever"]["id"]
     user_pool = cognito_client.describe_user_pool(UserPoolId=user_pool_id).get(
-        "UserPool"
+        "UserPool", {}
     )
     (user_pool_region, user_pool_hash) = user_pool_id.split("_")
 
-    domain_prefix = user_pool.get("CustomDomain") or user_pool.get("Domain")
+    domain_prefix = user_pool.get("CustomDomain", user_pool.get("Domain"))
 
     # Return early if we already have a domain
     if domain_prefix:

--- a/runway/hooks/staticsite/auth_at_edge/lambda_config.py
+++ b/runway/hooks/staticsite/auth_at_edge/lambda_config.py
@@ -89,7 +89,7 @@ def write(  # pylint: disable=too-many-locals
 
     # Shared file that contains the method called for configuration data
     path = os.path.join(os.path.dirname(__file__), "templates", "shared.py")
-    context_dict = {}
+    context_dict: Dict[str, Any] = {}
 
     with open(path) as file_:
         # Dynamically replace our configuration values

--- a/runway/hooks/staticsite/cleanup.py
+++ b/runway/hooks/staticsite/cleanup.py
@@ -25,7 +25,7 @@ STACK_STATUSES_TO_IGNORE = [
 
 def get_replicated_function_names(outputs: List[OutputTypeDef],) -> List[str]:
     """Extract replicated function names from CFN outputs."""
-    function_names = []
+    function_names: List[str] = []
     for i in [
         "LambdaCheckAuthArn",
         "LambdaHttpHeadersArn",

--- a/runway/hooks/staticsite/upload_staticsite.py
+++ b/runway/hooks/staticsite/upload_staticsite.py
@@ -205,7 +205,7 @@ def prune_archives(context: CfnginContext, session: Session) -> bool:
 
     """
     LOGGER.info("cleaning up old site archives...")
-    archives = []
+    archives: List[Dict[str, Any]] = []
     s3_client = session.client("s3")
     list_objects_v2_paginator = s3_client.get_paginator("list_objects_v2")
     response_iterator = list_objects_v2_paginator.paginate(
@@ -214,7 +214,7 @@ def prune_archives(context: CfnginContext, session: Session) -> bool:
     )
 
     for page in response_iterator:
-        archives.extend(page.get("Contents", []))
+        archives.extend(page.get("Contents", []))  # type: ignore
     archives_to_prune = get_archives_to_prune(archives, context.hook_data["staticsite"])
 
     # Iterate in chunks of 1000 to match delete_objects limit
@@ -400,7 +400,7 @@ def sync_extra_files(
 
     session = context.get_session()
     s3_client = session.client("s3")
-    uploaded = []
+    uploaded: List[str] = []
 
     hash_param = cast(str, kwargs.get("hash_tracking_parameter", ""))
     hash_new = None

--- a/runway/hooks/staticsite/util.py
+++ b/runway/hooks/staticsite/util.py
@@ -55,7 +55,7 @@ def get_hash_of_files(
     if not directories:
         directories = [{"path": "./"}]
 
-    files_to_hash = []
+    files_to_hash: List[str] = []
     for i in directories:
         ignorer = get_ignorer(
             root_path / cast(str, i["path"]), cast(List[str], i.get("exclusions"))
@@ -64,8 +64,8 @@ def get_hash_of_files(
         with change_dir(root_path):
             for root, dirs, files in os.walk(cast(str, i["path"]), topdown=True):
                 if (root != "./") and ignorer.is_ignored(root, True):
-                    dirs[:] = []
-                    files[:] = []
+                    dirs[:] = []  # type: ignore
+                    files[:] = []  # type: ignore
                 else:
                     for filename in files:
                         filepath = os.path.join(root, filename)

--- a/runway/lookups/handlers/base.py
+++ b/runway/lookups/handlers/base.py
@@ -205,7 +205,7 @@ class LookupHandler:
         colon_split = raw_value.split("::", 1)
 
         query = colon_split.pop(0)
-        args = cls._parse_args(colon_split[0]) if colon_split else {}
+        args: Dict[str, str] = cls._parse_args(colon_split[0]) if colon_split else {}
 
         return query, args
 

--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -120,7 +120,7 @@ class CloudDevelopmentKit(RunwayModuleNpm):
                             env=self.ctx.env.vars,
                         )
                         self.logger.info("build steps (complete)")
-                    cdk_context_opts = []
+                    cdk_context_opts: List[str] = []
                     for key, val in cast(Dict[str, str], self.parameters).items():
                         cdk_context_opts.extend(["-c", "%s=%s" % (key, val)])
                     cdk_opts.extend(cdk_context_opts)

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -35,7 +35,7 @@ LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 
 def gen_sls_config_files(stage: str, region: str) -> List[str]:
     """Generate possible SLS config files names."""
-    names = []
+    names: List[str] = []
     for ext in ["yml", "json"]:
         # Give preference to explicit stage-region files
         names.append(os.path.join("env", "%s-%s.%s" % (stage, region, ext)))
@@ -63,12 +63,12 @@ def get_src_hash(sls_config: Dict[str, Any], path: Path) -> Dict[str, str]:
     """Get hash(es) of serverless source."""
     funcs = sls_config["functions"]
 
-    if sls_config.get("package", {}).get("individually"):
+    if sls_config.get("package", {"": ""}).get("individually"):
         return {
             key: get_hash_of_files(path / os.path.dirname(funcs[key].get("handler")))
             for key in funcs.keys()
         }
-    directories = []
+    directories: List[Dict[str, Union[List[str], str]]] = []
     for _key, value in funcs.items():
         func_path = {"path": os.path.dirname(value.get("handler"))}
         if func_path not in directories:
@@ -434,7 +434,7 @@ class ServerlessOptions(ModuleOptions):
     @property
     def args(self) -> List[str]:
         """List of CLI arguments/options to pass to the Serverless Framework CLI."""
-        known_args = []
+        known_args: List[str] = []
         for key, val in self._cli_args.items():
             if isinstance(val, str):
                 known_args.extend(["--%s" % key, val])

--- a/runway/module/staticsite/handler.py
+++ b/runway/module/staticsite/handler.py
@@ -7,7 +7,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 import yaml
 
@@ -163,7 +163,7 @@ class StaticSite(RunwayModule):
         return module_dir
 
     def _create_dependencies_yaml(self, module_dir: Path) -> None:
-        pre_deploy = []
+        pre_deploy: List[Any] = []
 
         pre_destroy = [
             {
@@ -222,7 +222,7 @@ class StaticSite(RunwayModule):
                     }
                 )
 
-        content = {
+        content: Dict[str, Any] = {
             "namespace": "${namespace}",
             "cfngin_bucket": "",
             "stacks": {

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -162,7 +162,7 @@ class Terraform(RunwayModule):
     @cached_property
     def env_file(self) -> List[str]:
         """Find the environment file for the module."""
-        result = []
+        result: List[str] = []
         for name in gen_workspace_tfvars_files(
             self.ctx.env.name, self.ctx.env.aws_region
         ):
@@ -630,7 +630,7 @@ class TerraformBackendConfig(ModuleOptions):
     @cached_property
     def init_args(self) -> List[str]:
         """Return command line arguments for init."""
-        result = []
+        result: List[str] = []
         for k, v in self.data.dict(exclude_none=True).items():
             result.extend(["-backend-config", f"{k}={v}"])
         if not result:
@@ -690,7 +690,7 @@ class TerraformBackendConfig(ModuleOptions):
             "backend-{region}.{extension}",
             "backend.{extension}",
         ]
-        result = []
+        result: List[str] = []
         for fmt in formats:
             for ext in ["hcl", "tfvars"]:
                 result.append(

--- a/runway/s3_util.py
+++ b/runway/s3_util.py
@@ -5,7 +5,7 @@ import logging
 import os
 import tempfile
 import zipfile
-from typing import TYPE_CHECKING, Iterator, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Sequence, cast
 
 import boto3
 from botocore.exceptions import ClientError
@@ -98,7 +98,7 @@ def ensure_bucket_exists(
         LOGGER.info('creating bucket "%s" (in progress)', bucket_name)
         s3_client = _get_client(session, region)
         if region == "us-east-1":
-            create_bucket_opts = {}
+            create_bucket_opts: Dict[str, Any] = {}
         else:
             create_bucket_opts = {
                 "CreateBucketConfiguration": {"LocationConstraint": region}

--- a/runway/tests/handlers/yaml_lint.py
+++ b/runway/tests/handlers/yaml_lint.py
@@ -31,7 +31,7 @@ class YamllintHandler(TestHandler):
     @classmethod
     def get_yamllint_options(cls, path: str) -> List[str]:
         """Return yamllint option list."""
-        yamllint_options = []
+        yamllint_options: List[str] = []
 
         return yamllint_options + cls.get_dirs(path) + cls.get_yaml_files_at_path(path)
 

--- a/runway/util.py
+++ b/runway/util.py
@@ -112,7 +112,7 @@ class MutableMap(MutableMapping[str, Any]):
         Removes anything that starts with ``_``.
 
         """
-        result = {}
+        result: Dict[str, Any] = {}
         for key, val in self.__dict__.items():
             if key.startswith("_"):
                 continue
@@ -628,8 +628,8 @@ def merge_nested_environment_dicts(
         return {}
 
     combined_dicts = merge_dicts(
-        cast(Dict[Any, Any], env_dicts.get("*", {})),
-        cast(Dict[Any, Any], env_dicts.get(env_name, {})),
+        cast(Dict[Any, Any], env_dicts.get("*", cast(Dict[Any, Any], {}))),
+        cast(Dict[Any, Any], env_dicts.get(env_name, cast(Dict[Any, Any], {}))),
     )
     return flatten_path_lists(combined_dicts, env_root)
 

--- a/runway/variables.py
+++ b/runway/variables.py
@@ -519,21 +519,27 @@ class VariableValueList(VariableValue, MutableSequence[VariableValue]):
     def __getitem__(self, __index: slice) -> List[VariableValue]:
         ...
 
-    def __getitem__(self, __index: int) -> VariableValue:
+    def __getitem__(
+        self, __index: Union[int, slice]
+    ) -> Union[List[VariableValue], VariableValue]:
         """Get item by index."""
-        return self._data[__index]
+        return self._data[__index]  # type: ignore
 
     @overload
-    def __setitem__(self, __index: int, __value: List[VariableValue]) -> None:
+    def __setitem__(self, __index: int, __value: VariableValue) -> None:
         ...
 
     @overload
     def __setitem__(self, __index: slice, __value: List[VariableValue]) -> None:
         ...
 
-    def __setitem__(self, __index: int, __value: VariableValue) -> None:
+    def __setitem__(
+        self,
+        __index: Union[int, slice],
+        __value: Union[List[VariableValue], VariableValue],
+    ) -> None:
         """Set item by index."""
-        self._data[__index] = __value
+        self._data[__index] = __value  # type: ignore
 
     def __iter__(self) -> Iterator[VariableValue]:
         """Object iteration."""
@@ -704,7 +710,9 @@ class VariableValueConcatenation(Generic[_VariableValue], VariableValue):
     def __getitem__(self, __index: slice) -> List[_VariableValue]:
         ...
 
-    def __getitem__(self, __index: int) -> _VariableValue:
+    def __getitem__(
+        self, __index: Union[int, slice]
+    ) -> Union[List[_VariableValue], _VariableValue]:
         """Get item by index."""
         return self._data[__index]
 
@@ -716,7 +724,11 @@ class VariableValueConcatenation(Generic[_VariableValue], VariableValue):
     def __setitem__(self, __index: slice, __value: List[_VariableValue]) -> None:
         ...
 
-    def __setitem__(self, __index: int, __value: _VariableValue) -> None:
+    def __setitem__(
+        self,
+        __index: Union[int, slice],
+        __value: Union[List[_VariableValue], _VariableValue],
+    ) -> None:
         """Set item by index."""
         self._data[__index] = __value
 

--- a/tests/unit/cfngin/actions/test_deploy.py
+++ b/tests/unit/cfngin/actions/test_deploy.py
@@ -97,7 +97,7 @@ class TestBuildAction(unittest.TestCase):
         self, extra_config_args: Optional[Dict[str, Any]] = None, **kwargs: Any
     ) -> CfnginContext:
         """Get context."""
-        config = {
+        config: Dict[str, Any] = {
             "namespace": "namespace",
             "stacks": [
                 {"name": "vpc", "template_path": "."},
@@ -174,7 +174,7 @@ class TestBuildAction(unittest.TestCase):
         """Test missing params no existing stack."""
         all_params = ["Address", "StackName"]
         required = ["Address"]
-        parameter_values = {}
+        parameter_values: Dict[str, Any] = {}
         with self.assertRaises(exceptions.MissingParameterException) as result:
             _handle_missing_parameters(parameter_values, all_params, required)
 

--- a/tests/unit/cfngin/blueprints/test_base.py
+++ b/tests/unit/cfngin/blueprints/test_base.py
@@ -279,7 +279,7 @@ class TestVariables(unittest.TestCase):  # pylint: disable=too-many-public-metho
         """Test resolve variable no type on variable definition."""
         with self.assertRaises(VariableTypeRequired):
             var_name = "testVar"
-            var_def = {}
+            var_def: Dict[str, Any] = {}
             provided_variable = None
             blueprint_name = "testBlueprint"
 

--- a/tests/unit/cfngin/blueprints/test_raw.py
+++ b/tests/unit/cfngin/blueprints/test_raw.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import unittest
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, Dict, cast
 
 from mock import MagicMock
 
@@ -61,7 +61,7 @@ def test_get_template_path_file_in_syspath(
 
 def test_get_template_params() -> None:
     """Verify get_template_params function operation."""
-    template_dict = {
+    template_dict: Dict[str, Any] = {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Description": "TestTemplate",
         "Parameters": {

--- a/tests/unit/cfngin/factories.py
+++ b/tests/unit/cfngin/factories.py
@@ -72,7 +72,7 @@ def generate_definition(
     base_name: str, stack_id: Any, **overrides: Any
 ) -> CfnginStackDefinitionModel:
     """Generate definitions."""
-    definition = {
+    definition: Dict[str, Any] = {
         "name": f"{base_name}.{stack_id}",
         "class_path": f"tests.unit.cfngin.fixtures.mock_blueprints.{base_name.upper()}",
         "requires": [],

--- a/tests/unit/cfngin/lookups/handlers/test_dynamodb.py
+++ b/tests/unit/cfngin/lookups/handlers/test_dynamodb.py
@@ -3,7 +3,7 @@
 # pyright: basic
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 import pytest
 
@@ -171,7 +171,7 @@ class TestDynamoDBHandler:
             "Key": {"TestKey": {"S": "FakeVal"}},
             "ProjectionExpression": "FakeVal,TestMap,String1",
         }
-        empty_response = {"ResponseMetadata": {}}
+        empty_response: Dict[str, Any] = {"ResponseMetadata": {}}
         stubber.add_response("get_item", empty_response, expected_params)
         with stubber, pytest.raises(ValueError) as excinfo:
             DynamodbLookup.handle(

--- a/tests/unit/cfngin/providers/aws/test_default.py
+++ b/tests/unit/cfngin/providers/aws/test_default.py
@@ -465,13 +465,13 @@ class TestMethods(unittest.TestCase):
         stack_name = "mystack"
         template_url = "http://fake.s3url.com/blah.json"
         template_body = '{"fake_body": "woot"}'
-        std_args = {
+        std_args: Dict[str, Any] = {
             "stack_name": stack_name,
             "parameters": [],
             "tags": [],
             "template": Template(url=template_url),
         }
-        std_return = {
+        std_return: Dict[str, Any] = {
             "StackName": stack_name,
             "Parameters": [],
             "Tags": [],
@@ -521,8 +521,8 @@ class TestProviderDefaultMode(unittest.TestCase):
         """Test create_stack, no changeset, template url."""
         stack_name = "fake_stack"
         template = Template(url="http://fake.template.url.com/")
-        parameters = []
-        tags = []
+        parameters: List[Any] = []
+        tags: List[Any] = []
 
         expected_args = generate_cloudformation_args(
             stack_name, parameters, tags, template
@@ -546,8 +546,8 @@ class TestProviderDefaultMode(unittest.TestCase):
         stack_name = "fake_stack"
         template_path = Path("./tests/unit/cfngin/fixtures/cfn_template.yaml")
         template = Template(body=template_path.read_text())
-        parameters = []
-        tags = []
+        parameters: List[Any] = []
+        tags: List[Any] = []
 
         changeset_id = "CHANGESETID"
 
@@ -937,7 +937,7 @@ class TestProviderDefaultMode(unittest.TestCase):
         default.TAIL_RETRY_SLEEP = 0.01
         default.GET_EVENTS_SLEEP = 0.01
 
-        received_events = []
+        received_events: List[Any] = []
 
         def mock_log_func(event: Any) -> None:
             received_events.append(event)

--- a/tests/unit/cfngin/test_dag.py
+++ b/tests/unit/cfngin/test_dag.py
@@ -1,7 +1,7 @@
 """Tests for runway.cfngin.dag."""
 # pyright: basic
 import threading
-from typing import Any
+from typing import Any, List
 
 import pytest
 
@@ -69,7 +69,7 @@ def test_walk(empty_dag: DAG) -> None:
     # b and c should be executed at the same time.
     dag.from_dict({"a": ["b", "c"], "b": ["d"], "c": ["d"], "d": []})
 
-    nodes = []
+    nodes: List[Any] = []
 
     def walk_func(node: Any) -> bool:
         nodes.append(node)
@@ -210,7 +210,7 @@ def test_threaded_walker(empty_dag: DAG) -> None:
     dag.from_dict({"a": ["b", "c"], "b": ["d"], "c": ["d"], "d": []})
 
     lock = threading.Lock()  # Protects nodes from concurrent access
-    nodes = []
+    nodes: List[Any] = []
 
     def walk_func(node: Any) -> bool:
         lock.acquire()

--- a/tests/unit/cfngin/test_plan.py
+++ b/tests/unit/cfngin/test_plan.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import mock
 
@@ -79,7 +79,7 @@ class TestStep(unittest.TestCase):
     def test_from_persistent_graph(self) -> None:
         """Return list of steps from graph dict."""
         context = mock_context()
-        graph_dict = {"stack1": [], "stack2": ["stack1"]}
+        graph_dict: Dict[str, Any] = {"stack1": [], "stack2": ["stack1"]}
         result = Step.from_persistent_graph(graph_dict, context)
 
         self.assertEqual(2, len(result))
@@ -96,7 +96,7 @@ class TestGraph(unittest.TestCase):
     def setUp(self) -> None:
         """Run before tests."""
         self.context = mock_context()
-        self.graph_dict = {"stack1": [], "stack2": ["stack1"]}
+        self.graph_dict: Dict[str, Any] = {"stack1": [], "stack2": ["stack1"]}
         self.graph_dict_expected = {"stack1": set(), "stack2": set(["stack1"])}
         self.steps = Step.from_persistent_graph(self.graph_dict, self.context)
 
@@ -225,7 +225,7 @@ class TestPlan(unittest.TestCase):
         )
         context._persistent_graph = Graph.from_steps([Step(removed)])
 
-        calls = []
+        calls: List[str] = []
 
         def _launch_stack(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)
@@ -269,7 +269,7 @@ class TestPlan(unittest.TestCase):
             context=context,
         )
 
-        calls = []
+        calls: List[str] = []
 
         def _launch_stack(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)
@@ -299,7 +299,7 @@ class TestPlan(unittest.TestCase):
             context=self.context,
         )
 
-        calls = []
+        calls: List[str] = []
 
         def fn(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)
@@ -323,7 +323,7 @@ class TestPlan(unittest.TestCase):
             context=self.context,
         )
 
-        calls = []
+        calls: List[str] = []
 
         def fn(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)
@@ -346,7 +346,7 @@ class TestPlan(unittest.TestCase):
             context=self.context,
         )
 
-        calls = []
+        calls: List[str] = []
 
         def fn(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)
@@ -374,7 +374,7 @@ class TestPlan(unittest.TestCase):
             context=self.context,
         )
 
-        calls = []
+        calls: List[str] = []
 
         def fn(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)
@@ -400,7 +400,7 @@ class TestPlan(unittest.TestCase):
         )
         db = Stack(definition=generate_definition("db", 1), context=self.context)
 
-        calls = []
+        calls: List[str] = []
 
         def fn(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)
@@ -429,7 +429,7 @@ class TestPlan(unittest.TestCase):
             context=self.context,
         )
 
-        calls = []
+        calls: List[str] = []
 
         def fn(stack: Stack, status: Optional[Status] = None) -> Status:
             calls.append(stack.fqn)

--- a/tests/unit/cfngin/test_util.py
+++ b/tests/unit/cfngin/test_util.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
-from typing import Any, List
+from typing import Any, Dict, List, cast
 
 import boto3
 import mock
@@ -228,7 +228,7 @@ Outputs:
                 ),
                 "refs/heads/foo",
             )
-            for i in [{}, {"tag": "foo"}, {"commit": "1234"}]:
+            for i in [cast(Dict[str, Any], {}), {"tag": "foo"}, {"commit": "1234"}]:
                 self.assertEqual(
                     sp.determine_git_ls_remote_ref(
                         GitCfnginPackageSourceDefinitionModel(uri="git@foo", **i)

--- a/tests/unit/config/components/runway/test_deployment_def.py
+++ b/tests/unit/config/components/runway/test_deployment_def.py
@@ -1,7 +1,7 @@
 """Test runway.config.components.runway._deployment_dev."""
 # pylint: disable=no-self-use,protected-access
 # pyright: basic
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytest
 
@@ -118,13 +118,15 @@ class TestRunwayDeploymentDefinition:
 
     def test_parse_obj(self) -> None:
         """Test parse_obj."""
-        data = {"name": "test", "modules": [], "regions": ["us-east-1"]}
+        data: Dict[str, Any] = {"name": "test", "modules": [], "regions": ["us-east-1"]}
         obj = RunwayDeploymentDefinition.parse_obj(data)
         assert obj._data.dict(exclude_unset=True) == data
 
     def test_parse_obj_list(self) -> None:
         """Test parse_obj list."""
-        data = [{"name": "test", "modules": [], "regions": ["us-east-1"]}]
+        data: List[Dict[str, Any]] = [
+            {"name": "test", "modules": [], "regions": ["us-east-1"]}
+        ]
         result = RunwayDeploymentDefinition.parse_obj(data)
 
         assert isinstance(result, list)

--- a/tests/unit/config/models/runway/test_runway.py
+++ b/tests/unit/config/models/runway/test_runway.py
@@ -2,6 +2,7 @@
 # pylint: disable=no-self-use,too-few-public-methods
 # pyright: basic
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 import yaml
@@ -216,7 +217,7 @@ class TestRunwayDeploymentDefinitionModel:
     )
     def test_fields_string_lookup_only(self, field: str) -> None:
         """Test fields that support strings only for lookups."""
-        data = {}
+        data: Dict[str, Any] = {}
         if field not in ["parallel_regions", "regions"]:
             data["regions"] = ["us-east-1"]
         data[field] = "something"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, cast
 
 import pytest
 import yaml
@@ -54,7 +54,7 @@ def aws_credentials() -> Iterator[None]:
         "AWS_SECRET_ACCESS_KEY": "testing",
         "AWS_DEFAULT_REGION": "us-east-1",
     }
-    saved_env = {}
+    saved_env: Dict[str, Optional[str]] = {}
     for key, value in overrides.items():
         LOG.info("Overriding env var: %s=%s", key, value)
         saved_env[key] = os.environ.get(key, None)
@@ -109,7 +109,7 @@ def yaml_fixtures(request: FixtureRequest, fixture_dir: str) -> Dict[str, Any]:
 
     """
     file_paths = getattr(cast("Module", request.module), "YAML_FIXTURES", [])
-    result = {}
+    result: Dict[str, Any] = {}
     for file_path in file_paths:
         with open(os.path.join(fixture_dir, file_path)) as _file:
             data = _file.read()

--- a/tests/unit/context/test_cfngin.py
+++ b/tests/unit/context/test_cfngin.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 import pytest
 from botocore.response import StreamingBody
@@ -712,7 +712,9 @@ class TestCFNginContext:
         with stubber:
             assert obj.unlock_persistent_graph("123")
 
-    @pytest.mark.parametrize("graph_dict", [{"stack0": []}, {}])
+    @pytest.mark.parametrize(
+        "graph_dict", cast(List[Dict[str, List[str]]], [{"stack0": []}, {}])
+    )
     def test_unlock_persistent_graph(
         self, graph_dict: Dict[str, List[str]], mocker: MockerFixture
     ) -> None:

--- a/tests/unit/core/test_core.py
+++ b/tests/unit/core/test_core.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 import pytest
 from mock import MagicMock, call
@@ -274,7 +274,7 @@ class TestRunway:
     ) -> None:
         """Test test with handler not found."""
         caplog.set_level(logging.ERROR, logger="runway")
-        test_handlers = {}
+        test_handlers: Dict[str, Any] = {}
         monkeypatch.setattr(MODULE + "._TEST_HANDLERS", test_handlers)
         obj = Runway(runway_config, runway_context)  # type: ignore
 

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -59,7 +59,9 @@ terraform {
 def test_get_available_tf_versions(mocker: MockerFixture) -> None:
     """Test runway.env_mgr.tfenv.get_available_tf_versions."""
     mock_requests = mocker.patch(f"{MODULE}.requests")
-    response = {"terraform": {"versions": {"0.12.0": {}, "0.12.0-beta": {}}}}
+    response: Dict[str, Any] = {
+        "terraform": {"versions": {"0.12.0": {}, "0.12.0-beta": {}}}
+    }
     mock_requests.get.return_value = MagicMock(text=json.dumps(response))
     assert get_available_tf_versions() == ["0.12.0"]
     assert get_available_tf_versions(include_prerelease=True) == [

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -2,7 +2,7 @@
 # pyright: basic, reportIncompatibleMethodOverride=none
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, MutableMapping, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, Optional, Tuple
 
 import boto3
 import yaml
@@ -50,8 +50,8 @@ class MockBoto3Session:
             region_name: Same as boto3.Session.
 
         """
-        self._clients = clients or {}
-        self._client_calls = {}
+        self._clients = clients or MutableMap()
+        self._client_calls: Dict[str, Any] = {}
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_session_token = aws_session_token

--- a/tests/unit/mock_docker/fake_api.py
+++ b/tests/unit/mock_docker/fake_api.py
@@ -155,7 +155,7 @@ def post_fake_create_container() -> Tuple[int, Any]:
 
 def get_fake_inspect_container(tty: bool = False) -> Tuple[int, Any]:
     status_code = 200
-    response = {
+    response: Dict[str, Any] = {
         "Id": FAKE_CONTAINER_ID,
         "Config": {"Labels": {"foo": "bar"}, "Privileged": True, "Tty": tty},
         "ID": FAKE_CONTAINER_ID,

--- a/tests/unit/module/staticsite/options/test_models.py
+++ b/tests/unit/module/staticsite/options/test_models.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import pytest
 from pydantic import ValidationError
@@ -82,7 +82,13 @@ class TestRunwayStaticSiteExtraFileDataModel:
         assert obj.name == data["name"]
 
     @pytest.mark.parametrize(
-        "data", [{}, {"name": "test"}, {"content": "test"}, {"file": "test"}]
+        "data",
+        [
+            cast(Dict[str, str], {}),
+            {"name": "test"},
+            {"content": "test"},
+            {"file": "test"},
+        ],
     )
     def test_init_required(self, data: Dict[str, Any]) -> None:
         """Test init required fields."""

--- a/tests/unit/module/staticsite/parameters/test_models.py
+++ b/tests/unit/module/staticsite/parameters/test_models.py
@@ -1,7 +1,7 @@
 """Test runway.module.staticsite.parameters.models."""
 # pylint: disable=no-self-use
 # pyright: basic
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import pytest
 from pydantic import ValidationError
@@ -57,7 +57,7 @@ class TestRunwayStaticSiteLambdaFunctionAssociationDataModel:
     @pytest.mark.parametrize(
         "data",
         [
-            {},
+            cast(Dict[str, Any], {}),
             {"arn": "aws:arn:lambda:us-east-1:function:test"},
             {"type": "origin-request"},
         ],

--- a/tests/unit/module/test_base.py
+++ b/tests/unit/module/test_base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, cast
 
 import pytest
 
@@ -235,7 +235,7 @@ class TestRunwayModuleNpm:
     @pytest.mark.parametrize(
         "env_vars",
         [
-            {},
+            cast(Dict[str, str], {}),
             {"AWS_PROFILE": "something"},
             {"AWS_DEFAULT_PROFILE": "something", "AWS_PROFILE": "something"},
         ],

--- a/tests/unit/module/test_serverless.py
+++ b/tests/unit/module/test_serverless.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union, cast
 
 import pytest
 import yaml
@@ -509,14 +509,16 @@ class TestServerlessOptions:
         obj = ServerlessOptions.parse_obj(config)
 
         assert obj.args == config.get("args", [])
-        assert obj.extend_serverless_yml == config.get("extend_serverless_yml", {})
+        assert obj.extend_serverless_yml == config.get(
+            "extend_serverless_yml", cast(Dict[str, Any], {})
+        )
         if config.get("promotezip"):
             assert obj.promotezip
         else:
             assert not obj.promotezip
-        assert obj.promotezip.bucketname == config.get("promotezip", {}).get(
-            "bucketname"
-        )
+        assert obj.promotezip.bucketname == config.get(
+            "promotezip", cast(Dict[str, Any], {})
+        ).get("bucketname")
         assert obj.skip_npm_ci == config.get("skip_npm_ci", False)
 
     def test_parse_invalid_promotezip(self) -> None:

--- a/tests/unit/module/test_terraform.py
+++ b/tests/unit/module/test_terraform.py
@@ -370,7 +370,10 @@ class TestTerraform:  # pylint: disable=too-many-public-methods
         """Test handle_backend with no handler."""
         caplog.set_level(LogLevels.DEBUG, logger=MODULE)
         mock_get_full_configuration = MagicMock(return_value={})
-        backend = {"type": "unsupported", "config": {}}
+        backend: Dict[str, Union[Dict[str, Any], str]] = {
+            "type": "unsupported",
+            "config": {},
+        }
 
         obj = Terraform(runway_context, module_root=tmp_path)
         mocker.patch.object(obj, "tfenv", MagicMock(backend=backend))
@@ -465,7 +468,10 @@ class TestTerraform:  # pylint: disable=too-many-public-methods
         caplog.set_level(LogLevels.WARNING, logger=MODULE)
         monkeypatch.delenv("TF_WORKSPACE", raising=False)
         mock_get_full_configuration = MagicMock(return_value={})
-        backend = {"type": "remote", "config": {}}
+        backend: Dict[str, Union[Dict[str, Any], str]] = {
+            "type": "remote",
+            "config": {},
+        }
 
         obj = Terraform(runway_context, module_root=tmp_path)
         monkeypatch.setattr(obj, "tfenv", MagicMock(backend=backend))
@@ -940,7 +946,7 @@ class TestTerraformBackendConfig:
         tmp_path: Path,
     ) -> None:
         """Test init_args."""
-        expected = []
+        expected: List[str] = []
         for i in expected_items:
             expected.extend(["-backend-config", i])
         assert (

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -126,7 +126,7 @@ TestParamsTypeDef = Optional[Union[Dict[str, str], List[str], str]]
 class TestSafeHaven:
     """Test SafeHaven context manager."""
 
-    TEST_PARAMS = [
+    TEST_PARAMS: List[TestParamsTypeDef] = [
         (None),
         ("string"),
         ({}),


### PR DESCRIPTION
## Summary

Update pyright to `<1.1.120` and update code to pass type check.

`1.1.120` implements PEP 655 which is still a draft and is not supported by mypy_boto3 yet (heavily uses TypedDict)