### PR TITLE
replace `init` command with `new` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Use one of the endpoints below to download a single-binary executable version of
 ```shell
 $ curl -L oni.ca/runway/latest/osx -o runway
 $ chmod +x runway
-$ ./runway init
+$ ./runway new
 ```
 
 **Suggested use:** CloudFormation or Terraform projects
@@ -78,7 +78,7 @@ $ ./runway init
 
 ```shell
 $ npm i -D @onica/runway
-$ npx runway init
+$ npx runway new
 ```
 
 **Suggested use:** Serverless or AWS CDK projects
@@ -88,10 +88,10 @@ $ npx runway init
 
 ```shell
 $ pip install runway
-$ runway init
+$ runway new
 # OR
 $ pipenv install runway
-$ pipenv run runway init
+$ pipenv run runway new
 ```
 
 **Suggested use:** Python projects

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -332,39 +332,6 @@ If a directory already exists with the name Runway tries to use, the sample will
   $ runway gen-sample cfngin
   $ runway gen-sample static-react
 
-----
-
-
-.. _command-init:
-
-****
-init
-****
-
-.. file://./../../runway/_cli/commands/_envvars.py
-
-Creates a sample :ref:`runway-config` in the current directory.
-
-.. rubric:: Usage
-.. code-block:: text
-
-  $ runway init [OPTIONS]
-
-
-.. rubric:: Options
-.. code-block:: text
-
-  --debug                         Supply once to display Runway debug logs.
-                                  Supply twice to display all debug logs.
-  --no-color                      Disable color in Runway's logs.
-  --verbose                       Display Runway verbose logs.
-
-
-.. rubric:: Example
-.. code-block:: shell
-
-  $ runway init
-  $ runway init --debug
 
 ----
 
@@ -443,6 +410,42 @@ Uses the version of kubectl_ specified in the ``.kubectl-version`` file in the c
 
   $ runway kbenv run version --client
   $ runway kbenv run -- --help
+
+
+----
+
+
+.. _command-new:
+
+****
+new
+****
+
+.. file://./../../runway/_cli/commands/_new.py
+
+Creates a sample :ref:`runway-config` in the current directory.
+
+.. rubric:: Usage
+.. code-block:: text
+
+  $ runway new [OPTIONS]
+
+
+.. rubric:: Options
+.. code-block:: text
+
+  --debug                         Supply once to display Runway debug logs.
+                                  Supply twice to display all debug logs.
+  --no-color                      Disable color in Runway's logs.
+  --verbose                       Display Runway verbose logs.
+
+
+.. rubric:: Example
+.. code-block:: shell
+
+  $ runway new
+  $ runway new --debug
+
 
 ----
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -115,12 +115,12 @@ Deploying Your First Module
 
 #. With the :ref:`module<runway-module>` ready to deploy, now we need to create
    our :ref:`Runway config file<runway-config>`. Do to this, use the
-   :ref:`init<command-init>` command to generate a sample file at the root of
+   :ref:`new<command-new>` command to generate a sample file at the root of
    the project repo.
 
    .. code-block:: shell
 
-       $ ./runway init
+       $ ./runway new
 
    **runway.yml contents**
 

--- a/runway/_cli/commands/__init__.py
+++ b/runway/_cli/commands/__init__.py
@@ -7,6 +7,7 @@ from ._envvars import envvars
 from ._gen_sample import gen_sample
 from ._init import init
 from ._kbenv import kbenv
+from ._new import new
 from ._plan import plan
 from ._preflight import preflight
 from ._run_aws import run_aws
