### PR TITLE
Revert "Bump coloredlogs from 15.0 to 15.0.1 (#665)"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -558,7 +558,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coloredlogs"
-version = "15.0.1"
+version = "15.0"
 description = "Colored terminal output for Python's logging module"
 category = "main"
 optional = false
@@ -2311,8 +2311,8 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coloredlogs = [
-    {file = "coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"},
-    {file = "coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"},
+    {file = "coloredlogs-15.0-py2.py3-none-any.whl", hash = "sha256:b7f630a8297a66984b6bae0f6a1b0e0afb9f2f6838ea3bfa58f50d3d13e133d6"},
+    {file = "coloredlogs-15.0.tar.gz", hash = "sha256:5e78691e2673a8e294499e1832bb13efcfb44a86b92e18109fa18951093218ab"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},


### PR DESCRIPTION
# Summary

This reverts commit a910b3f6224f257ce2529606f18b0bdc11dd7e23.

# Why This Is Needed

This release appears to have caused this error in our functional tests - https://github.com/onicagroup/runway/runs/2802805895?check_suite_focus=true#step:10:10975

# What Changed

## Fixed

- fixed an issue causing most functional test to fail
