### PR TITLE
tfenv: log hcl errors & return empty dict if module can't be parsed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ help: ## show this message
 		printf "%s\n" $$help_info; \
 	done
 
+cov-report: ## display a report in the terminal of files missing coverage
+	@pipenv run coverage report \
+		--precision=2 \
+		--show-missing \
+		--skip-covered \
+		--skip-empty \
+		--rcfile=pyproject.toml
+
 list: ## list all targets in this Makefile
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
 
@@ -86,7 +94,7 @@ lint-pyright:
 
 test: ## run integration and unit tests
 	@echo "Running integration & unit tests..."
-	@pipenv run pytest --cov=runway --cov-report term:skip-covered --integration
+	@pipenv run pytest --cov=runway --cov-report term-missing:skip-covered --integration
 
 test-functional: ## run function tests only
 	@echo "Running functional tests..."
@@ -94,11 +102,11 @@ test-functional: ## run function tests only
 
 test-integration: ## run integration tests only
 	@echo "Running integration tests..."
-	@pipenv run pytest --cov=runway --cov-report term:skip-covered --integration-only
+	@pipenv run pytest --cov=runway --cov-report term-missing:skip-covered --integration-only
 
 test-unit: ## run unit tests only
 	@echo "Running unit tests..."
-	@pipenv run pytest --cov=runway --cov-config=tests/unit/.coveragerc --cov-report term-missing
+	@pipenv run pytest --cov=runway --cov-config=tests/unit/.coveragerc --cov-report term-missing:skip-covered
 
 create_tfenv_ver_file: ## create a tfenv version file using the latest version
 	curl --silent https://releases.hashicorp.com/index.json | jq -r '.terraform.versions | to_entries | map(select(.key | contains ("-") | not)) | sort_by(.key | split(".") | map(tonumber))[-1].key' | egrep -o '^[0-9]*\.[0-9]*\.[0-9]*' > runway/templates/terraform/.terraform-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,7 @@ addopts = [
     "--no-cov-on-fail"
 ]
 minversion = 6.0
