### PR TITLE
cfngin will now exit on `DELETE_FAILED` instead of infinite retry loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ max-branches = 20
 max-locals = 25
 max-parents = 10
 max-public-methods = 30
-max-returns = 6
+max-returns = 10
 max-statements = 50
 min-public-methods = 0
 


### PR DESCRIPTION
# Why This Is Needed

When a CloudFormation Stack's status is `DELETE_FAILED`, CFNgin will continually resubmit the Stack for deletion even though the Stack will likely never succeed deletion without manual intervention to clear the failure reason.

# What Changed

## Changed

- CFNgin will now exit when trying to delete a Stack with status `DELETE_FAILED` instead of retrying indefinitely

# Screenshots

![image](https://user-images.githubusercontent.com/23145462/117992179-b609b100-b30c-11eb-9fc0-19de1ab7f326.png)



