### PR TITLE
fix issue causing install from PyPi to fail

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -36,7 +36,6 @@ prune integration_tests
 prune node_modules
 prune npm
 prune quickstarts
-prune scripts
 prune tests
 prune typings
 recursive-include runway/templates *

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "linux",
     "win32"
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "dependencies": {
     "tar": "^6.1.0"
   },


### PR DESCRIPTION
# Summary

Fix issue causing install from PyPi to fail.

# Why This Is Needed

```
error: file '.../pip-req-build-nukfza31/scripts/tf-runway' does not exist
```

# What Changed

## Removed

- remove `prune scripts` from MANIFEST.in

