### PR TITLE
cdk: change `-c` to `--context` to prevent conflict with `npx -c ...`

### DIFF
--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -122,7 +122,7 @@ class CloudDevelopmentKit(RunwayModuleNpm):
                         self.logger.info("build steps (complete)")
                     cdk_context_opts: List[str] = []
                     for key, val in cast(Dict[str, str], self.parameters).items():
-                        cdk_context_opts.extend(["-context", "%s=%s" % (key, val)])
+                        cdk_context_opts.extend(["--context", "%s=%s" % (key, val)])
                     cdk_opts.extend(cdk_context_opts)
                     if command == "diff":
                         self.logger.info("plan (in progress)")

--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -122,7 +122,7 @@ class CloudDevelopmentKit(RunwayModuleNpm):
                         self.logger.info("build steps (complete)")
                     cdk_context_opts: List[str] = []
                     for key, val in cast(Dict[str, str], self.parameters).items():
-                        cdk_context_opts.extend(["-c", "%s=%s" % (key, val)])
+                        cdk_context_opts.extend(["-context", "%s=%s" % (key, val)])
                     cdk_opts.extend(cdk_context_opts)
                     if command == "diff":
                         self.logger.info("plan (in progress)")


### PR DESCRIPTION
# Summary

Use fqn of CDK option (`--context`) instead of short (`-c`).

The majority of the CDK module is not covered by unit tests so no tests needed to be updated.
Rather than writing brand new unit test now, I will wait until I can refactor the CDK module to meet current standards.

# Why This Is Needed

resolves #621

# What Changed

## Changed

- CDK module now uses `--context <key>=<val>` instead of `-c ...` when passing context values
