### PR TITLE
core: add logic to handle `init` action

### DIFF
--- a/runway/context/_runway.py
+++ b/runway/context/_runway.py
@@ -12,6 +12,7 @@ from ._base import BaseContext
 
 if TYPE_CHECKING:
     from .._logging import PrefixAdaptor, RunwayLogger
+    from ..core.type_defs import RunwayActionTypeDef
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 
@@ -19,14 +20,14 @@ LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 class RunwayContext(BaseContext):
     """Runway context object."""
 
-    command: Optional[str]
+    command: Optional[RunwayActionTypeDef]
     env: DeployEnvironment
     logger: Union[PrefixAdaptor, RunwayLogger]
 
     def __init__(
         self,
         *,
-        command: Optional[str] = None,
+        command: Optional[RunwayActionTypeDef] = None,
         deploy_environment: Optional[DeployEnvironment] = None,
         logger: Union[PrefixAdaptor, RunwayLogger] = LOGGER,
         **_: Any,

--- a/runway/core/__init__.py
+++ b/runway/core/__init__.py
@@ -14,7 +14,7 @@ from .._logging import RunwayLogger as _RunwayLogger
 from ..tests.registry import TEST_HANDLERS as _TEST_HANDLERS
 from ..utils import DOC_SITE
 from ..utils import YamlDumper as _YamlDumper
-from . import components, providers
+from . import components, providers, type_defs
 
 if TYPE_CHECKING:
     from ..config import RunwayConfig
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 LOGGER = cast(_RunwayLogger, _logging.getLogger(__name__))
 
-__all__ = ["Runway", "components", "providers"]
+__all__ = ["Runway", "components", "providers", "type_defs"]
 
 
 class Runway:
@@ -101,6 +101,20 @@ class Runway:
             )
             result.update(obj.env_vars_config)
         return result
+
+    def init(
+        self, deployments: Optional[List[RunwayDeploymentDefinition]] = None
+    ) -> None:
+        """Init action.
+
+        Args:
+            deployments: List of deployments to run. If not provided,
+                all deployments in the config will be run.
+
+        """
+        self.__run_action(
+            "init", deployments if deployments is not None else self.deployments
+        )
 
     def plan(
         self, deployments: Optional[List[RunwayDeploymentDefinition]] = None
@@ -226,7 +240,9 @@ class Runway:
         _sys.exit(1)
 
     def __run_action(
-        self, action: str, deployments: Optional[List[RunwayDeploymentDefinition]]
+        self,
+        action: type_defs.RunwayActionTypeDef,
+        deployments: Optional[List[RunwayDeploymentDefinition]],
     ) -> None:
         """Run an action on a list of deployments.
 

--- a/runway/core/components/_deployment.py
+++ b/runway/core/components/_deployment.py
@@ -22,6 +22,7 @@ from ._module import Module
 if TYPE_CHECKING:
     from ...config.components.runway import RunwayDeploymentDefinition
     from ...context import RunwayContext
+    from ..type_defs import RunwayActionTypeDef
 
 
 LOGGER = logging.getLogger(__name__.replace("._", "."))
@@ -144,7 +145,7 @@ class Deployment:
             )
         return self.__sync("plan")
 
-    def run(self, action: str, region: str) -> None:
+    def run(self, action: RunwayActionTypeDef, region: str) -> None:
         """Run a single deployment in a single region.
 
         Low level API access to run a deployment object.
@@ -222,7 +223,7 @@ class Deployment:
             )
             self.ctx.env.vars = merge_dicts(self.ctx.env.vars, self.env_vars_config)
 
-    def __async(self, action: str) -> None:
+    def __async(self, action: RunwayActionTypeDef) -> None:
         """Execute asynchronously.
 
         Args:
@@ -242,7 +243,7 @@ class Deployment:
         for job in futures:
             job.result()  # raise exceptions / exit as needed
 
-    def __sync(self, action: str) -> None:
+    def __sync(self, action: RunwayActionTypeDef) -> None:
         """Execute synchronously.
 
         Args:
