### PR TITLE
update doc link

### DIFF
--- a/runway/cfngin/blueprints/base.py
+++ b/runway/cfngin/blueprints/base.py
@@ -359,9 +359,8 @@ class Blueprint:
                 "deprecated PARAMETERS or "
                 "LOCAL_PARAMETERS, rather than VARIABLES. "
                 "Please update your blueprints. See "
-                "https://docs.onica.com/projects/runway"
-                "/en/release/cfngin/blueprints."
-                "html#variables for additional information." % name
+                "https://docs.onica.com/projects/runway/page/cfngin/blueprints.html#variables "
+                "for additional information." % name
             )
 
     @cached_property


### PR DESCRIPTION
# Summary

Update doc link to use `/page` to direct to the default version rather then statically setting it to `/release`
