### PR TITLE
test: override sls stack exports to avoid conflicts

### DIFF
--- a/tests/functional/serverless/test_promotezip/serverless.yml
+++ b/tests/functional/serverless/test_promotezip/serverless.yml
@@ -26,3 +26,15 @@ functions:
   helloWorld1:
     handler: frontend/func/handler.hello1
     name: ${self:custom.namespace}-${self:custom.environment}-sls-promotezip-frontend
+
+resources:
+  Outputs:
+    ServerlessDeploymentBucketName:
+      Export:
+        Name: !Sub ${AWS::StackName}-ServerlessDeploymentBucketName
+    HelloWorld0LambdaFunctionQualifiedArn:
+      Export:
+        Name: !Sub ${AWS::StackName}-HelloWorld0LambdaFunctionQualifiedArn
+    HelloWorld1LambdaFunctionQualifiedArn:
+      Export:
+        Name: !Sub ${AWS::StackName}-HelloWorld1LambdaFunctionQualifiedArn


### PR DESCRIPTION
# Why This Is Needed

If more than one instance of the functional tests are run it once, it would result in the following error:

```
Serverless Error ----------------------------------------
 
  An error occurred: gh-915938183-promotezip-sls-promotezip - Export with name sls-serverless-test-promotezip-promotezip-HelloWorld0LambdaFunctionQualifiedArn is already exported by stack gh-915938814-promotezip-sls-promotezip.
```