### PR TITLE
s3 helpers use ParametersDataModel instead of Dict

### DIFF
--- a/runway/core/providers/aws/s3/_helpers/action_architecture.py
+++ b/runway/core/providers/aws/s3/_helpers/action_architecture.py
@@ -189,7 +189,7 @@ class ActionArchitecture:
             request_parameters=self._get_file_generator_request_parameters_skeleton(),
         )
         file_info_builder = FileInfoBuilder(
-            client=self.client, parameters=self.parameters.dict()
+            client=self.client, parameters=self.parameters
         )
         s3_transfer_handler = S3TransferHandlerFactory(
             config_params=self.parameters, runtime_config=self._runtime_config

--- a/runway/core/providers/aws/s3/_helpers/action_architecture.py
+++ b/runway/core/providers/aws/s3/_helpers/action_architecture.py
@@ -192,7 +192,7 @@ class ActionArchitecture:
             client=self.client, parameters=self.parameters.dict()
         )
         s3_transfer_handler = S3TransferHandlerFactory(
-            config_params=self.parameters.dict(), runtime_config=self._runtime_config
+            config_params=self.parameters, runtime_config=self._runtime_config
         )(self.client, result_queue)
 
         sync_strategies = self.choose_sync_strategies()

--- a/runway/core/providers/aws/s3/_helpers/parameters.py
+++ b/runway/core/providers/aws/s3/_helpers/parameters.py
@@ -19,38 +19,58 @@ class ParametersDataModel(BaseModel):
     Attributes:
         dest: File/object destination.
         src: File/object source.
+        content_type: Explicitly provided content type.
         delete: Whether or not to delete files at the destination that are
             missing from the source location.
         dir_op: If the source location is a directory.
+        dryrun: Whether this is a dry run.
         exact_timestamps: Use exact time stamp when comparing files/objects
             during sync.
         exclude: List of patterns for files/objects to exclude.
+        expected_size: Expected size of transfer.
         follow_symlinks: Whether or not to follow symlinks.
+        force_glacier_transfer: Force transfer even if glacier.
         guess_mime_type: Whether or not to guess content type.
+        ignore_glacier_warnings: Don't show glacier warnings.
         include: List of patterns for files/objects to explicitly include.
         is_move: Whether or not the action is move.
+        is_stream: Source or destination is a stream.
+        no_progress: Whether to not show progress.
         only_show_errors: Whether or not to only show errors while running.
         page_size: Number of objects to list per call.
+        quiet: Don't output anything.
         paths_type: Concatinated path types for source and destination.
         size_only: When comparing files/objects, only consider size.
