### PR TITLE
remove `region` field from cfngin stack configuration

### DIFF
--- a/runway/cfngin/actions/base.py
+++ b/runway/cfngin/actions/base.py
@@ -147,16 +147,11 @@ class BaseAction:
             raise ValueError("ProviderBuilder required to build a provider")
         return self.provider_builder.build()
 
-    def build_provider(self, stack: Stack) -> Provider:
-        """Build a CFNgin provider.
-
-        Args:
-            stack: Stack the action will be executed on.
-
-        """
+    def build_provider(self) -> Provider:
+        """Build a CFNgin provider."""
         if not self.provider_builder:
             raise ValueError("ProviderBuilder required to build a provider")
-        return self.provider_builder.build(region=stack.region)
+        return self.provider_builder.build()
 
     def ensure_cfn_bucket(self) -> None:
         """CloudFormation bucket where templates will be stored."""
@@ -292,7 +287,7 @@ class BaseAction:
         self, stack: Stack, cancel: threading.Event, retries: int = 0, **kwargs: Any
     ) -> None:
         """Tail a stack's event stream."""
-        provider = self.build_provider(stack)
+        provider = self.build_provider()
         return provider.tail_stack(
             stack, cancel, action=self.NAME, retries=retries, **kwargs
         )

--- a/runway/cfngin/actions/deploy.py
+++ b/runway/cfngin/actions/deploy.py
@@ -277,7 +277,7 @@ class Action(BaseAction):
         if self.cancel.wait(wait_time):
             return INTERRUPTED
 
-        provider = self.build_provider(stack)
+        provider = self.build_provider()
 
         try:
             stack_data = provider.get_stack(stack.fqn)
@@ -327,7 +327,7 @@ class Action(BaseAction):
         if not should_submit(stack):
             return NotSubmittedStatus()
 
-        provider = self.build_provider(stack)
+        provider = self.build_provider()
 
         try:
             provider_stack = provider.get_stack(stack.fqn)

--- a/runway/cfngin/actions/destroy.py
+++ b/runway/cfngin/actions/destroy.py
@@ -49,7 +49,7 @@ class Action(BaseAction):
         if self.cancel.wait(wait_time):
             return INTERRUPTED
 
-        provider = self.build_provider(stack)
+        provider = self.build_provider()
 
         try:
             provider_stack = provider.get_stack(stack.fqn)

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -205,7 +205,7 @@ class Action(deploy.Action):
         if not deploy.should_submit(stack):
             return NotSubmittedStatus()
 
-        provider = self.build_provider(stack)
+        provider = self.build_provider()
 
         if not deploy.should_update(stack):
             stack.set_outputs(provider.get_outputs(stack.fqn))

--- a/runway/cfngin/actions/info.py
+++ b/runway/cfngin/actions/info.py
@@ -28,7 +28,7 @@ class Action(BaseAction):
         if not self.context.stacks:
             LOGGER.warning("no stacks detected (error in config?)")
         for stack in self.context.stacks:
-            provider = self.build_provider(stack)
+            provider = self.build_provider()
 
             try:
                 provider_stack = provider.get_stack(stack.fqn)

--- a/runway/cfngin/hooks/base.py
+++ b/runway/cfngin/hooks/base.py
@@ -286,7 +286,7 @@ class HookDeployAction(deploy.Action):
         """Override the inherited property to return the local provider."""
         return self._provider
 
-    def build_provider(self, stack: Stack) -> Provider:
+    def build_provider(self) -> Provider:
         """Override the inherited method to always return local provider."""
         return self._provider
 

--- a/runway/cfngin/stack.py
+++ b/runway/cfngin/stack.py
@@ -58,7 +58,6 @@ class Stack:
         name: Name of the stack taken from the definition.
         outputs: CloudFormation Stack outputs.
         protected: Whether this stack is protected.
-        region: AWS region name.
         termination_protection: The state of termination protection
             to apply to the stack.
         variables: Variables for the stack.
@@ -80,7 +79,6 @@ class Stack:
     name: str
     outputs: Dict[str, Any]
     protected: bool
-    region: Optional[str]
     termination_protection: bool
     variables: List[Variable]
 
@@ -124,7 +122,6 @@ class Stack:
         self.mappings = mappings or {}
         self.outputs = {}
         self.protected = protected
-        self.region = definition.region
         self.termination_protection = definition.termination_protection
         self.variables = _initialize_variables(definition, variables)
 

--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -90,7 +90,6 @@ class CfnginStackDefinitionModel(ConfigProperty):
         False,
         description="Whether to force all updates to the stack to be performed interactively.",
     )
-    region: Optional[str] = None  # TODO remove
     required_by: List[str] = Field(
         [], description="Array of stacks (by name) that require this stack."
     )

--- a/tests/unit/cfngin/hooks/test_base.py
+++ b/tests/unit/cfngin/hooks/test_base.py
@@ -242,7 +242,7 @@ class TestHookDeployAction:
         provider = MagicMock()
         obj = HookDeployAction(cfngin_context, provider)
 
-        assert obj.build_provider(None) == provider  # type: ignore
+        assert obj.build_provider() == provider
 
     def test_run(
         self, cfngin_context: MockCFNginContext, monkeypatch: MonkeyPatch

--- a/tests/unit/config/models/cfngin/test_cfngin.py
+++ b/tests/unit/config/models/cfngin/test_cfngin.py
@@ -192,7 +192,6 @@ class TestCfnginStackDefinitionModel:
         assert not obj.locked
         assert obj.name == "stack-name"
         assert not obj.protected
-        assert not obj.region
         assert obj.required_by == []
         assert obj.requires == []
         assert not obj.stack_name


### PR DESCRIPTION
## Summary

Remove the `region` field from stacks in CFNgin configs. Runway controls region selection so this is redundant. 

## Why This Is Needed

resolves #517 

## What Changed

### Changed

- removed `region` field from CFNgin stack configuration
