### PR TITLE
add assign-author action

### DIFF
--- a/.github/workflows/on-pr-target-opened.yml
+++ b/.github/workflows/on-pr-target-opened.yml
@@ -5,6 +5,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
 
 
 jobs:

--- a/.github/workflows/on-pr-target-opened.yml
+++ b/.github/workflows/on-pr-target-opened.yml
@@ -1,0 +1,15 @@
+name: PR Target (opened)
+
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+
+jobs:
+  assign-author:
+    name: Assign Author to PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/assign-author@v1  # cspell:ignore technote


### PR DESCRIPTION
# Summary

Add [technote-space/assign-author](https://github.com/technote-space/assign-author) action.

# Why This Is Needed

Automatically assign author to PR.

# What Changed

## Added

- added `PR Target (opened)` workflow with `Assign Author to PR` action
