### PR TITLE
cli: add functionality to `init` command

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -143,6 +143,8 @@ init
 .. code-block:: sh
 
   $ runway init
+  $ runway init --ci --deploy-environment example
+  $ runway init --tag tag1 --tag tag2
 
 ----
 

--- a/runway/_cli/commands/_init.py
+++ b/runway/_cli/commands/_init.py
@@ -1,22 +1,53 @@
 """``runway init`` command."""
 # docs: file://./../../../docs/source/commands.rst
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, Tuple
 
 import click
+from pydantic import ValidationError
 
+from ...core import Runway
+from ...exceptions import ConfigNotFound, VariablesFileNotFound
 from .. import options
+from ..utils import select_deployments
 
-if TYPE_CHECKING:
-    from ..._logging import RunwayLogger
-
-LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
+LOGGER = logging.getLogger(__name__.replace("._", "."))
 
 
 @click.command("init", short_help="coming soon")
+@options.ci
 @options.debug
+@options.deploy_environment
 @options.no_color
+@options.tags
 @options.verbose
-def init(**_: Any) -> None:
-    """Coming soon."""
-    LOGGER.warning("functionality comming soon")
+@click.pass_context
+def init(ctx: click.Context, debug: bool, tags: Tuple[str, ...], **_: Any) -> None:
+    """Run initialization/bootstrap steps.
+
+    \b
+    1. Determines the deploy environment.
+        - "-e, --deploy-environment" option
+        - "DEPLOY_ENVIRONMENT" environment variable
+        - git branch name
+            - strips "ENV-" prefix, master is converted to common
+            - ignored if "ignore_git_branch: true"
+        - name of the current working directory
+    2. Selects deployments & modules to deploy.
+        - (default) prompts
+        - (tags) module contains all tags
+        - (non-interactive) all
+    3. Initializes/bootstraps selected deployments/modules in the order defined.
+       (e.g. "cdk bootstrap", "terraform init")
+
+    """  # noqa: D301
+    try:
+        Runway(ctx.obj.runway_config, ctx.obj.get_runway_context()).init(
+            select_deployments(ctx, ctx.obj.runway_config.deployments, tags)
+        )
+    except ValidationError as err:
+        LOGGER.error(err, exc_info=debug)
+        ctx.exit(1)
+    except (ConfigNotFound, VariablesFileNotFound) as err:
+        LOGGER.error(err.message, exc_info=debug)
+        ctx.exit(1)

--- a/runway/_cli/commands/_init.py
+++ b/runway/_cli/commands/_init.py
@@ -14,7 +14,7 @@ from ..utils import select_deployments
 LOGGER = logging.getLogger(__name__.replace("._", "."))
 
 
-@click.command("init", short_help="coming soon")
+@click.command("init", short_help="initialize/bootstrap things")
 @options.ci
 @options.debug
 @options.deploy_environment

--- a/tests/integration/cli/commands/test_init.py
+++ b/tests/integration/cli/commands/test_init.py
@@ -37,7 +37,7 @@ def test_init(
     mocker: MockerFixture,
 ) -> None:
     """Test init."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     caplog.set_level(logging.INFO, logger="runway")
     cp_config("min_required", cd_tmp_path)
     runner = CliRunner()
@@ -95,7 +95,7 @@ def test_init_options_ci(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init option --ci."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("min_required", cd_tmp_path)
     runner = CliRunner()
     assert runner.invoke(cli, ["init", "--ci"]).exit_code == 0
@@ -109,7 +109,7 @@ def test_init_options_deploy_environment(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init option -e, --deploy-environment."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("min_required", cd_tmp_path)
     runner = CliRunner()
     assert runner.invoke(cli, ["init", "-e", "e-option"]).exit_code == 0
@@ -131,7 +131,7 @@ def test_init_options_tag(
     mocker: MockerFixture,
 ) -> None:
     """Test init option --tag."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     caplog.set_level(logging.ERROR, logger="runway.cli.commands.init")
     cp_config("tagged_modules", cd_tmp_path)
     runner = CliRunner()
