### PR TITLE
dependabot: enable updates for python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,17 @@ updates:
       interval: daily
       time: "08:00"
       timezone: America/New_York
+  - directory: /
+    labels:
+      - dependencies
+      - poetry
+      - python
+    open-pull-requests-limit: 5
+    package-ecosystem: pip
+    reviewers:
+      - ITProKyle
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: America/New_York
+    versioning-strategy: lockfile-only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,11 @@ pyyaml = "^5"
 requests = "*"
 send2trash = "*"
 sphinx = { version = "^3.5", optional = true }  # docs
-sphinx-github-changelog = { version = "^1.0", optional = true }# docs
+sphinx-github-changelog = { version = "^1.0", optional = true }  # docs
 sphinx-rtd-theme = { version = "^0.5", optional = true } # docs
-sphinx-tabs = { version = "^3.0", optional = true }# docs
-sphinxcontrib-apidoc = { version = "^0.3", optional = true } # docs
-sphinxcontrib-programoutput = { version = "^0.17", optional = true } # docs
+sphinx-tabs = { version = "^3.0", optional = true }  # docs
+sphinxcontrib-apidoc = { version = "^0.3", optional = true }  # docs
+sphinxcontrib-programoutput = { version = "^0.17", optional = true }  # docs
 troposphere = "^2.4"
 typing_extensions = "*"  # only really needed for < 3.8 but can still be used in >= 3.8
 urllib3 = "*"  # allow us to follow botocore's hard pinning without needing to update our own


### PR DESCRIPTION
# Summary

Enable dependabot updates for python packages.
