### PR TITLE
cdk: use `npx --package aws-cdk cdk ...` to fix issue causing module to fail when using npm 7

### DIFF
--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -27,7 +27,10 @@ def get_cdk_stacks(
     LOGGER.debug("listing stacks in the CDK app prior to diff...")
     result = subprocess.check_output(
         generate_node_command(
-            command="cdk", command_opts=["list"] + context_opts, path=module_path
+            command="cdk",
+            command_opts=["list"] + context_opts,
+            package="aws-cdk",
+            path=module_path,
         ),
         env=env_vars,
     ).decode()
@@ -130,8 +133,11 @@ class CloudDevelopmentKit(RunwayModuleNpm):
                             self.path, self.ctx.env.vars, cdk_context_opts
                         ):
                             subprocess.call(
-                                generate_node_command(
-                                    "cdk", cdk_opts + [i], self.path  # 'diff <stack>'
+                                generate_node_command(  # 'diff <stack>'
+                                    command="cdk",
+                                    command_opts=cdk_opts + [i],
+                                    package="aws-cdk",
+                                    path=self.path,
                                 ),
                                 env=self.ctx.env.vars,
                             )
@@ -146,11 +152,12 @@ class CloudDevelopmentKit(RunwayModuleNpm):
                                 cdk_opts.append("--ci")
                                 cdk_opts.append("--require-approval=never")
                             bootstrap_command = generate_node_command(
-                                "cdk",
-                                ["bootstrap"]
+                                command="cdk",
+                                command_opts=["bootstrap"]
                                 + cdk_context_opts
                                 + (["--no-color"] if self.ctx.no_color else []),
-                                self.path,
+                                package="aws-cdk",
+                                path=self.path,
                             )
                             self.logger.info("bootstrap (in progress)")
                             run_module_command(
@@ -161,7 +168,12 @@ class CloudDevelopmentKit(RunwayModuleNpm):
                             self.logger.info("bootstrap (complete)")
                         elif command == "destroy" and self.ctx.is_noninteractive:
                             cdk_opts.append("-f")  # Don't prompt
-                        cdk_command = generate_node_command("cdk", cdk_opts, self.path)
+                        cdk_command = generate_node_command(
+                            command="cdk",
+                            command_opts=cdk_opts,
+                            package="aws-cdk",
+                            path=self.path,
+                        )
                         self.logger.info("%s (in progress)", command)
                         run_module_command(
                             cmd_list=cdk_command,

--- a/tests/unit/module/test_utils.py
+++ b/tests/unit/module/test_utils.py
@@ -58,6 +58,21 @@ def test_format_npm_command_for_logging_windows(
 
 
 @pytest.mark.parametrize(
+    "command, opts", [("test", []), ("test", ["arg1"]), ("test", ["arg1", "arg2"])]
+)
+def test_generate_node_command(
+    command: str, mocker: MockerFixture, opts: List[str], tmp_path: Path
+) -> None:
+    """Test generate_node_command."""
+    mock_which = mocker.patch(f"{MODULE}.which", return_value=False)
+    assert generate_node_command(command, opts, tmp_path) == [
+        str(tmp_path / "node_modules" / ".bin" / command),
+        *opts,
+    ]
+    mock_which.assert_called_once_with(NPX_BIN)
+
+
+@pytest.mark.parametrize(
     "command, opts, expected",
     [
         ("test", [], [NPX_BIN, "-c", "test"]),
@@ -78,18 +93,20 @@ def test_generate_node_command_npx(
     mock_which.assert_called_once_with(NPX_BIN)
 
 
-@pytest.mark.parametrize(
-    "command, opts", [("test", []), ("test", ["arg1"]), ("test", ["arg1", "arg2"])]
-)
-def test_generate_node_command(
-    command: str, mocker: MockerFixture, opts: List[str], tmp_path: Path
+def test_generate_node_command_npx_package(
+    mocker: MockerFixture, tmp_path: Path
 ) -> None:
     """Test generate_node_command."""
-    mock_which = mocker.patch(f"{MODULE}.which", return_value=False)
-    assert generate_node_command(command, opts, tmp_path) == [
-        str(tmp_path / "node_modules" / ".bin" / command),
-        *opts,
-    ]
+    mock_which = mocker.patch(f"{MODULE}.which", return_value=True)
+    assert (
+        generate_node_command(
+            command="cdk",
+            command_opts=["--context", "key=val"],
+            package="aws-cdk",
+            path=tmp_path,
+        )
+        == [NPX_BIN, "--package", "aws-cdk", "cdk", "--context", "key=val"]
+    )
     mock_which.assert_called_once_with(NPX_BIN)
 
 


### PR DESCRIPTION
# Summary

Fix issue preventing `cdk` commands from working when using npm 7.

# Why This Is Needed

resolves #622 

# What Changed

## Added

- added ability to pass `--package` to `npx` when constructing node command

## Changed

- cdk npm command now uses `npx --package aws-cdk cdk ...` to ensure `npx` is trying to use the `cdk` binary from the correct package
  - excluding `--package` causes the command to fail

## Fixed

- fixed issue causing the cdk module to fail when executing npm commands
