### PR TITLE
make `future.strict_environments` standard behavior

### DIFF
--- a/docs/source/runway_config.rst
+++ b/docs/source/runway_config.rst
@@ -364,6 +364,13 @@ Deployment
         environments:
           dev: True
 
+    .. versionchanged:: 1.4.0
+      Now acts as an explicit toggle for deploying modules to a set AWS Account/AWS Region.
+      For passing values to a module, :attr:`deployment.parameters`/:attr:`module.parameters` should be used instead.
+
+    .. versionchanged:: 2.0.0
+      If defined and the current deploy environment is missing from the definition, processing will be skipped.
+
   .. attribute:: modules
     :type: List[Union[module, str]]
 
@@ -490,6 +497,8 @@ Deployment
         parameters:
           dev:
             namespace: example-dev
+
+    .. versionadded:: 1.4.0
 
   .. attribute:: regions
     :type: Optional[Union[Dict[str, Union[List[str], str], List[str], str]]
@@ -677,6 +686,13 @@ Module
         environments:
           dev: True
 
+    .. versionchanged:: 1.4.0
+      Now acts as an explicit toggle for deploying modules to a set AWS Account/AWS Region.
+      For passing values to a module, :attr:`deployment.parameters`/:attr:`module.parameters` should be used instead.
+
+    .. versionchanged:: 2.0.0
+      If defined and the current deploy environment is missing from the definition, processing will be skipped.
+
   .. attribute:: name
     :type: Optional[str]
 
@@ -782,6 +798,8 @@ Module
         parameters:
           dev:
             namespace: example-dev
+
+    .. versionadded:: 1.4.0
 
   .. attribute:: path
     :type: Optional[Union[str, Path]]

--- a/runway/config/models/runway/__init__.py
+++ b/runway/config/models/runway/__init__.py
@@ -349,12 +349,6 @@ class RunwayDeploymentDefinitionModel(ConfigProperty):
 class RunwayFutureDefinitionModel(ConfigProperty):
     """Model for the Runway future definition."""
 
-    strict_environments: bool = Field(
-        False,
-        description="If 'environments' is included in a deployment, modules will "
-        "be skipped if the current environment is not defined.",
-    )
-
     class Config(ConfigProperty.Config):
         """Model configuration."""
 

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -94,12 +94,7 @@ class Module:
         Will return None if there is nothing defined for the current environment.
 
         """
-        return validate_environment(
-            self.ctx,
-            self.environments,
-            logger=self.logger,
-            strict=self.__future.strict_environments,
-        )
+        return validate_environment(self.ctx, self.environments, logger=self.logger,)
 
     @cached_property
     def environments(self) -> RunwayEnvironmentsType:
@@ -331,7 +326,6 @@ def validate_environment(
     context: RunwayContext,
     env_def: Optional[Union[bool, Dict[str, Any], int, str, List[str]]],
     logger: Union[PrefixAdaptor, RunwayLogger] = LOGGER,
-    strict: bool = False,
 ) -> Optional[bool]:
     """Check if an environment should be deployed to.
 
@@ -339,8 +333,6 @@ def validate_environment(
         context: Runway context object.
         env_def: Runway module definition.
         logger: Logger to log messages to.
-        strict: Whether to consider the current environment missing from
-            definition as a failure.
 
     Returns:
         Booleon value of whether to deploy or not.
@@ -357,18 +349,10 @@ def validate_environment(
         return cast(Optional[bool], env_def)
     if isinstance(env_def, dict):
         if context.env.name not in env_def:
-            if strict:
-                logger.info("skipped; environment not in definition")
-                return False
-            logger.info(
-                "environment not in definition; module will determine deployment"
-            )
-            return None
+            logger.info("skipped; environment not in definition")
+            return False
         return validate_environment(
-            context,
-            cast(Any, env_def.get(context.env.name, False)),
-            logger=logger,
-            strict=strict,
+            context, cast(Any, env_def.get(context.env.name, False)), logger=logger,
         )
 
     account = aws.AccountDetails(context)

--- a/tests/unit/config/models/runway/test_runway.py
+++ b/tests/unit/config/models/runway/test_runway.py
@@ -315,10 +315,6 @@ class TestRunwayFutureDefinitionModel:
         assert errors[0]["loc"] == ("invalid",)
         assert errors[0]["msg"] == "extra fields not permitted"
 
-    def test_field_defaults(self) -> None:
-        """Test field defaults."""
-        assert not RunwayFutureDefinitionModel().strict_environments
-
 
 class TestRunwayModuleDefinitionModel:
     """Test runway.config.models.runway.RunwayModuleDefinitionModel."""

--- a/tests/unit/core/components/test_deployment.py
+++ b/tests/unit/core/components/test_deployment.py
@@ -55,7 +55,7 @@ class TestDeployment:
     ) -> None:
         """Test init with args."""
         definition = fx_deployments.load("simple_env_vars")
-        future = RunwayFutureDefinitionModel(strict_environments=True)
+        future = RunwayFutureDefinitionModel()
         variables = RunwayVariablesDefinition.parse_obj({"some_key": "val"})
 
         obj = Deployment(


### PR DESCRIPTION
# Summary

The behavior enabled with `future.strict_environments` is now the standard behavior in version 2.0.0.

# What Changed

## Changed

- behavior once enabled by `future.strict_environments` is now standard

## Removed

- removed `future.strict_environments` field from Runway config
