### PR TITLE
dependabot: enable updates for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
       time: "08:00"
       timezone: America/New_York
   - directory: /
+    labels:
+      - maintenance
+      - javascript
     open-pull-requests-limit: 5
     package-ecosystem: npm
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,12 @@ updates:
       interval: daily
       time: "08:00"
       timezone: America/New_York
+  - directory: /
+    open-pull-requests-limit: 5
+    package-ecosystem: npm
+    reviewers:
+      - ITProKyle
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: America/New_York


### PR DESCRIPTION
# Summary

Enable dependabot updates for npm packages.