@@ -158,7 +158,7 @@ def test_init_select_deployment(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select from two deployments."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # first value entered is out of range
@@ -173,7 +173,7 @@ def test_init_select_deployment_all(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select all deployments."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # first value entered is out of range
@@ -190,7 +190,7 @@ def test_init_select_module(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select from two modules."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # 2nd deployment, out of range, select second module
@@ -205,7 +205,7 @@ def test_init_select_module_all(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select all modules."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # 2nd deployment, select all
@@ -221,7 +221,7 @@ def test_init_select_module_child_modules(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select child module."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("simple_child_modules.1", cd_tmp_path)
     runner = CliRunner()
     # 2nd module, first child
@@ -236,7 +236,7 @@ def test_init_select_module_child_modules_all(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select all child module."""
-    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
+    mock_runway = mocker.patch(f"{MODULE}.Runway", Mock(spec=Runway, spec_set=True))
     cp_config("simple_child_modules.1", cd_tmp_path)
     runner = CliRunner()
     # 2nd module, first child

--- a/tests/integration/cli/commands/test_init.py
+++ b/tests/integration/cli/commands/test_init.py
@@ -37,12 +37,7 @@ def test_init(
     mocker: MockerFixture,
 ) -> None:
     """Test init."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     caplog.set_level(logging.INFO, logger="runway")
     cp_config("min_required", cd_tmp_path)
     runner = CliRunner()
@@ -100,12 +95,7 @@ def test_init_options_ci(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init option --ci."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("min_required", cd_tmp_path)
     runner = CliRunner()
     assert runner.invoke(cli, ["init", "--ci"]).exit_code == 0
@@ -119,12 +109,7 @@ def test_init_options_deploy_environment(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init option -e, --deploy-environment."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("min_required", cd_tmp_path)
     runner = CliRunner()
     assert runner.invoke(cli, ["init", "-e", "e-option"]).exit_code == 0
@@ -146,12 +131,7 @@ def test_init_options_tag(
     mocker: MockerFixture,
 ) -> None:
     """Test init option --tag."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     caplog.set_level(logging.ERROR, logger="runway.cli.commands.init")
     cp_config("tagged_modules", cd_tmp_path)
     runner = CliRunner()
@@ -178,12 +158,7 @@ def test_init_select_deployment(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select from two deployments."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # first value entered is out of range
@@ -198,12 +173,7 @@ def test_init_select_deployment_all(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select all deployments."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # first value entered is out of range
@@ -220,12 +190,7 @@ def test_init_select_module(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select from two modules."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # 2nd deployment, out of range, select second module
@@ -240,12 +205,7 @@ def test_init_select_module_all(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select all modules."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("min_required_multi", cd_tmp_path)
     runner = CliRunner()
     # 2nd deployment, select all
@@ -261,12 +221,7 @@ def test_init_select_module_child_modules(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select child module."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("simple_child_modules.1", cd_tmp_path)
     runner = CliRunner()
     # 2nd module, first child
@@ -281,12 +236,7 @@ def test_init_select_module_child_modules_all(
     cd_tmp_path: Path, cp_config: CpConfigTypeDef, mocker: MockerFixture
 ) -> None:
     """Test init select all child module."""
-    mock_runway = mocker.patch(
-        f"{MODULE}.Runway",
-        spec=Runway,
-        spec_set=True,
-        init=Mock(side_effect=ValidationError([], Mock())),
-    )
+    mock_runway = mocker.patch(f"{MODULE}.Runway", spec=Runway, spec_set=True)
     cp_config("simple_child_modules.1", cd_tmp_path)
     runner = CliRunner()
     # 2nd module, first child

--- a/tests/integration/cli/commands/test_init.py
+++ b/tests/integration/cli/commands/test_init.py
@@ -1,12 +1,208 @@
-"""Test ``runway init`` command."""
+"""Test ``runway init`` command.
+
+The below tests only cover the CLI.
+Runway's core logic has been mocked out to test on separately from the CLI.
+
+"""
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
 from click.testing import CliRunner
+from mock import patch
 
 from runway._cli import cli
+from runway.config import RunwayConfig
+from runway.context import RunwayContext
+from runway.core import Runway
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mock import MagicMock
+    from pytest import LogCaptureFixture
+
+    from ...conftest import CpConfigTypeDef
+
+MODULE = "runway._cli.commands._init"
 
 
-def test_init() -> None:
-    """Test ``runway init``."""
-    result = CliRunner().invoke(cli, ["init"])
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init(
+    mock_runway: MagicMock,
+    cd_tmp_path: Path,
+    cp_config: CpConfigTypeDef,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Test init."""
+    caplog.set_level(logging.INFO, logger="runway")
+    cp_config("min_required", cd_tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init"])
     assert result.exit_code == 0
+
+    mock_runway.assert_called_once()
+    assert isinstance(mock_runway.call_args.args[0], RunwayConfig)
+    assert isinstance(mock_runway.call_args.args[1], RunwayContext)
+
+    inst = mock_runway.return_value
+    inst.init.assert_called_once()
+    assert len(inst.init.call_args.args[0]) == 1
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_options_ci(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init option --ci."""
+    cp_config("min_required", cd_tmp_path)
+    runner = CliRunner()
+    assert runner.invoke(cli, ["init", "--ci"]).exit_code == 0
+    assert mock_runway.call_args.args[1].env.ci is True
+
+    assert runner.invoke(cli, ["init"]).exit_code == 0
+    assert mock_runway.call_args.args[1].env.ci is False
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_options_deploy_environment(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init option -e, --deploy-environment."""
+    cp_config("min_required", cd_tmp_path)
+    runner = CliRunner()
+    assert runner.invoke(cli, ["init", "-e", "e-option"]).exit_code == 0
+    assert mock_runway.call_args.args[1].env.name == "e-option"
+
+    assert (
+        runner.invoke(
+            cli, ["init", "--deploy-environment", "deploy-environment-option"]
+        ).exit_code
+        == 0
+    )
+    assert mock_runway.call_args.args[1].env.name == "deploy-environment-option"
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_options_tag(
+    mock_runway: MagicMock,
+    caplog: LogCaptureFixture,
+    cd_tmp_path: Path,
+    cp_config: CpConfigTypeDef,
+) -> None:
+    """Test init option --tag."""
+    caplog.set_level(logging.ERROR, logger="runway.cli.commands.init")
+    cp_config("tagged_modules", cd_tmp_path)
+    runner = CliRunner()
+    result0 = runner.invoke(cli, ["init", "--tag", "app:test-app", "--tag", "tier:iac"])
+    assert result0.exit_code == 0
+    deployment = mock_runway.return_value.init.call_args.args[0][0]
+    assert len(deployment.modules) == 1
+    assert deployment.modules[0].name == "sampleapp-01.cfn"
+
+    assert runner.invoke(cli, ["init", "--tag", "app:test-app"]).exit_code == 0
+    deployment = mock_runway.return_value.init.call_args.args[0][0]
+    assert len(deployment.modules) == 3
+    assert deployment.modules[0].name == "sampleapp-01.cfn"
+    assert deployment.modules[1].name == "sampleapp-02.cfn"
+    assert deployment.modules[2].name == "parallel_parent"
+    assert len(deployment.modules[2].child_modules) == 1
+    assert deployment.modules[2].child_modules[0].name == "sampleapp-03.cfn"
+
+    assert runner.invoke(cli, ["init", "--tag", "no-match"]).exit_code == 1
+    assert "No modules found with the provided tag(s): no-match" in caplog.messages
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_select_deployment(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init select from two deployments."""
+    cp_config("min_required_multi", cd_tmp_path)
+    runner = CliRunner()
+    # first value entered is out of range
+    result = runner.invoke(cli, ["init"], input="35\n1\n")
+    assert result.exit_code == 0
+    deployments = mock_runway.return_value.init.call_args.args[0]
+    assert len(deployments) == 1
+    assert deployments[0].name == "deployment_1"
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_select_deployment_all(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init select all deployments."""
+    cp_config("min_required_multi", cd_tmp_path)
+    runner = CliRunner()
+    # first value entered is out of range
+    result = runner.invoke(cli, ["init"], input="all\n")
+    assert result.exit_code == 0
+    deployments = mock_runway.return_value.init.call_args.args[0]
+    assert len(deployments) == 2
+    assert deployments[0].name == "deployment_1"
+    assert deployments[1].name == "deployment_2"
+    assert len(deployments[1].modules) == 2
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_select_module(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init select from two modules."""
+    cp_config("min_required_multi", cd_tmp_path)
+    runner = CliRunner()
+    # 2nd deployment, out of range, select second module
+    result = runner.invoke(cli, ["init"], input="2\n35\n2\n")
+    assert result.exit_code == 0
+    deployment = mock_runway.return_value.init.call_args.args[0][0]
+    assert len(deployment.modules) == 1
+    assert deployment.modules[0].name == "sampleapp-03.cfn"
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_select_module_all(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init select all modules."""
+    cp_config("min_required_multi", cd_tmp_path)
+    runner = CliRunner()
+    # 2nd deployment, select all
+    result = runner.invoke(cli, ["init"], input="2\nall\n")
+    assert result.exit_code == 0
+    deployment = mock_runway.return_value.init.call_args.args[0][0]
+    assert len(deployment.modules) == 2
+    assert deployment.modules[0].name == "sampleapp-02.cfn"
+    assert deployment.modules[1].name == "sampleapp-03.cfn"
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_select_module_child_modules(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init select child module."""
+    cp_config("simple_child_modules.1", cd_tmp_path)
+    runner = CliRunner()
+    # 2nd module, first child
+    result = runner.invoke(cli, ["init"], input="2\n1\n")
+    assert result.exit_code == 0
+    deployment = mock_runway.return_value.init.call_args.args[0][0]
+    assert len(deployment.modules) == 1
+    assert deployment.modules[0].name == "parallel-sampleapp-01.cfn"
+
+
+@patch(MODULE + ".Runway", spec=Runway, spec_set=True)
+def test_init_select_module_child_modules_all(
+    mock_runway: MagicMock, cd_tmp_path: Path, cp_config: CpConfigTypeDef
+) -> None:
+    """Test init select all child module."""
+    cp_config("simple_child_modules.1", cd_tmp_path)
+    runner = CliRunner()
+    # 2nd module, first child
+    result = runner.invoke(cli, ["init"], input="2\nall\n")
+    assert result.exit_code == 0
+    deployment = mock_runway.return_value.init.call_args.args[0][0]
+    assert len(deployment.modules) == 2
+    assert deployment.modules[0].name == "parallel-sampleapp-01.cfn"
+    assert deployment.modules[1].name == "parallel-sampleapp-02.cfn"


### PR DESCRIPTION
# Summary

As discussed in #427, this adds the required CLI functionality to run the init methods added in #659.

# What Changed

## Added

- added functionality to the `init` command - it will no longer log that it is coming soon
