### PR TITLE
change default cfngin bucket to `cfngin-${namespace}-${region}`

### DIFF
--- a/runway/context/cfngin.py
+++ b/runway/context/cfngin.py
@@ -120,8 +120,10 @@ class CfnginContext(BaseContext):
         """Return ``cfngin_bucket`` from config, calculated name, or None."""
         if not self.upload_to_s3:
             return None
-
-        return self.config.cfngin_bucket or f"stacker-{self.get_fqn()}"
+        return (
+            self.config.cfngin_bucket
+            or f"cfngin-{self.get_fqn()}-{self.env.aws_region}"
+        )
 
     @cached_property
     def mappings(self) -> Dict[str, Dict[str, Dict[str, Any]]]:

--- a/tests/unit/cfngin/actions/test_base.py
+++ b/tests/unit/cfngin/actions/test_base.py
@@ -351,7 +351,7 @@ class TestBaseAction(unittest.TestCase):
                 "%s/%s/stack_templates/%s/%s-%s.json"
                 % (
                     endpoint,
-                    "stacker-mynamespace",
+                    "cfngin-mynamespace-us-east-1",
                     "mynamespace-myblueprint",
                     "myblueprint",
                     MOCK_VERSION,

--- a/tests/unit/context/test_cfngin.py
+++ b/tests/unit/context/test_cfngin.py
@@ -128,7 +128,7 @@ class TestCFNginContext:  # pylint: disable=too-many-public-methods
     def test_bucket_name_generated(self, mocker: MockerFixture) -> None:
         """Test bucket_name generated."""
         mocker.patch.object(CfnginContext, "upload_to_s3", True)
-        assert CfnginContext(config=self.config).bucket_name == "stacker-test"
+        assert CfnginContext(config=self.config).bucket_name == "cfngin-test-us-east-1"
 
     def test_bucket_name_none(self, mocker: MockerFixture) -> None:
         """Test bucket_name is None."""


### PR DESCRIPTION
# Summary

CFNgin will no longer default to looking for a `stacker-${namespace}` bucket to use for staging CFN template files. It will now look for a bucket with name `cfngin-${namespace}-${region}` and create it if one does not exist.

# Why This Is Needed

This further removes CFNgin from Stacker.

resolves #321 

# What Changed

## Changed

- the default CFNgin bucket when one is not specified is now `cfngin-${namespace}-${region}`