+        storage_class: S3 storage class.
 
     """
 
     dest: str
     src: str
     # these need to be set after dest & src so their validators can access the value if needed
+    content_type: Optional[str] = None
     delete: bool = False
     dir_op: bool = False
+    dryrun: bool = False
     exact_timestamps: bool = False
     exclude: List[str] = []
+    expected_size: Optional[int] = None
     follow_symlinks: bool = False
+    force_glacier_transfer: bool = False
     guess_mime_type: bool = True
+    ignore_glacier_warnings: bool = False
     include: List[str] = []
     is_move: bool = False
+    is_stream: bool = False
+    no_progress: bool = False
     only_show_errors: bool = False
     page_size: Optional[int] = None
     paths_type: PathsType = "local"  # will be overwritten
+    quiet: bool = False
     size_only: bool = False
+    sse_c: Optional[str] = None
+    sse_c_key: Optional[str] = None
+    storage_class: Optional[str] = None
 
     @validator("paths_type", always=True, pre=True)
     @classmethod

--- a/tests/unit/core/providers/aws/s3/_helpers/test_file_info_builder.py
+++ b/tests/unit/core/providers/aws/s3/_helpers/test_file_info_builder.py
@@ -7,6 +7,7 @@ from mock import Mock
 from runway.core.providers.aws.s3._helpers.file_generator import FileStats
 from runway.core.providers.aws.s3._helpers.file_info import FileInfo
 from runway.core.providers.aws.s3._helpers.file_info_builder import FileInfoBuilder
+from runway.core.providers.aws.s3._helpers.parameters import ParametersDataModel
 
 
 class TestFileInfoBuilder:
@@ -17,7 +18,9 @@ class TestFileInfoBuilder:
         client = Mock()
         source_client = Mock()
         builder = FileInfoBuilder(
-            client=client, source_client=source_client, parameters={"delete": True}
+            client=client,
+            source_client=source_client,
+            parameters=ParametersDataModel(dest="", src="", delete=True),
         )
         file_stats = FileStats(
             src="src",

--- a/tests/unit/core/providers/aws/s3/_helpers/test_s3handler.py
+++ b/tests/unit/core/providers/aws/s3/_helpers/test_s3handler.py
@@ -11,6 +11,7 @@ from mock import MagicMock, Mock
 from s3transfer.manager import TransferManager
 
 from runway.core.providers.aws.s3._helpers.file_info import FileInfo
+from runway.core.providers.aws.s3._helpers.parameters import ParametersDataModel
 from runway.core.providers.aws.s3._helpers.results import (
     CommandResultRecorder,
     CopyResultSubscriber,
@@ -98,7 +99,7 @@ class BaseTransferRequestSubmitterTest:
     """Base class for transfer request submitter test classes."""
 
     bucket: ClassVar[str] = "test-bucket"
-    config_params: Dict[str, Any]
+    config_params: ParametersDataModel
     filename: ClassVar[str] = "test-file.txt"
     key: ClassVar[str] = "test-key.txt"
     result_queue: "Queue[Any]"
@@ -106,7 +107,7 @@ class BaseTransferRequestSubmitterTest:
 
     def setup_method(self) -> None:
         """Run before each test method if run to return the class instance attrs to default."""
-        self.config_params = {}
+        self.config_params = ParametersDataModel(dest="", src="")
         self.result_queue = Queue()
         self.transfer_manager = Mock(spec=TransferManager)
 
@@ -118,7 +119,9 @@ class TestBaseTransferRequestSubmitter:
         """Test can_submit."""
         with pytest.raises(NotImplementedError) as excinfo:
             BaseTransferRequestSubmitter(
-                Mock(name="transfer_manager"), Mock(name="result_queue"), {}
+                Mock(name="transfer_manager"),
+                Mock(name="result_queue"),
+                ParametersDataModel(dest="", src=""),
             ).can_submit(Mock(name="fileinfo"))
         assert str(excinfo.value) == "can_submit()"
 
@@ -137,7 +140,9 @@ class TestBaseTransferRequestSubmitter:
         """Test _format_s3_path."""
         assert (
             # pylint: disable=protected-access
-            BaseTransferRequestSubmitter(Mock(), Mock(), {})._format_s3_path(path)
+            BaseTransferRequestSubmitter(
+                Mock(), Mock(), ParametersDataModel(dest="", src="")
+            )._format_s3_path(path)
             == expected
         )
 
@@ -145,7 +150,9 @@ class TestBaseTransferRequestSubmitter:
         """Test submit."""
         with pytest.raises(NotImplementedError) as excinfo:
             BaseTransferRequestSubmitter(
-                Mock(name="transfer_manager"), Mock(name="result_queue"), {}
+                Mock(name="transfer_manager"),
+                Mock(name="result_queue"),
+                ParametersDataModel(dest="", src=""),
             ).submit(Mock(name="fileinfo"))
         assert str(excinfo.value) == "_submit_transfer_request()"
 
@@ -155,7 +162,7 @@ class TestBaseTransferRequestSubmitter:
             BaseTransferRequestSubmitter(
                 Mock(name="transfer_manager"),
                 Mock(name="result_queue"),
-                {"dryrun": True},
+                ParametersDataModel(dest="", src="", dryrun=True),
             ).submit(Mock(name="fileinfo"))
         assert str(excinfo.value) == "_format_src_dest()"
 
@@ -773,7 +780,7 @@ class TestLocalDeleteRequestSubmitter(BaseTransferRequestSubmitterTest):
 class TestS3TransferHandler:
     """Test S3TransferHandler."""
 
-    config_params: ClassVar[Dict[str, Any]] = {}
+    config_params: ClassVar[ParametersDataModel] = ParametersDataModel(dest="", src="")
     result_command_recorder: CommandResultRecorder
     result_queue: "Queue[Any]"
     transfer_manager: TransferManager
@@ -807,14 +814,14 @@ class TestS3TransferHandler:
 class TestS3TransferHandlerFactory:
     """Test S3TransferHandlerFactory."""
 
-    config_params: Dict[str, Any]
+    config_params: ParametersDataModel
     client: S3Client
     result_queue: "Queue[Any]"
     runtime_config: TransferConfigDict
 
     def setup_method(self) -> None:
         """Run before each test method if run to return the class instance attrs to default."""
-        self.config_params = {}
+        self.config_params = ParametersDataModel(dest="", src="")
         self.client = Mock()
         self.result_queue = Queue()
         self.runtime_config = RuntimeConfig.build_config()


### PR DESCRIPTION
# Summary

Replace areas in `runway.core.providers.aws.s3._helpers` that convert `ParametersDataModel` to `Dict` to retain the original data type.

# What Changed

## Changed

- `S3Handler` & `BaseTransferRequestSubmitter` now accept `ParametersDataModel` object as init arg
- `FileInfoBuilder` now accepts `ParametersDataModel` object as init arg


