### PR TITLE
fix `output` lookup so that namespace is added to provided stack name

### DIFF
--- a/runway/cfngin/lookups/handlers/output.py
+++ b/runway/cfngin/lookups/handlers/output.py
@@ -47,7 +47,7 @@ class OutputLookup(LookupHandler):
         stack = context.get_stack(decon.stack_name)
         if stack:
             return stack.outputs[decon.output_name]
-        raise StackDoesNotExist(decon.stack_name)
+        raise StackDoesNotExist(context.get_fqn(decon.stack_name))
 
     @classmethod
     def dependencies(cls, lookup_query: VariableValue) -> Set[str]:

--- a/runway/context/_cfngin.py
+++ b/runway/context/_cfngin.py
@@ -366,10 +366,10 @@ class CfnginContext(BaseContext):
         """Get a stack by name.
 
         Args:
-            name: Name of a stack to retrieve.
+            name: Name of a Stack as defined in the config.
 
         """
-        return self.stacks_dict.get(name)
+        return self.stacks_dict.get(self.get_fqn(name))
 
     def lock_persistent_graph(self, lock_code: str) -> None:
         """Locks the persistent graph in s3.

--- a/tests/unit/context/test_cfngin.py
+++ b/tests/unit/context/test_cfngin.py
@@ -156,7 +156,10 @@ class TestCFNginContext:  # pylint: disable=too-many-public-methods
         """Test get_stack."""
         obj = CfnginContext(config=self.config)
         assert obj.get_stack("test-stack1") == obj.stacks[0]
-        assert not obj.get_stack("stack1")
+        # namespace is added if not provided
+        assert obj.get_stack("stack1") == obj.stacks[0]
+        assert not obj.get_stack("dev-stack1")
+        assert not obj.get_stack("stack12")
 
     def test_init(self, tmp_path: Path) -> None:
         """Test init."""


### PR DESCRIPTION
# Summary

The `output` lookup is broken on the master branch. It does not account for `namespace` when looking for the provided stack.

# What Changed

## Changed

- `CfnginContext.get_stack()` now calls `.get_fqn()` to add namespace to the provided stack name when looking for a stack
- `output` lookup now shows the FQN of the stack when a stack is not found to provide a more useful error