@@ -27,6 +28,7 @@ __all__ = [
     "gen_sample",
     "init",
     "kbenv",
+    "new",
     "plan",
     "preflight",
     "run_aws",

--- a/runway/_cli/commands/_init.py
+++ b/runway/_cli/commands/_init.py
@@ -1,7 +1,6 @@
 """``runway init`` command."""
 # docs: file://./../../../docs/source/commands.rst
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import click
@@ -12,37 +11,12 @@ if TYPE_CHECKING:
     from ..._logging import RunwayLogger
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
-RUNWAY_YML = """---
-# See full syntax at https://docs.onica.com/projects/runway/en/latest/
-deployments:
-  - modules:
-      - path: sampleapp.cfn
-      - path: sampleapp.tf
-      # - etc...
-    regions:
-      - us-east-1
-"""
 
 
-@click.command("init", short_help="create runway.yml")
+@click.command("init", short_help="coming soon")
 @options.debug
 @options.no_color
 @options.verbose
-@click.pass_context
-def init(ctx: click.Context, **_: Any) -> None:
-    """Create an example runway.yml file in the currect directory."""
-    runway_yml = Path.cwd() / "runway.yml"
-
-    LOGGER.verbose("checking for preexisting runway.yml file...")
-    if runway_yml.is_file():
-        LOGGER.error(
-            "There is already a %s file in the current directory", runway_yml.name
-        )
-        ctx.exit(1)
-
-    runway_yml.write_text(RUNWAY_YML)
-    LOGGER.success("runway.yml generated")
-    LOGGER.notice(
-        "See addition getting started information at "
-        "https://docs.onica.com/projects/runway/en/latest/getting_started.html"
-    )
+def init(**_: Any) -> None:
+    """Coming soon."""
+    LOGGER.warning("functionality comming soon")

--- a/runway/_cli/commands/_new.py
+++ b/runway/_cli/commands/_new.py
@@ -1,0 +1,48 @@
+"""``runway new`` command."""
+# docs: file://./../../../docs/source/commands.rst
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import click
+
+from .. import options
+
+if TYPE_CHECKING:
+    from ..._logging import RunwayLogger
+
+LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
+RUNWAY_YML = """---
+# See full syntax at https://docs.onica.com/projects/runway/en/latest/
+deployments:
+  - modules:
+      - path: sampleapp.cfn
+      - path: sampleapp.tf
+      # - etc...
+    regions:
+      - us-east-1
+"""
+
+
+@click.command("new", short_help="create runway.yml")
+@options.debug
+@options.no_color
+@options.verbose
+@click.pass_context
+def new(ctx: click.Context, **_: Any) -> None:
+    """Create an example runway.yml file in the currect directory."""
+    runway_yml = Path.cwd() / "runway.yml"
+
+    LOGGER.verbose("checking for preexisting runway.yml file...")
+    if runway_yml.is_file():
+        LOGGER.error(
+            "There is already a %s file in the current directory", runway_yml.name
+        )
+        ctx.exit(1)
+
+    runway_yml.write_text(RUNWAY_YML)
+    LOGGER.success("runway.yml generated")
+    LOGGER.notice(
+        "See addition getting started information at "
+        "https://docs.onica.com/projects/runway/en/latest/getting_started.html"
+    )

--- a/tests/integration/cli/commands/test_init.py
+++ b/tests/integration/cli/commands/test_init.py
@@ -1,47 +1,12 @@
 """Test ``runway init`` command."""
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING
-
-import yaml
 from click.testing import CliRunner
 
 from runway._cli import cli
 
-if TYPE_CHECKING:
-    from pathlib import Path
 
-    from pytest import LogCaptureFixture
-
-
-def test_init(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
-    """Test ``runway init`` command."""
-    caplog.set_level(logging.INFO, logger="runway.cli")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["init"])
+def test_init() -> None:
+    """Test ``runway init``."""
+    result = CliRunner().invoke(cli, ["init"])
     assert result.exit_code == 0
-
-    # ensure the generated file is valid yaml
-    runway_yml = yaml.safe_load((cd_tmp_path / "runway.yml").read_text())
-
-    # simple check of the value
-    assert len(runway_yml["deployments"][0]["modules"]) == 2
-
-    assert caplog.messages == [
-        "runway.yml generated",
-        "See addition getting started information at "
-        "https://docs.onica.com/projects/runway/en/latest/getting_started.html",
-    ]
-
-
-def test_init_file_exists(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
-    """Test ``runway init`` command with existing file."""
-    caplog.set_level(logging.ERROR, logger="runway.cli")
-    (cd_tmp_path / "runway.yml").touch()
-    runner = CliRunner()
-    result = runner.invoke(cli, ["init"])
-    assert result.exit_code == 1
-    assert caplog.messages == [
-        "There is already a runway.yml file in the current directory"
-    ]

--- a/tests/integration/cli/commands/test_new.py
+++ b/tests/integration/cli/commands/test_new.py
@@ -1,0 +1,47 @@
+"""Test ``runway new`` command."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import yaml
+from click.testing import CliRunner
+
+from runway._cli import cli
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import LogCaptureFixture
+
+
+def test_new(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    """Test ``runway new`` command."""
+    caplog.set_level(logging.INFO, logger="runway.cli")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["new"])
+    assert result.exit_code == 0
+
+    # ensure the generated file is valid yaml
+    runway_yml = yaml.safe_load((cd_tmp_path / "runway.yml").read_text())
+
+    # simple check of the value
+    assert len(runway_yml["deployments"][0]["modules"]) == 2
+
+    assert caplog.messages == [
+        "runway.yml generated",
+        "See addition getting started information at "
+        "https://docs.onica.com/projects/runway/en/latest/getting_started.html",
+    ]
+
+
+def test_new_file_exists(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    """Test ``runway new`` command with existing file."""
+    caplog.set_level(logging.ERROR, logger="runway.cli")
+    (cd_tmp_path / "runway.yml").touch()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["new"])
+    assert result.exit_code == 1
+    assert caplog.messages == [
+        "There is already a runway.yml file in the current directory"
+    ]

--- a/tests/integration/cli/commands/test_schema.py
+++ b/tests/integration/cli/commands/test_schema.py
@@ -1,4 +1,4 @@
-"""Test ``runway schema cfngin`` command."""
+"""Test ``runway schema`` command."""
 from __future__ import annotations
 
 from click.testing import CliRunner


### PR DESCRIPTION
## Summary

Add `runway new` to replace `runway init`

## Why This Is Needed

This allows us to use `runway init` for initialization steps of applications like Terraform and CDK.

## What Changed

### Added

- added `new` command

### Changed

- `init` command will now only log that functionality is coming soon
