### PR TITLE
actions: disable running if actor is dependabot[bot]

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,6 +112,7 @@ jobs:
     if: |
       always() &&
       github.repository == 'onicagroup/runway' &&
+      github.actor != 'dependabot[bot]' &&
       (needs.deploy-test-infrastructure.result == 'success' || needs.deploy-test-infrastructure.result == 'skipped')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/label-maker.yml
+++ b/.github/workflows/label-maker.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   label-maker:
     # Skip running the job from forks.
-    if: github.repository == 'onicagroup/runway'
+    if: github.repository == 'onicagroup/runway' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/on-pr-target-opened.yml
+++ b/.github/workflows/on-pr-target-opened.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   assign-author:
     name: Assign Author to PR
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: technote-space/assign-author@v1  # cspell:ignore technote

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -18,7 +18,7 @@ jobs:
   label-pr:
     name: Label PR
     # Skip running the job from forks.
-    if: github.repository == 'onicagroup/runway'
+    if: github.repository == 'onicagroup/runway' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5.15.0


### PR DESCRIPTION
# Summary

Skip actions that required secrets or write access to repo when the actor is dependabot.

# Why This Is Needed

https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
