### PR TITLE
terraform destroy: handle differences in supported cli options by tf version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,6 +15,7 @@ defaults:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  PYTEST_ADDOPTS: --color=yes
   RUNWAY_TEST_NAMESPACE: gh-${{ github.run_id }}
 
 

--- a/.vscode/dictionaries/local.txt
+++ b/.vscode/dictionaries/local.txt
@@ -282,6 +282,7 @@ sssz
 strtobool
 stubber
 stubbers
+subcmd
 subdirs
 submodules
 subpackages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,7 +319,6 @@ ignored-modules = ["distutils"]
 [tool.pytest.ini_options]
 addopts = [
   "--cov-config=pyproject.toml",
-  "--force-sugar",
   "--no-cov-on-fail",
 ]
 filterwarnings = [

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -400,6 +400,8 @@ class TFEnvManager(EnvManager):
                 ``<major>.<minor>.<patch>`` with an optional ``-<prerelease>``.
 
         """
+        if self.current_version == version:
+            return
         self.current_version = version
         try:
             del self.version

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -425,7 +425,7 @@ class TFEnvManager(EnvManager):
 
         """
         output = subprocess.check_output(
-            [str(bin_path), "--version"], cwd=cwd, env=env
+            [str(bin_path), "-version"], cwd=cwd, env=env
         ).decode()
         match = re.search(cls.VERSION_OUTPUT_REGEX, output)
         if not match:

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -364,7 +364,43 @@ class Terraform(RunwayModule):
         https://www.terraform.io/docs/cli/commands/destroy.html
 
         """
-        run_module_command(
+        if self.version >= (0, 15, 2):
+            return self._terraform_destroy_15_2()
+        if self.version >= (0, 12):
+            return self._terraform_destroy_12()
+        return self._terraform_destroy_legacy()
+
+    def _terraform_destroy_12(self) -> None:
+        """Execute ``terraform destroy -auto-approve`` command.
+
+        Compatible with Terraform >=0.12.0, <0.15.2.
+
+        """
+        return run_module_command(
+            self.gen_command("destroy", ["-auto-approve"] + self.env_file),
+            env_vars=self.ctx.env.vars,
+            logger=self.logger,
+        )
+
+    def _terraform_destroy_15_2(self) -> None:
+        """Execute ``terraform apply -destroy -auto-approve`` command.
+
+        Compatible with Terraform >=0.15.2.
+
+        """
+        return run_module_command(
+            self.gen_command("apply", ["-destroy", "-auto-approve"] + self.env_file),
+            env_vars=self.ctx.env.vars,
+            logger=self.logger,
+        )
+
+    def _terraform_destroy_legacy(self) -> None:
+        """Execute ``terraform destroy -force`` command.
+
+        Compatible with Terrafrom <0.12.0.
+
+        """
+        return run_module_command(
             self.gen_command("destroy", ["-force"] + self.env_file),
             env_vars=self.ctx.env.vars,
             logger=self.logger,

--- a/tests/functional/terraform/test_backend_local_2_s3/test_runner.py
+++ b/tests/functional/terraform/test_backend_local_2_s3/test_runner.py
@@ -31,8 +31,7 @@ def tf_state_bucket(cli_runner: CliRunner) -> None:
 
 @pytest.fixture(
     autouse=True,
-    # TODO add 0.15 after implimenting https://github.com/onicagroup/runway/issues/597
-    params=["0.11.15", "0.12.31", "0.13.7", "0.14.11"],
+    params=["0.11.15", "0.12.31", "0.13.7", "0.14.11", "0.15.5"],
     scope="module",
 )
 def tf_version(request: SubRequest) -> Generator[str, None, None]:

--- a/tests/functional/terraform/test_backend_no_2_local/test_runner.py
+++ b/tests/functional/terraform/test_backend_no_2_local/test_runner.py
@@ -20,8 +20,7 @@ CURRENT_DIR = Path(__file__).parent
 
 @pytest.fixture(
     autouse=True,
-    # TODO add 0.15 after implimenting https://github.com/onicagroup/runway/issues/597
-    params=["0.11.15", "0.12.31", "0.13.7", "0.14.11"],
+    params=["0.11.15", "0.12.31", "0.13.7", "0.14.11", "0.15.5"],
     scope="module",
 )
 def tf_version(request: SubRequest) -> Generator[str, None, None]:

--- a/tests/functional/terraform/test_base/test_runner.py
+++ b/tests/functional/terraform/test_base/test_runner.py
@@ -25,8 +25,7 @@ CURRENT_DIR = Path(__file__).parent
 
 @pytest.fixture(
     autouse=True,
-    # TODO add 0.15 after implimenting https://github.com/onicagroup/runway/issues/597
-    params=["0.11.15", "0.12.31", "0.13.7", "0.14.11"],
+    params=["0.11.15", "0.12.31", "0.13.7", "0.14.11", "0.15.5"],
     scope="module",
 )
 def tf_version(request: SubRequest) -> Generator[str, None, None]:

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -326,6 +326,15 @@ class TestTFEnvManager:
         assert tfenv.version == version
         assert tfenv.current_version == str(version)
 
+    def test_set_version_same(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test set_version same."""
+        version = mocker.patch.object(TFEnvManager, "version")
+        tfenv = TFEnvManager(tmp_path)
+        tfenv.current_version = "0.15.5"
+        assert not tfenv.set_version("0.15.5")
+        assert tfenv.current_version == "0.15.5"
+        assert tfenv.version == version
+
     @pytest.mark.parametrize(
         "response, expected",
         [  # type: ignore

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -201,7 +201,7 @@ class TestTFEnvManager:
     ) -> None:
         """Test get_version_from_executable."""
         fake_process.register_subprocess(
-            ["usr/tfenv/terraform", "--version"], stdout=output
+            ["usr/tfenv/terraform", "-version"], stdout=output
         )
         assert (
             TFEnvManager.get_version_from_executable("usr/tfenv/terraform") == expected
@@ -210,7 +210,7 @@ class TestTFEnvManager:
     def test_get_version_from_executable_raise(self, fake_process: FakeProcess) -> None:
         """Test get_version_from_executable raise exception."""
         fake_process.register_subprocess(
-            ["usr/tfenv/terraform", "--version"], returncode=1
+            ["usr/tfenv/terraform", "-version"], returncode=1
         )
         with pytest.raises(
             subprocess.CalledProcessError, match="returned non-zero exit status 1"

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -16,6 +17,7 @@ from runway._logging import LogLevels
 from runway.env_mgr.tfenv import (
     TF_VERSION_FILENAME,
     TFEnvManager,
+    VersionTuple,
     get_available_tf_versions,
     get_latest_tf_version,
     load_terraform_module,
@@ -181,19 +183,19 @@ class TestTFEnvManager:
         "output, expected",
         [
             ("", None),
-            ("Terraform v0.15.5\non darwin_amd64", (0, 15, 5)),
+            ("Terraform v0.15.5\non darwin_amd64", VersionTuple(0, 15, 5)),
             (
                 "Terraform v0.10.3\n\n"
                 "Your version of Terraform is out of date! The latest version\n"
                 "is 0.15.5. You can update by downloading from www.terraform.io",
-                (0, 10, 3),
+                VersionTuple(0, 10, 3),
             ),
-            ("Terraform v0.15.0-alpha.13", (0, 15, 0)),
+            ("Terraform v0.15.0-alpha.13", VersionTuple(0, 15, 0)),
         ],
     )
     def test_get_version_from_executable(
         self,
-        expected: Optional[Tuple[str, ...]],
+        expected: Optional[VersionTuple],
         fake_process: FakeProcess,
         output: str,
     ) -> None:
@@ -235,116 +237,94 @@ class TestTFEnvManager:
 
     def test_install(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test install."""
-        mock_available_versions = mocker.patch(
-            f"{MODULE}.get_available_tf_versions", return_value=["0.12.0", "0.11.5"]
-        )
-        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
+        version = VersionTuple(0, 15, 5)
+        mocker.patch.object(TFEnvManager, "version", version)
         mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
-        mocker.patch.object(
-            TFEnvManager, "get_version_from_file", MagicMock(return_value="0.11.5")
-        )
+        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
         tfenv = TFEnvManager(tmp_path)
-
-        assert tfenv.install("0.12.0")
-        mock_available_versions.assert_called_once_with(True)
+        (tfenv.versions_dir / "0.15.2").mkdir()
+        assert tfenv.install() == str(tfenv.bin)
         mock_download.assert_called_once_with(
-            "0.12.0", tfenv.versions_dir, tfenv.command_suffix
+            str(version), tfenv.versions_dir, tfenv.command_suffix
         )
-        assert tfenv.current_version == "0.12.0"
-
-        assert tfenv.install()
-        mock_download.assert_called_with(
-            "0.11.5", tfenv.versions_dir, tfenv.command_suffix
-        )
-        assert tfenv.current_version == "0.11.5"
 
     def test_install_already_installed(
         self, mocker: MockerFixture, tmp_path: Path
     ) -> None:
-        """Test install with version already installed."""
-        mock_available_versions = mocker.patch(
-            f"{MODULE}.get_available_tf_versions", return_value=["0.12.0"]
-        )
-        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
-        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
-        tfenv = TFEnvManager(tmp_path)
-        (tfenv.versions_dir / "0.12.0").mkdir()
-
-        assert tfenv.install("0.12.0")
-        mock_available_versions.assert_not_called()
-        mock_download.assert_not_called()
-        assert tfenv.current_version == "0.12.0"
-
-        assert tfenv.install(r"0\.12\..*")  # regex does not match dir
-
-    def test_install_latest(self, mocker: MockerFixture, tmp_path: Path) -> None:
-        """Test install latest."""
-        mock_available_versions = mocker.patch(
-            f"{MODULE}.get_available_tf_versions", return_value=["0.12.0", "0.11.5"]
-        )
-        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
-        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
-        tfenv = TFEnvManager(tmp_path)
-
-        assert tfenv.install("latest")
-        mock_available_versions.assert_called_once_with(False)
-        mock_download.assert_called_once_with(
-            "0.12.0", tfenv.versions_dir, tfenv.command_suffix
-        )
-        assert tfenv.current_version == "0.12.0"
-
-        assert tfenv.install("latest:0.11.5")
-        mock_available_versions.assert_called_with(False)
-        mock_download.assert_called_with(
-            "0.11.5", tfenv.versions_dir, tfenv.command_suffix
-        )
-        assert tfenv.current_version == "0.11.5"
-
-    def test_install_min_required(self, mocker: MockerFixture, tmp_path: Path) -> None:
-        """Test install min_required."""
-        mock_available_versions = mocker.patch(
-            f"{MODULE}.get_available_tf_versions", return_value=["0.12.0"]
-        )
-        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
-        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
-        mocker.patch.object(
-            TFEnvManager, "get_min_required", MagicMock(return_value="0.12.0")
-        )
-        tfenv = TFEnvManager(tmp_path)
-
-        assert tfenv.install("min-required")
-        mock_available_versions.assert_called_once_with(True)
-        mock_download.assert_called_once_with(
-            "0.12.0", tfenv.versions_dir, tfenv.command_suffix
-        )
-        assert tfenv.current_version == "0.12.0"
-        tfenv.get_min_required.assert_called_once_with()  # pylint: disable=no-member
-
-    def test_install_no_version(self, tmp_path: Path) -> None:
-        """Test install with no version available."""
-        tfenv = TFEnvManager(tmp_path)
-
-        with pytest.raises(ValueError) as excinfo:
-            assert tfenv.install()
-        assert str(excinfo.value) == (
-            "version not provided and unable to find a .terraform-version file"
-        )
-
-    def test_install_unavailable(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test install."""
-        mock_available_versions = mocker.patch(
-            f"{MODULE}.get_available_tf_versions", return_value=[]
-        )
-        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
+        version = VersionTuple(0, 15, 5)
+        mocker.patch.object(TFEnvManager, "version", version)
         mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
         tfenv = TFEnvManager(tmp_path)
-
-        with pytest.raises(SystemExit) as excinfo:
-            assert tfenv.install("0.12.0")
-        assert excinfo.value.code == 1
-        mock_available_versions.assert_called_once_with(True)
+        (tfenv.versions_dir / str(version)).mkdir()
+        assert tfenv.install() == str(tfenv.bin)
         mock_download.assert_not_called()
+
+    def test_install_set_version(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test install set version."""
+        version = VersionTuple(0, 15, 5)
+        mocker.patch.object(TFEnvManager, "version", version)
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mock_download = mocker.patch(f"{MODULE}.download_tf_release")
+        mock_set_version = mocker.patch.object(
+            TFEnvManager, "set_version", return_value=None
+        )
+        tfenv = TFEnvManager(tmp_path)
+        assert tfenv.install(str(version))
+        mock_download.assert_called_once_with(
+            str(version), tfenv.versions_dir, tfenv.command_suffix
+        )
+        mock_set_version.assert_called_once_with(str(version))
+
+    def test_install_version_undefined(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Test install."""
+        mocker.patch.object(TFEnvManager, "version", None)
+        tfenv = TFEnvManager(tmp_path)
+        with pytest.raises(
+            ValueError, match=r"^version not provided and unable to find .*"
+        ):
+            tfenv.install()
+
+    @pytest.mark.parametrize(
+        "provided, expected",
+        [
+            ("0.15.2", VersionTuple(0, 15, 2)),
+            ("0.13.0", VersionTuple(0, 13, 0)),
+            ("0.15.0-alpha13", VersionTuple(0, 15, 0, "alpha", 13)),
+            ("0.15.0-beta", VersionTuple(0, 15, 0, "beta", None)),
+            ("0.15.0-rc1", VersionTuple(0, 15, 0, "rc", 1)),
+        ],
+    )
+    def test_parse_version_string(
+        self, provided: str, expected: Optional[VersionTuple]
+    ) -> None:
+        """Test parse_version_string."""
+        assert TFEnvManager.parse_version_string(provided) == expected
+
+    def test_parse_version_string_raise_value_error(self) -> None:
+        """Test parse_version_string."""
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                f"provided version doesn't conform to regex: {TFEnvManager.VERSION_REGEX}"
+            ),
+        ):
+            TFEnvManager.parse_version_string("0.15")
+
+    def test_set_version(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test set_version."""
+        version = VersionTuple(0, 15, 5)
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mocker.patch.object(TFEnvManager, "get_version_from_file", return_value=None)
+        tfenv = TFEnvManager(tmp_path)
+        (tfenv.versions_dir / str(version)).mkdir()
         assert not tfenv.current_version
+        assert not tfenv.set_version(str(version))
+        assert tfenv.version == version
+        assert tfenv.current_version == str(version)
 
     @pytest.mark.parametrize(
         "response, expected",
@@ -425,25 +405,101 @@ class TestTFEnvManager:
         else:
             mock_load_terraform_module.assert_called_once_with(hcl2, tmp_path)
 
-    @pytest.mark.parametrize(
-        "current, expected",
-        [
-            (None, None),
-            ("0.15.2", (0, 15, 2)),
-            ("0.13", (0, 13)),
-            ("0.15.0-alpha.13", (0, 15, 0)),
-        ],
-    )
-    def test_version(
-        self,
-        current: Optional[str],
-        expected: Optional[Tuple[int, ...]],
-        tmp_path: Path,
-    ) -> None:
+    def test_version(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test version."""
+        version = VersionTuple(0, 15, 5)
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mock_get_available_tf_versions = mocker.patch(
+            f"{MODULE}.get_available_tf_versions", return_value=[]
+        )
+        mock_get_version_from_file = mocker.patch.object(
+            TFEnvManager, "get_version_from_file", return_value=None
+        )
         tfenv = TFEnvManager(tmp_path)
-        tfenv.current_version = current
-        assert tfenv.version == expected
+        (tfenv.versions_dir / str(version)).mkdir()
+        tfenv.current_version = str(version)
+        assert tfenv.version == version
+        assert tfenv.current_version == str(version)
+        mock_get_version_from_file.assert_not_called()
+        mock_get_available_tf_versions.assert_not_called()
+
+    def test_version_latest(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test version latest."""
+        version = VersionTuple(0, 15, 5)
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mock_get_available_tf_versions = mocker.patch(
+            f"{MODULE}.get_available_tf_versions", return_value=["0.15.5", "0.15.4"]
+        )
+        mock_get_version_from_file = mocker.patch.object(
+            TFEnvManager, "get_version_from_file", return_value="latest"
+        )
+        tfenv = TFEnvManager(tmp_path)
+        assert tfenv.version == version
+        assert tfenv.current_version == str(version)
+        mock_get_version_from_file.assert_called_once_with()
+        mock_get_available_tf_versions.assert_called_once_with(False)
+
+    def test_version_latest_partial(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Test version latest."""
+        version = VersionTuple(0, 14, 3)
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mock_get_available_tf_versions = mocker.patch(
+            f"{MODULE}.get_available_tf_versions",
+            return_value=["0.15.5", "0.15.4", "0.14.3", "0.14.2", "0.13.8"],
+        )
+        mock_get_version_from_file = mocker.patch.object(
+            TFEnvManager, "get_version_from_file", return_value="latest:0.14"
+        )
+        tfenv = TFEnvManager(tmp_path)
+        assert tfenv.version == version
+        assert tfenv.current_version == str(version)
+        mock_get_version_from_file.assert_called_once_with()
+        mock_get_available_tf_versions.assert_called_once_with(False)
+
+    def test_version_min_required(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test version minimum required."""
+        version = VersionTuple(0, 14, 3)
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mock_get_available_tf_versions = mocker.patch(
+            f"{MODULE}.get_available_tf_versions",
+            return_value=["0.15.5", "0.15.4", "0.14.3", "0.14.2", "0.13.8"],
+        )
+        mock_get_min_required = mocker.patch.object(
+            TFEnvManager, "get_min_required", return_value="0.14.3"
+        )
+        mock_get_version_from_file = mocker.patch.object(
+            TFEnvManager, "get_version_from_file", return_value="min-required"
+        )
+        tfenv = TFEnvManager(tmp_path)
+        assert tfenv.version == version
+        assert tfenv.current_version == str(version)
+        mock_get_version_from_file.assert_called_once_with()
+        mock_get_min_required.assert_called_once_with()
+        mock_get_available_tf_versions.assert_called_once_with(True)
+
+    def test_version_unavailable(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test version latest."""
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        mocker.patch(
+            f"{MODULE}.get_available_tf_versions",
+            return_value=["0.15.5", "0.15.4", "0.14.3", "0.14.2", "0.13.8"],
+        )
+        tfenv = TFEnvManager(tmp_path)
+        tfenv.current_version = "1.0.0"
+        with pytest.raises(SystemExit):
+            assert not tfenv.version
+
+    def test_version_undefined(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test version not specified."""
+        mock_get_version_from_file = mocker.patch.object(
+            TFEnvManager, "get_version_from_file", return_value=None
+        )
+        tfenv = TFEnvManager(tmp_path)
+        assert tfenv.version is None
+        assert tfenv.current_version is None
+        mock_get_version_from_file.assert_called_once_with()
 
     def test_version_file(self, tmp_path: Path) -> None:
         """Test version_file."""
@@ -465,3 +521,19 @@ class TestTFEnvManager:
         expected = subdir / TF_VERSION_FILENAME
         expected.touch()
         assert tfenv.version_file == expected
+
+
+class TestVersionTuple:
+    """Test VersionTuple."""
+
+    @pytest.mark.parametrize(
+        "provided, expected",
+        [
+            ((0, 15, 5), "0.15.5"),
+            ((0, 15, 5, "rc"), "0.15.5-rc"),
+            ((0, 15, 5, "rc", 3), "0.15.5-rc3"),
+        ],
+    )
+    def test_str(self, provided: Tuple[Any, ...], expected: str) -> None:
+        """Test __str__."""
+        assert str(VersionTuple(*provided)) == expected

--- a/tests/unit/module/test_terraform.py
+++ b/tests/unit/module/test_terraform.py
@@ -9,9 +9,10 @@ import subprocess
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 import pytest
-from mock import MagicMock
+from mock import MagicMock, Mock
 
 from runway._logging import LogLevels
+from runway.env_mgr.tfenv import VersionTuple
 from runway.module.terraform import (
     Terraform,
     TerraformBackendConfig,
@@ -70,8 +71,7 @@ class TestTerraform:  # pylint: disable=too-many-public-methods
     ) -> None:
         """Test auto_tfvars."""
         caplog.set_level(LogLevels.DEBUG, logger=MODULE)
-        mock_tfenv = MagicMock(current_version="0.12.0")
-        mocker.patch.object(Terraform, "tfenv", mock_tfenv)
+        mocker.patch.object(Terraform, "version", VersionTuple(0, 15, 5))
         options = {
             "terraform_write_auto_tfvars": True,
         }
@@ -94,26 +94,6 @@ class TestTerraform:  # pylint: disable=too-many-public-methods
         obj.parameters = {}
         assert not obj.auto_tfvars.exists()  # type: ignore
 
-    def test_auto_tfvars_invalid_version(
-        self,
-        caplog: LogCaptureFixture,
-        mocker: MockerFixture,
-        runway_context: MockRunwayContext,
-        tmp_path: Path,
-    ) -> None:
-        """Test auto_tfvars with a version that cannot be converted to int."""
-        caplog.set_level(LogLevels.DEBUG, logger=MODULE)
-        mock_tfenv = MagicMock(current_version="v0.12.0")
-        mocker.patch.object(Terraform, "tfenv", mock_tfenv)
-        options = {"terraform_write_auto_tfvars": True}
-        parameters = {"key": "val"}
-        obj = Terraform(
-            runway_context, module_root=tmp_path, options=options, parameters=parameters
-        )
-        assert obj.auto_tfvars.is_file()
-        assert json.loads(obj.auto_tfvars.read_text()) == parameters
-        assert "unable to parse current version" in "\n".join(caplog.messages)
-
     def test_auto_tfvars_unsupported_version(
         self,
         caplog: LogCaptureFixture,
@@ -123,8 +103,7 @@ class TestTerraform:  # pylint: disable=too-many-public-methods
     ) -> None:
         """Test auto_tfvars with a version that does not support it."""
         caplog.set_level(LogLevels.WARNING, logger=MODULE)
-        mock_tfenv = MagicMock(current_version="0.9.0")
-        mocker.patch.object(Terraform, "tfenv", mock_tfenv)
+        mocker.patch.object(Terraform, "version", VersionTuple(0, 9, 0))
         options = {"terraform_write_auto_tfvars": True}
         parameters = {"key": "val"}
         obj = Terraform(
@@ -788,6 +767,58 @@ class TestTerraform:  # pylint: disable=too-many-public-methods
         )
         assert not obj[action]()
         obj.terraform_workspace_new.assert_called_once_with("test")
+
+    def test_version(
+        self, mocker: MockerFixture, runway_context: MockRunwayContext, tmp_path: Path
+    ) -> None:
+        """Test version."""
+        version = VersionTuple(0, 15, 5)
+        tfenv = Mock(current_version="0.15.5", version=version)
+        mocker.patch.object(Terraform, "tfenv", tfenv)
+        assert Terraform(runway_context, module_root=tmp_path).version == version
+
+    def test_version_from_executable(
+        self, mocker: MockerFixture, runway_context: MockRunwayContext, tmp_path: Path
+    ) -> None:
+        """Test version from executable."""
+        version = VersionTuple(0, 15, 5)
+        tfenv = Mock(current_version=None, version=None)
+        tfenv.get_version_from_executable.return_value = version
+        mocker.patch.object(Terraform, "tfenv", tfenv)
+        mocker.patch.object(Terraform, "tf_bin", "/bin/terraform")
+        obj = Terraform(runway_context, module_root=tmp_path)
+        assert obj.version == version
+        tfenv.get_version_from_executable.assert_called_once_with(obj.tf_bin)
+
+    def test_version_from_options(
+        self, mocker: MockerFixture, runway_context: MockRunwayContext, tmp_path: Path
+    ) -> None:
+        """Test version from options."""
+        version = VersionTuple(0, 15, 5)
+        tfenv = Mock(current_version=None, version=version)
+        mocker.patch.object(Terraform, "tfenv", tfenv)
+        assert (
+            Terraform(
+                runway_context,
+                module_root=tmp_path,
+                options={"terraform_version": "0.15.5"},
+            ).version
+            == version
+        )
+        tfenv.set_version.assert_called_once_with("0.15.5")
+
+    def test_version_raise_value_error(
+        self, mocker: MockerFixture, runway_context: MockRunwayContext, tmp_path: Path
+    ) -> None:
+        """Test version."""
+        tfenv = Mock(current_version=None, version=None)
+        tfenv.get_version_from_executable.return_value = None
+        mocker.patch.object(Terraform, "tfenv", tfenv)
+        mocker.patch.object(Terraform, "tf_bin", "/bin/terraform")
+        with pytest.raises(
+            ValueError, match="unable to retrieve version from /bin/terraform"
+        ):
+            assert Terraform(runway_context, module_root=tmp_path).version
 
 
 class TestTerraformOptions:


### PR DESCRIPTION
# Summary

Terraform version 0.15 included a breaking change that removed `terraform destroy -force`. 0.15.2 also introduced a change that made `terraform destroy` and alias of `terraform apply -destroy`.

We need to be able to alter the Terraform commands we are using according to the version of Terraform in use.

# Why This Is Needed

resolves #597 

# What Changed

## Added

- added `TFEnvManager.version` to handle logic pertaining to determining version from file or explicitly provided
- added `TFEnvManager.set_version()` to explicitly set a version
  - clears cached value of `TFEnvManager.version` if the version is different
- added `tfenv.VersionTuple` for a structured data object for comparing versions
- added `TFEnvManager.parse_version_string()` to parse a Terraform version string into a `VersionTuple`
- added `TFEnvManager.get_version_from_executable()` to get Terraform version from output of executable
- added `Terraform.version` to provide easy access to the current version of Terraform being used (tfenv or otherwise)

## Changed

- `Terraform.terraform_destroy()` now considers which version of Terraform is being used when constructing the command to run
  - `terraform apply -destroy -auto-approve` for `>=0.15.2`
  - `terraform destroy -auto-approve` for `>=0.12.0, <0.15.2` (around the version `-auto-approve` was added in favor of `-force`)
  - `terraform destroy -force` for everything else

## Removed

- removed logic from `TFEnvManager.install()` that was used to determine version - this is now handled by a new property
