### PR TITLE
fix staticsite test

### DIFF
--- a/runway/cfngin/hooks/staticsite/upload_staticsite.py
+++ b/runway/cfngin/hooks/staticsite/upload_staticsite.py
@@ -63,7 +63,7 @@ def sync(
     bucket_name: str,
     cf_disabled: bool = False,
     distribution_domain: str = "undefined",
-    distribution_id: str,
+    distribution_id: str = "undefined",
     distribution_path: str = "/*",
     extra_files: Optional[List[ExtraFileTypeDef]] = None,
     website_url: Optional[str] = None,

--- a/runway/module/staticsite/handler.py
+++ b/runway/module/staticsite/handler.py
@@ -284,11 +284,14 @@ class StaticSite(RunwayModule):
                 "required": True,
                 "args": {
                     "bucket_name": f"${{cfn ${{namespace}}-{self.name}.BucketName}}",
-                    "website_url": f"${{cfn ${{namespace}}-{self.name}.BucketWebsiteURL::default=undefined}}",  # noqa
+                    "website_url": f"${{cfn ${{namespace}}-{self.name}.BucketWebsiteURL"
+                    "::default=undefined}}",
                     "extra_files": [i.dict() for i in self.options.extra_files],
                     "cf_disabled": site_stack_variables["DisableCloudFront"],
-                    "distribution_id": f"${{cfn ${{namespace}}-{self.name}.CFDistributionId}}",
-                    "distribution_domain": f"${{cfn ${{namespace}}-{self.name}.CFDistributionDomainName}}",  # noqa
+                    "distribution_id": f"${{cfn ${{namespace}}-{self.name}.CFDistributionId"
+                    "::default=undefined}}",
+                    "distribution_domain": f"${{cfn ${{namespace}}-{self.name}."
+                    "CFDistributionDomainName::default=undefined}}",
                 },
             }
         ]


### PR DESCRIPTION
# Summary

Fix failing staticsite test.

# What Changed

## Changed

- staticsite hook arg cfn lookup now defaults to `undefined` to avoid error when CloudFront is disabled
