### PR TITLE
cfngin: add `timeout` field to specify CloudFormation Stack `TimeoutInMinutes`

### DIFF
--- a/docs/source/cfngin/configuration.rst
+++ b/docs/source/cfngin/configuration.rst
@@ -695,6 +695,24 @@ Stack
         - name: another-stack
           termination_protection: ${termination_protection_another_stack}
 
+  .. attribute:: timeout
+    :type: Optional[int]
+    :value: None
+
+    Specifies the amount of time, in minutes, that CloudFormation should allot before timing out stack creation operations.
+    If CloudFormation can't create the entire stack in the time allotted, it fails the stack creation due to timeout and rolls back the stack.
+
+    By default, there is no timeout for stack creation.
+    However, individual resources may have their own timeouts based on the nature of the service they implement.
+    For example, if an individual resource in your stack times out, stack creation also times out even if the timeout you specified for stack creation hasn't yet been reached.
+
+    .. rubric:: Example
+    .. code-block:: yaml
+
+      stacks:
+        - name: example-stack
+          timeout: 120
+
   .. attribute:: variables
     :type: Optional[Dict[str, Any]]
     :value: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,9 @@ exclude_lines = [
   "from pathlib import Path",
   "@overload",
 ]
+fail_under = 85
+precision = 2
+show_missing = true
 
 
 [tool.coverage.run]

--- a/runway/cfngin/actions/deploy.py
+++ b/runway/cfngin/actions/deploy.py
@@ -405,6 +405,7 @@ class Action(BaseAction):
                 tags,
                 stack_policy=stack_policy,
                 termination_protection=stack.termination_protection,
+                timeout=stack.definition.timeout,
             )
             return SubmittedStatus("re-creating stack")
         if not provider_stack:
@@ -414,9 +415,10 @@ class Action(BaseAction):
                 template,
                 parameters,
                 tags,
-                force_change_set,
+                force_change_set=force_change_set,
                 stack_policy=stack_policy,
                 termination_protection=stack.termination_protection,
+                timeout=stack.definition.timeout,
             )
             return SubmittedStatus("creating new stack")
 
@@ -436,6 +438,7 @@ class Action(BaseAction):
                     force_change_set=force_change_set,
                     stack_policy=stack_policy,
                     termination_protection=stack.termination_protection,
+                    timeout=stack.definition.timeout,
                 )
 
                 LOGGER.debug("%s:updating existing stack", stack.fqn)

--- a/runway/cfngin/actions/deploy.py
+++ b/runway/cfngin/actions/deploy.py
@@ -438,7 +438,6 @@ class Action(BaseAction):
                     force_change_set=force_change_set,
                     stack_policy=stack_policy,
                     termination_protection=stack.termination_protection,
-                    timeout=stack.definition.timeout,
                 )
 
                 LOGGER.debug("%s:updating existing stack", stack.fqn)

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -918,9 +918,11 @@ class Provider(BaseProvider):
         template: Template,
         parameters: List[ParameterTypeDef],
         tags: List[TagTypeDef],
+        *,
         force_change_set: bool = False,
         stack_policy: Optional[Template] = None,
         termination_protection: bool = False,
+        timeout: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         """Create a new Cloudformation stack.
@@ -936,6 +938,8 @@ class Provider(BaseProvider):
             stack_policy: A template object representing a stack policy.
             termination_protection: End state of the stack's termination
                 protection.
+            timeout: The amount of time that can pass before the stack status becomes
+                ``CREATE_FAILED``.
 
         """
         LOGGER.debug(
@@ -971,9 +975,11 @@ class Provider(BaseProvider):
                 service_role=self.service_role,
                 stack_policy=stack_policy,
             )
-            # this arg is only valid for stack creation so its not part of
+            # these args are only valid for stack creation so they are not part of
             # generate_cloudformation_args.
             args["EnableTerminationProtection"] = termination_protection
+            if timeout:
+                args["TimeoutInMinutes"] = timeout
 
             try:
                 self.cloudformation.create_stack(**args)

--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -116,6 +116,11 @@ class CfnginStackDefinitionModel(ConfigProperty):
         False,
         description="Set the value of termination protection on the CloudFormation stack.",
     )
+    timeout: Optional[int] = Field(
+        None,
+        description="The amount of time (in minutes) that can pass before the "
+        "Stack status becomes CREATE_FAILED.",
+    )
     variables: Dict[str, Any] = Field(
         {},
         description="Parameter values that will be passed to the "

--- a/tests/unit/cfngin/providers/aws/test_default.py
+++ b/tests/unit/cfngin/providers/aws/test_default.py
@@ -615,13 +615,16 @@ class TestProviderDefaultMode(unittest.TestCase):
             stack_name, parameters, tags, template
         )
         expected_args["EnableTerminationProtection"] = False
+        expected_args["TimeoutInMinutes"] = 60
 
         self.stubber.add_response(
             "create_stack", {"StackId": stack_name}, expected_args
         )
 
         with self.stubber:
-            self.provider.create_stack(stack_name, template, parameters, tags)
+            self.provider.create_stack(
+                stack_name, template, parameters, tags, timeout=60
+            )
         self.stubber.assert_no_pending_responses()
 
     @patch("runway.cfngin.providers.aws.default.Provider.update_termination_protection")

--- a/tests/unit/config/models/cfngin/test_cfngin.py
+++ b/tests/unit/config/models/cfngin/test_cfngin.py
@@ -199,6 +199,7 @@ class TestCfnginStackDefinitionModel:
         assert obj.tags == {}
         assert not obj.template_path
         assert not obj.termination_protection
+        assert not obj.timeout
         assert obj.variables == {}
 
     def test_required_fields(self) -> None:


### PR DESCRIPTION
# Summary

Add the ability to set `TimeoutInMinutes` when creating a CloudFormation Stack with CFNgin.

# Why This Is Needed

resolves #589 

# What Changed

## Added

- added `timeout` field to stacks in CFNgin config file
