### PR TITLE
remove assignment of troyready from issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG] report"
 labels: bug, priority:low, status:review_needed
-assignees: ITProKyle, troyready
+assignees: ITProKyle
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[REQUEST] feature"
 labels: feature, priority:low, status:review_needed
-assignees: ITProKyle, troyready
+assignees: ITProKyle
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -3,7 +3,7 @@ name: General Question
 about: General question about the project, usage, design, etc.
 title: "[QUESTION]"
 labels: priority:low, status:review_needed, question
-assignees: ITProKyle, troyready
+assignees: ITProKyle
 
 ---
 


### PR DESCRIPTION
# Summary

Remove user `troyready` from issue assignees as he is no longer with the organization.