-filterwarnings = ["ignore::DeprecationWarning"]
+filterwarnings = ["ignore::DeprecationWarning", "ignore::pytest_mock.PytestMockWarning"]
 python_classes = ["Test*"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -127,7 +127,7 @@ def load_terrafrom_module(parser: ModuleType, path: Path) -> Dict[str, Any]:
             tf_config = parser.loads(tf_file.read_text())  # type: ignore
             result = merge_dicts(result, cast(Dict[str, Any], tf_config))
         except Exception as exc:
-            raise HclParserError(exc, tf_file, parser)
+            raise HclParserError(exc, tf_file, parser) from None
     return result
 
 

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -111,7 +111,7 @@ def get_latest_tf_version(include_prerelease: bool = False) -> str:
     return get_available_tf_versions(include_prerelease)[0]
 
 
-def load_terrafrom_module(parser: ModuleType, path: Path) -> Dict[str, Any]:
+def load_terraform_module(parser: ModuleType, path: Path) -> Dict[str, Any]:
     """Load all Terraform files in a module into one dict.
 
     Args:
@@ -199,14 +199,14 @@ class TFEnvManager(EnvManager):
             return data
 
         try:
-            result: Union[Dict[str, Any], List[Dict[str, Any]]] = load_terrafrom_module(
+            result: Union[Dict[str, Any], List[Dict[str, Any]]] = load_terraform_module(
                 hcl2, self.path
             ).get("terraform", cast(Dict[str, Any], {}))
         except HclParserError as exc:
             LOGGER.warning(exc)
             LOGGER.warning("failed to parse as HCL2; trying HCL...")
             try:
-                result = load_terrafrom_module(hcl, self.path).get(
+                result = load_terraform_module(hcl, self.path).get(
                     "terraform", cast(Dict[str, Any], {})
                 )
             except HclParserError as exc:

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -11,8 +11,7 @@ import sys
 import tempfile
 import zipfile
 from distutils.version import LooseVersion
-from types import ModuleType
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast, overload
 from urllib.error import URLError
 from urllib.request import urlretrieve
 
@@ -20,11 +19,13 @@ import hcl
 import hcl2
 import requests
 
+from ..exceptions import HclParserError
 from ..util import cached_property, get_hash_for_filename, merge_dicts, sha256sum
 from . import EnvManager, handle_bin_download_error
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from types import ModuleType
 
     from .._logging import RunwayLogger
 
@@ -122,8 +123,11 @@ def load_terrafrom_module(parser: ModuleType, path: Path) -> Dict[str, Any]:
     result: Dict[str, Any] = {}
     LOGGER.debug("using %s parser to load module: %s", parser.__name__.upper(), path)
     for tf_file in path.glob("*.tf"):
-        tf_config = parser.loads(tf_file.read_text())  # type: ignore
-        result = merge_dicts(result, cast(Dict[str, Any], tf_config))
+        try:
+            tf_config = parser.loads(tf_file.read_text())  # type: ignore
+            result = merge_dicts(result, cast(Dict[str, Any], tf_config))
+        except Exception as exc:
+            raise HclParserError(exc, tf_file, parser)
     return result
 
 
@@ -143,16 +147,32 @@ class TFEnvManager(EnvManager):
         """Backend config of the Terraform module."""
         # Terraform can only have one backend configured; this formats the
         # data to make it easier to work with
-        return [  # type: ignore
+        return [
             {"type": k, "config": v}
-            for k, v in self.terraform_block.get("backend", {None: {}}).items()  # type: ignore
+            for k, v in self.terraform_block.get(
+                "backend", {None: cast(Dict[str, str], {})}
+            ).items()
         ][0]
 
     @cached_property
     def terraform_block(self) -> Dict[str, Any]:
         """Collect Terraform configuration blocks from a Terraform module."""
 
-        def _flatten_lists(data: Any) -> Dict[str, Any]:
+        @overload
+        def _flatten_lists(data: Dict[str, Any]) -> Dict[str, Any]:
+            ...
+
+        @overload
+        def _flatten_lists(data: List[Any]) -> List[Any]:
+            ...
+
+        @overload
+        def _flatten_lists(data: str) -> str:
+            ...
+
+        def _flatten_lists(
+            data: Union[Dict[str, Any], List[Any], Any]
+        ) -> Union[Dict[str, Any], Any]:
             """Flatten HCL2 list attributes until its fixed.
 
             python-hcl2 incorrectly turns all attributes into lists so we need
@@ -176,21 +196,24 @@ class TFEnvManager(EnvManager):
                         data[attr] = [_flatten_lists(v) for v in cast(List[Any], val)]
                 elif isinstance(val, dict):
                     data[attr] = _flatten_lists(cast(Dict[str, Any], val))
-            return data  # type: ignore
+            return data
 
         try:
             result: Union[Dict[str, Any], List[Dict[str, Any]]] = load_terrafrom_module(
                 hcl2, self.path
-            ).get(
-                "terraform", {}  # type: ignore
-            )
-        except Exception:  # pylint: disable=broad-except
-            # could result in any number of lark exceptions
-            LOGGER.verbose(
-                "failed to parse as HCL2; trying HCL",
-                exc_info=True,  # useful in troubleshooting
-            )
-            result = load_terrafrom_module(hcl, self.path).get("terraform", {})  # type: ignore
+            ).get("terraform", cast(Dict[str, Any], {}))
+        except HclParserError as exc:
+            LOGGER.warning(exc)
+            LOGGER.warning("failed to parse as HCL2; trying HCL...")
+            try:
+                result = load_terrafrom_module(hcl, self.path).get(
+                    "terraform", cast(Dict[str, Any], {})
+                )
+            except HclParserError as exc:
+                LOGGER.warning(exc)
+                # return an empty dict if we can't parse HCL
+                # let Terraform decide if it's actually valid
+                result = {}
 
         # python-hcl2 turns all blocks into lists in v0.3.0. this flattens it.
         if isinstance(result, list):

--- a/runway/exceptions.py
+++ b/runway/exceptions.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from .variables import (
         Variable,
         VariableValue,
@@ -96,6 +98,34 @@ class FailedVariableLookup(Exception):
             *args,
             **kwargs
         )
