### PR TITLE
add autolabeler configuration for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,42 @@
 # https://github.com/release-drafter/release-drafter
+autolabeler:  # cspell:ignore autolabeler
+  - label: bug
+    branch: [/^(bug|bugfix|fix|hotfix)\/.*/]
+  - label: cloudformation
+    files:
+      - '**/templates/*.json'
+      - '**/templates/*.template'
+      - '**/templates/*.yaml'
+      - '**/templates/*.yml'
+  - label: dependencies
+    branch: [/^(depend|dependabot)\/.*/]
+  - label: documentation
+    branch: [/^(docs)\/.*/]
+  - label: feature
+    branch: [/^(enhancement|feat|feature)\/.*/]
+  - label: maintenance
+    branch: [/^(chore|maint|maintain|maintenance)\/.*/]
+  - label: patch
+    branch: [/^(bug|bugfix|fix|hotfix)\/.*/]
+  - label: poetry
+    files:
+      - poetry.lock
+      - poetry.toml
+  - label: pyinstaller
+    files:
+      - runway.file.spec
+      - runway.folder.spec
+  - label: python
+    files:
+      - '**/*.py'
+      - poetry.lock
+      - pyproject.toml
+      - setup.cfg
+  - label: release
+    branch: [/^(release)\/.*/]
+  - label: workflows
+    files:
+      - .github/workflows/*.yml
 categories:
   - title: 🚀 Features
     labels:
@@ -18,6 +56,7 @@ categories:
 category-template: >-
   ### $TITLE
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+commitish: master  # cspell:ignore commitish
 exclude-labels:
   - skip-changelog
   - release

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -1,0 +1,17 @@
+name: PR
+
+
+on:
+  pull_request:
+
+
+jobs:
+  branch:
+    name: Label PR
+    # Skip running the job from forks.
+    if: github.repository == 'onicagroup/runway'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.15.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -6,7 +6,7 @@ on:
 
 
 jobs:
-  branch:
+  label-pr:
     name: Label PR
     # Skip running the job from forks.
     if: github.repository == 'onicagroup/runway'

--- a/.vscode/dictionaries/local.txt
+++ b/.vscode/dictionaries/local.txt
@@ -104,6 +104,7 @@ decon
 delenv
 delim
 delims
+dependabot
 deps
 deque
 dockercfg


### PR DESCRIPTION
# Summary

Add `autolabeler` configuration for release-drafter

# Why This Is Needed

Automatically label PRs (not supported from forks yet).

# What Changed

## Added

- added `PR` workflow with `Label PR` action