@@ -257,7 +258,7 @@ class Deployment:
     @classmethod
     def run_list(
         cls,
-        action: str,
+        action: RunwayActionTypeDef,
         context: RunwayContext,
         deployments: List[RunwayDeploymentDefinition],
         future: RunwayFutureDefinitionModel,

--- a/runway/core/components/_deployment.py
+++ b/runway/core/components/_deployment.py
@@ -123,11 +123,24 @@ class Deployment:
 
         """
         self.logger.verbose(
-            "attempting to destroy in regions(s): %s", ", ".join(self.regions)
+            "attempting to destroy in region(s): %s", ", ".join(self.regions)
         )
         if self.use_async:
             return self.__async("destroy")
         return self.__sync("destroy")
+
+    def init(self) -> None:
+        """Initialize/bootstrap deployment.
+
+        High level method for running a deployment.
+
+        """
+        self.logger.verbose(
+            "attempting to initialize region(s): %s", ", ".join(self.regions)
+        )
+        if self.use_async:
+            return self.__async("init")
+        return self.__sync("init")
 
     def plan(self) -> None:
         """Plan for the next deploy of the deployment.

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -190,6 +190,18 @@ class Module:
             return self.__async("destroy")
         return self.__sync("destroy")
 
+    def init(self) -> None:
+        """Initialize/bootstrap module.
+
+        High level method for running a deployment.
+
+        """
+        if not self.child_modules:
+            return self.run("init")
+        if self.use_async:
+            return self.__async("init")
+        return self.__sync("init")
+
     def plan(self) -> None:
         """Plan for the next deploy of the module.
 

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     )
     from ...config.models.runway import RunwayEnvironmentsType
     from ...context import RunwayContext
+    from ..type_defs import RunwayActionTypeDef
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
 
@@ -203,7 +204,7 @@ class Module:
             )
         return self.__sync("plan")
 
-    def run(self, action: str) -> None:
+    def run(self, action: RunwayActionTypeDef) -> None:
         """Run a single module.
 
         Low level API access to run a module object.
@@ -234,7 +235,7 @@ class Module:
             "processing module in %s (complete)", self.ctx.env.aws_region
         )
 
-    def __async(self, action: str) -> None:
+    def __async(self, action: RunwayActionTypeDef) -> None:
         """Execute asynchronously.
 
         Args:
@@ -257,7 +258,7 @@ class Module:
         for job in futures:
             job.result()  # raise exceptions / exit as needed
 
-    def __sync(self, action: str) -> None:
+    def __sync(self, action: RunwayActionTypeDef) -> None:
         """Execute synchronously.
 
         Args:
@@ -284,7 +285,7 @@ class Module:
     @classmethod
     def run_list(
         cls,
-        action: str,
+        action: RunwayActionTypeDef,
         context: RunwayContext,
         modules: List[RunwayModuleDefinition],
         variables: RunwayVariablesDefinition,

--- a/runway/core/type_defs.py
+++ b/runway/core/type_defs.py
@@ -1,0 +1,6 @@
+"""Type definitions."""
+from __future__ import annotations
+
+from typing_extensions import Literal
+
+RunwayActionTypeDef = Literal["deploy", "destroy", "init", "plan", "test"]

--- a/tests/unit/core/components/test_deployment.py
+++ b/tests/unit/core/components/test_deployment.py
@@ -32,13 +32,13 @@ MODULE = "runway.core.components._deployment"
 class TestDeployment:
     """Test runway.core.components.deployment.Deployment."""
 
-    def test_init(
+    def test___init__(
         self,
         fx_deployments: YamlLoaderDeployment,
         mocker: MockerFixture,
         runway_context: MockRunwayContext,
     ) -> None:
-        """Test init."""
+        """Test __init__."""
         definition = fx_deployments.load("min_required")
         mock_merge = MagicMock()
         mocker.patch.object(Deployment, "_Deployment__merge_env_vars", mock_merge)
@@ -52,10 +52,10 @@ class TestDeployment:
         assert obj.name == "unnamed_deployment"
         mock_merge.assert_called_once_with()
 
-    def test_init_args(
+    def test___init___args(
         self, fx_deployments: YamlLoaderDeployment, runway_context: MockRunwayContext
     ) -> None:
-        """Test init with args."""
+        """Test __init__ with args."""
         definition = fx_deployments.load("simple_env_vars")
         future = RunwayFutureDefinitionModel()
         variables = RunwayVariablesDefinition.parse_obj({"some_key": "val"})
@@ -290,6 +290,35 @@ class TestDeployment:
         else:
             mock_async.assert_not_called()
             mock_sync.assert_called_once_with("destroy")
+
+    @pytest.mark.parametrize("async_used", [(True), (False)])
+    def test_init(
+        self,
+        async_used: bool,
+        caplog: LogCaptureFixture,
+        fx_deployments: YamlLoaderDeployment,
+        mocker: MockerFixture,
+        runway_context: MockRunwayContext,
+    ) -> None:
+        """Test init."""
+        caplog.set_level(logging.INFO, logger="runway")
+        mock_async = MagicMock()
+        mocker.patch.object(Deployment, "_Deployment__async", mock_async)
+        mock_sync = MagicMock()
+        mocker.patch.object(Deployment, "_Deployment__sync", mock_sync)
+        runway_context._use_concurrent = async_used
+        obj = Deployment(
+            context=runway_context,
+            definition=fx_deployments.load("simple_parallel_regions"),
+        )
+        assert obj.init()
+
+        if async_used:
+            mock_async.assert_called_once_with("init")
+            mock_sync.assert_not_called()
+        else:
+            mock_async.assert_not_called()
+            mock_sync.assert_called_once_with("init")
 
     @pytest.mark.parametrize("async_used", [(True), (False)])
     def test_plan(

--- a/tests/unit/core/components/test_deployment.py
+++ b/tests/unit/core/components/test_deployment.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
+    from runway.core.type_defs import RunwayActionTypeDef
+
     from ...factories import MockRunwayContext, YamlLoaderDeployment
 
 MODULE = "runway.core.components._deployment"
@@ -424,7 +426,10 @@ class TestDeployment:
 
     @pytest.mark.parametrize("action", [("deploy"), ("destroy")])
     def test_run_list(
-        self, action: str, mocker: MockerFixture, runway_context: MockRunwayContext
+        self,
+        action: RunwayActionTypeDef,
+        mocker: MockerFixture,
+        runway_context: MockRunwayContext,
     ) -> None:
         """Test run_list."""
         dep0 = MagicMock()

--- a/tests/unit/core/components/test_module.py
+++ b/tests/unit/core/components/test_module.py
@@ -33,8 +33,8 @@ def empty_opts_from_file(mocker: MockerFixture) -> None:
 class TestModule:
     """Test runway.core.components._module.Module."""
 
-    def test_init(self) -> None:
-        """Test init."""
+    def test___init__(self) -> None:
+        """Test __init__."""
         mock_ctx = MagicMock()
         mock_def = MagicMock()
         mock_def.name = "module-name"
@@ -432,6 +432,31 @@ class TestModule:
         mock_run.assert_called_once_with("destroy")
         mock_async.assert_not_called()
         mock_sync.assert_not_called()
+
+    @pytest.mark.parametrize("async_used", [(True), (False)])
+    def test_init(
+        self,
+        async_used: bool,
+        fx_deployments: YamlLoaderDeployment,
+        mocker: MockerFixture,
+        runway_context: MockRunwayContext,
+    ) -> None:
+        """Test init."""
+        mock_async = mocker.patch.object(Module, "_Module__async")
+        mock_sync = mocker.patch.object(Module, "_Module__sync")
+        mocker.patch.object(Module, "use_async", async_used)
+        mod = Module(
+            context=runway_context,
+            definition=fx_deployments.load("simple_parallel_module").modules[0],
+        )
+        assert mod.init()
+
+        if async_used:
+            mock_async.assert_called_once_with("init")
+            mock_sync.assert_not_called()
+        else:
+            mock_async.assert_not_called()
+            mock_sync.assert_called_once_with("init")
 
     @pytest.mark.parametrize("async_used", [(True), (False)])
     def test_plan(

--- a/tests/unit/core/components/test_module.py
+++ b/tests/unit/core/components/test_module.py
@@ -458,6 +458,25 @@ class TestModule:
             mock_async.assert_not_called()
             mock_sync.assert_called_once_with("init")
 
+    def test_init_no_children(
+        self,
+        fx_deployments: YamlLoaderDeployment,
+        mocker: MockerFixture,
+        runway_context: MockRunwayContext,
+    ) -> None:
+        """Test init with no child modules."""
+        mock_async = mocker.patch.object(Module, "_Module__async")
+        mock_sync = mocker.patch.object(Module, "_Module__sync")
+        mock_run = mocker.patch.object(Module, "run")
+        mod = Module(
+            context=runway_context,
+            definition=fx_deployments.load("min_required").modules[0],
+        )
+        assert mod.init()
+        mock_run.assert_called_once_with("init")
+        mock_async.assert_not_called()
+        mock_sync.assert_not_called()
+
     @pytest.mark.parametrize("async_used", [(True), (False)])
     def test_plan(
         self,

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from runway.config import CfnginConfig
+    from runway.core.type_defs import RunwayActionTypeDef
 
 
 class MockBoto3Session:
@@ -203,7 +204,11 @@ class MockRunwayContext(RunwayContext):
     _use_concurrent: bool
 
     def __init__(
-        self, *, command: Optional[str] = None, deploy_environment: Any = None, **_: Any
+        self,
+        *,
+        command: Optional[RunwayActionTypeDef] = None,
+        deploy_environment: Any = None,
+        **_: Any,
     ) -> None:
         """Instantiate class."""
         if not deploy_environment:


### PR DESCRIPTION
# Summary

Add the base functionality of the new `init` action.

# Why This Is Needed

Provides functionality required to develop & test `.init()` methods specific to each module type.

# What Changed

## Added

- added `runway.core.Runway.init()` method - similar to those used for the other actions
- added `runway.core.type_defs` for type definitions