+
+
+class HclParserError(Exception):
+    """HCL/HCL2 parser error."""
+
+    def __init__(
+        self,
+        exc: Exception,
+        file_path: Union[Path, str],
+        parser: Optional[ModuleType] = None,
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            exc: Exception that was raised.
+            file_path: File that resulted in the error.
+            parser: The parser what was used to try to parse the file (hcl|hcl2).
+
+        """
+        self.reason = exc
+        self.file_path = file_path
+        if parser:
+            self.message = (
+                f"Unable to parse {file_path} as {parser.__name__.upper()}\n\n{exc}"
+            )
+        else:
+            self.message = f"Unable to parse {file_path}\n\n{exc}"
+        super().__init__(self.message)
 
 
 class InvalidLookupConcatenation(Exception):

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -17,7 +17,7 @@ from runway.env_mgr.tfenv import (
     TFEnvManager,
     get_available_tf_versions,
     get_latest_tf_version,
-    load_terrafrom_module,
+    load_terraform_module,
 )
 from runway.exceptions import HclParserError
 
@@ -89,18 +89,18 @@ def test_get_latest_tf_version(mocker: MockerFixture) -> None:
         (hcl2, {"terraform": [{"backend": [{"s3": {"bucket": ["name"]}}]}]}),
     ],
 )
-def test_load_terrafrom_module(
+def test_load_terraform_module(
     parser: ModuleType, expected: Dict[str, Any], tmp_path: Path
 ) -> None:
-    """Test runway.env_mgr.tfenv.load_terrafrom_module."""
+    """Test runway.env_mgr.tfenv.load_terraform_module."""
     tf_file = tmp_path / "module.tf"
     tf_file.write_text(HCL_BACKEND_S3)
 
-    assert load_terrafrom_module(parser, tmp_path) == expected
+    assert load_terraform_module(parser, tmp_path) == expected
 
 
-def test_load_terrafrom_module_raise_hcl_parser_error(tmp_path: Path) -> None:
-    """Test load_terrafrom_module raise HclParserError."""
+def test_load_terraform_module_raise_hcl_parser_error(tmp_path: Path) -> None:
+    """Test load_terraform_module raise HclParserError."""
     tf_file = tmp_path / "module.tf"
     tf_file.write_text(HCL_BACKEND_S3)
 
@@ -108,7 +108,7 @@ def test_load_terrafrom_module_raise_hcl_parser_error(tmp_path: Path) -> None:
     mock_parser.__name__ = "TestParser"
 
     with pytest.raises(HclParserError) as excinfo:
-        load_terrafrom_module(mock_parser, tmp_path)
+        load_terraform_module(mock_parser, tmp_path)
 
     assert excinfo.value.file_path == tf_file
     assert str(tf_file) in excinfo.value.message
@@ -154,7 +154,7 @@ class TestTFEnvManager:
         tmp_path: Path,
     ) -> None:
         """Test backend."""
-        mocker.patch(f"{MODULE}.load_terrafrom_module", return_value=response)
+        mocker.patch(f"{MODULE}.load_terraform_module", return_value=response)
         tfenv = TFEnvManager(tmp_path)
         assert tfenv.backend == expected
 
@@ -370,8 +370,8 @@ class TestTFEnvManager:
     ) -> None:
         """Test terraform_block."""
         caplog.set_level(LogLevels.VERBOSE, logger=MODULE)
-        mock_load_terrafrom_module = mocker.patch(
-            f"{MODULE}.load_terrafrom_module", side_effect=response
+        mock_load_terraform_module = mocker.patch(
+            f"{MODULE}.load_terraform_module", side_effect=response
         )
         tfenv = TFEnvManager(tmp_path)
 
@@ -379,11 +379,11 @@ class TestTFEnvManager:
 
         if not isinstance(response[0], dict):
             assert "failed to parse as HCL2; trying HCL" in "\n".join(caplog.messages)
-            mock_load_terrafrom_module.assert_has_calls(
+            mock_load_terraform_module.assert_has_calls(
                 [call(hcl2, tmp_path), call(hcl, tmp_path)]  # type: ignore
             )
         else:
-            mock_load_terrafrom_module.assert_called_once_with(hcl2, tmp_path)
+            mock_load_terraform_module.assert_called_once_with(hcl2, tmp_path)
 
     def test_version_file(self, tmp_path: Path) -> None:
         """Test version_file."""


### PR DESCRIPTION
## Summary

When an HCL parser fails, log the exception as a warning and include the path to the file that was being parsed at the time of the exception.

If both fail, return an empty dict which will cause Runway to treat the module as not having a backend configured in the scope of special backend handling. Right now, the only backend that requires special handling is [remote](https://www.terraform.io/docs/language/settings/backends/remote.html).

If special handling is required, Terraform will inevitably fail and the user can review the logs to see that Runway was unable to parse a file in the module to determine the backend so no special handling was applied.

## Why This Is Needed

Relying on third-party HCL/HCL2 parsers can result in flakey handling of Terraform modules where Terraform accepts the syntax in the files but our parsers do not.

resolves #546
supersedes #547 

## What Changed

### Added

- added `HclParserError`
- added warning when an HCL parser fails to parse a file; includes:
	- path to file that caused the error
	- reason for the error

### Changed

- Runway will no longer raise an error if both HCL and HCL2 parsers are unable to parse the files in the module; empty dict is used for Terraform block

## Screenshots

![image](https://user-images.githubusercontent.com/23145462/112493046-31f96b00-8d58-11eb-8a6e-4244aff9907a.png)
