### PR TITLE
module.*: add `.init()` method to base class & module handler classes

### DIFF
--- a/docs/source/developers/custom_module.rst
+++ b/docs/source/developers/custom_module.rst
@@ -4,53 +4,48 @@
 Custom Plugin Support
 #####################
 
-Need to expand Runway to wrap other tools? Yes - you can do that with custom
-plugin support.
+Need to expand Runway to wrap other tools?
+Yes - you can do that with custom plugin support.
 
 
 ********
 Overview
 ********
 
-Runway can import Python modules that can perform custom deployments with your
-own set of Runway modules. Let's say for example you want to have Runway
-execute an Ansible playbook to create an EC2 security group as one of the steps
-in the middle of your Runway deployment list - this is possible with your own
-plugin. The custom plugin support allows you to mix-and-match natively
-supported modules (e.g. CloudFormation, Terraform) with plugins you write
-providing additional support for non-native modules. Although written in
-Python, these plugins can natively execute non Python binaries.
+Runway can import Python modules that can perform custom deployments with your own set of Runway modules.
+Let's say for example you want to have Runway execute an Ansible playbook to create an EC2 security group as one of the steps in the middle of your Runway deployment list - this is possible with your own plugin.
+The custom plugin support allows you to mix-and-match natively supported modules (e.g. CloudFormation, Terraform) with plugins you write providing additional support for non-native modules.
+Although written in Python, these plugins can natively execute non-Python binaries.
 
 
 ******************
 RunwayModule Class
 ******************
 
-Runway provides a Python Class named ``RunwayModule`` that can be imported
-into your custom plugin/Python module. This base class will give you the
-ability to write your own module that can be added to your runway.yml
-deployment list (More info on runway.yml below). There are three required
-functions:
-
-**plan**
-  This code block gets called when ``runway taxi`` executes
+Runway provides :class:`~runway.module.base.RunwayModule` to use as the base class of all module handler classes.
+This base class will give you the ability to write your own module handler class that can be added to your runway.yml deployment list (More info on runway.yml below).
+There are four methods that need to be defined for the class:
 
 **deploy**
-  This code block gets called when ``runway takeoff`` executes
+  This method is called when ``runway deploy`` is run.
 
 **destroy**
-  This code block gets called when ``runway destroy`` executes
+  This method is called when ``runway destroy`` is run.
 
-All of these functions are required, but are permitted to be empty no-op/pass
-statements if applicable.
+**init**
+  This method is called when ``runway init`` is run.
+
+**plan**
+  This method is called when ``runway plan`` is run.
 
 
 **************
 Context Object
 **************
 
-``self.ctx`` includes many helpful resources for use in your Python
-module. Some notable examples are::
+``self.ctx`` includes many helpful resources for use in your Python module.
+
+Some notable examples are:
 
 - ``self.ctx.env.name`` - name of the environment
 - ``self.ctx.env.aws_region`` - region in which the module is being executed
@@ -131,10 +126,6 @@ skipped. This matches the behavior of the Runway's native modules.
   class DeployToAWS(RunwayModule):
       """Ansible Runway Module."""
 
-      def plan(self) -> None:
-          """Skip plan."""
-          LOGGER.info("plan not currently supported for Ansible")
-
       def deploy(self) -> None:
           """Run ansible-playbook."""
           if not which("ansible-playbook"):
@@ -152,7 +143,15 @@ skipped. This matches the behavior of the Runway's native modules.
 
       def destroy(self) -> None:
           """Skip destroy."""
-          LOGGER.info("Destroy not currently supported for Ansible")
+          LOGGER.info("destroy not currently supported for Ansible")
+
+      def init(self) -> None:
+          """Skip init."""
+          LOGGER.info("init not currently supported for Ansible")
+
+      def plan(self) -> None:
+          """Skip plan."""
+          LOGGER.info("plan not currently supported for Ansible")
 
 
 And below is the example Ansible playbook itself, saved as ``dev-us-east-1.yaml`` in the security_group.ansible folder:

--- a/docs/source/maintainers/infrastructure.rst
+++ b/docs/source/maintainers/infrastructure.rst
@@ -65,7 +65,7 @@ onica-platform-runway-testing-lab
 TBA
 
 
-*******
+********
 test-alt
 ********
 

--- a/runway/module/base.py
+++ b/runway/module/base.py
@@ -73,6 +73,10 @@ class RunwayModule:
         """Abstract method called when running destroy."""
         raise NotImplementedError("You must implement the destroy() method yourself!")
 
+    def init(self) -> None:
+        """Abstract method called when running init."""
+        raise NotImplementedError("You must implement the init() method yourself!")
+
     def plan(self) -> None:
         """Abstract method called when running plan."""
         raise NotImplementedError("You must implement the plan() method yourself!")

--- a/runway/module/cdk.py
+++ b/runway/module/cdk.py
@@ -191,10 +191,6 @@ class CloudDevelopmentKit(RunwayModuleNpm):
             response["skipped_configs"] = True
         return response
 
-    def plan(self) -> None:
-        """Run cdk diff."""
-        self.run_cdk(command="diff")
-
     def deploy(self) -> None:
         """Run cdk deploy."""
         self.run_cdk(command="deploy")
@@ -202,6 +198,14 @@ class CloudDevelopmentKit(RunwayModuleNpm):
     def destroy(self) -> None:
         """Run cdk destroy."""
         self.run_cdk(command="destroy")
+
+    def init(self) -> None:
+        """Run cdk init."""
+        LOGGER.warning("init not currently supported for %s", self.__class__.__name__)
+
+    def plan(self) -> None:
+        """Run cdk diff."""
+        self.run_cdk(command="diff")
 
 
 class CloudDevelopmentKitOptions(ModuleOptions):

--- a/runway/module/cloudformation.py
+++ b/runway/module/cloudformation.py
@@ -71,6 +71,10 @@ class CloudFormation(RunwayModule):
         cfngin = CFNgin(self.ctx, parameters=self.parameters, sys_path=self.path)
         cfngin.destroy(force=bool(self.parameters or self.explicitly_enabled))
 
+    def init(self) -> None:
+        """Run init."""
+        LOGGER.warning("init not currently supported for %s", self.__class__.__name__)
+
     def plan(self) -> None:
         """Run diff."""
         cfngin = CFNgin(self.ctx, parameters=self.parameters, sys_path=self.path)

--- a/runway/module/k8s.py
+++ b/runway/module/k8s.py
@@ -152,10 +152,6 @@ class K8s(RunwayModule):
             self.logger.info("%s (complete)", command)
         return {"skipped_configs": False}
 
-    def plan(self) -> None:
-        """Run kustomize build and display generated plan."""
-        self.run_kubectl(command="plan")
-
     def deploy(self) -> None:
         """Run kubectl apply."""
         self.run_kubectl(command="apply")
@@ -163,6 +159,14 @@ class K8s(RunwayModule):
     def destroy(self) -> None:
         """Run kubectl delete."""
         self.run_kubectl(command="delete")
+
+    def init(self) -> None:
+        """Run init."""
+        LOGGER.warning("init not currently supported for %s", self.__class__.__name__)
+
+    def plan(self) -> None:
+        """Run kustomize build and display generated plan."""
+        self.run_kubectl(command="plan")
 
 
 class K8sOptions(ModuleOptions):

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -386,10 +386,6 @@ class Serverless(RunwayModuleNpm):
             sys.exit(proc.returncode)
         self.logger.info("destroy (complete)")
 
-    def plan(self) -> None:
-        """Entrypoint for Runway's plan action."""
-        self.logger.info("plan not currently supported for Serverless")
-
     def deploy(self) -> None:
         """Entrypoint for Runway's deploy action."""
         if self.skip:
@@ -407,6 +403,14 @@ class Serverless(RunwayModuleNpm):
             self.extend_serverless_yml(self.sls_remove)
         else:
             self.sls_remove()
+
+    def init(self) -> None:
+        """Run init."""
+        LOGGER.warning("init not currently supported for %s", self.__class__.__name__)
+
+    def plan(self) -> None:
+        """Entrypoint for Runway's plan action."""
+        self.logger.info("plan not currently supported for Serverless")
 
 
 class ServerlessOptions(ModuleOptions):

--- a/runway/module/staticsite/handler.py
+++ b/runway/module/staticsite/handler.py
@@ -80,13 +80,6 @@ class StaticSite(RunwayModule):
         self._ensure_cloudfront_with_auth_at_edge()
         self._ensure_correct_region_with_auth_at_edge()
 
-    def plan(self) -> None:
-        """Create website CFN module and run CFNgin.diff."""
-        if self.parameters:
-            self._setup_website_module(command="plan")
-        else:
-            self.logger.info("skipped; environment required but not defined")
-
     def deploy(self) -> None:
         """Create website CFN module and run CFNgin.deploy."""
         if self.parameters:
@@ -122,6 +115,17 @@ class StaticSite(RunwayModule):
         """Create website CFN module and run CFNgin.destroy."""
         if self.parameters:
             self._setup_website_module(command="destroy")
+        else:
+            self.logger.info("skipped; environment required but not defined")
+
+    def init(self) -> None:
+        """Run init."""
+        LOGGER.warning("init not currently supported for %s", self.__class__.__name__)
+
+    def plan(self) -> None:
+        """Create website CFN module and run CFNgin.diff."""
+        if self.parameters:
+            self._setup_website_module(command="plan")
         else:
             self.logger.info("skipped; environment required but not defined")
 

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -556,10 +556,6 @@ class Terraform(RunwayModule):
             if self.auto_tfvars.exists():
                 self.auto_tfvars.unlink()
 
-    def plan(self) -> None:
-        """Run Terraform plan."""
-        self.run("plan")
-
     def deploy(self) -> None:
         """Run Terraform apply."""
         self.run("apply")
@@ -567,6 +563,14 @@ class Terraform(RunwayModule):
     def destroy(self) -> None:
         """Run Terraform destroy."""
         self.run("destroy")
+
+    def init(self) -> None:
+        """Run init."""
+        LOGGER.warning("init not currently supported for %s", self.__class__.__name__)
+
+    def plan(self) -> None:
+        """Run Terraform plan."""
+        self.run("plan")
 
 
 class TerraformOptions(ModuleOptions):

--- a/tests/unit/module/staticsite/test_handler.py
+++ b/tests/unit/module/staticsite/test_handler.py
@@ -3,6 +3,7 @@
 # pyright: basic
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from runway.module.staticsite.handler import StaticSite
@@ -14,14 +15,19 @@ from runway.module.staticsite.parameters.models import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pytest import LogCaptureFixture
+
     from runway.context import RunwayContext
+
+
+MODULE = "runway.module.staticsite.handler"
 
 
 class TestStaticSite:
     """Test StaticSite."""
 
-    def test_init(self, runway_context: RunwayContext, tmp_path: Path) -> None:
-        """Test init."""
+    def test___init__(self, runway_context: RunwayContext, tmp_path: Path) -> None:
+        """Test __init__."""
         obj = StaticSite(
             runway_context,
             module_root=tmp_path,
@@ -36,3 +42,16 @@ class TestStaticSite:
             {"namespace": "test"}
         )
         assert obj.path == tmp_path
+
+    def test_init(
+        self, caplog: LogCaptureFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test init."""
+        caplog.set_level(logging.WARNING, logger=MODULE)
+        obj = StaticSite(
+            runway_context, module_root=tmp_path, parameters={"namespace": "test"}
+        )
+        assert not obj.init()
+        assert (
+            f"init not currently supported for {StaticSite.__name__}" in caplog.messages
+        )

--- a/tests/unit/module/test_base.py
+++ b/tests/unit/module/test_base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, cast
 
 import pytest
@@ -14,6 +13,8 @@ from runway.exceptions import NpmNotFound
 from runway.module.base import NPM_BIN, ModuleOptions, RunwayModule, RunwayModuleNpm
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
     from pytest_subprocess import FakeProcess
@@ -256,22 +257,7 @@ class TestRunwayModuleNpm:
 class TestRunwayModule:
     """Test runway.module.base.RunwayModule."""
 
-    def test_deploy(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
-        """Test deploy."""
-        with pytest.raises(NotImplementedError):
-            RunwayModule(runway_context, module_root=tmp_path).deploy()
-
-    def test_destroy(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
-        """Test destroy."""
-        with pytest.raises(NotImplementedError):
-            RunwayModule(runway_context, module_root=tmp_path).destroy()
-
-    def test_getitem(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
-        """Test __getitem__."""
-        obj = RunwayModule(runway_context, module_root=tmp_path)
-        assert obj["path"] == tmp_path
-
-    def test_init_default(
+    def test___init___default(
         self, runway_context: MockRunwayContext, tmp_path: Path
     ) -> None:
         """Test __init__ default values."""
@@ -282,7 +268,7 @@ class TestRunwayModule:
         assert obj.options == {}
         assert obj.parameters == {}
 
-    def test_init(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
+    def test___init__(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
         """Test __init__."""
         obj = RunwayModule(
             runway_context,
@@ -301,6 +287,26 @@ class TestRunwayModule:
         assert obj.parameters == {"parameters": "test"}
         assert obj.path == tmp_path
         assert not hasattr(obj, "something")
+
+    def test_deploy(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
+        """Test deploy."""
+        with pytest.raises(NotImplementedError):
+            RunwayModule(runway_context, module_root=tmp_path).deploy()
+
+    def test_destroy(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
+        """Test destroy."""
+        with pytest.raises(NotImplementedError):
+            RunwayModule(runway_context, module_root=tmp_path).destroy()
+
+    def test_getitem(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
+        """Test __getitem__."""
+        obj = RunwayModule(runway_context, module_root=tmp_path)
+        assert obj["path"] == tmp_path
+
+    def test_init(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
+        """Test init."""
+        with pytest.raises(NotImplementedError):
+            RunwayModule(runway_context, module_root=tmp_path).init()
 
     def test_plan(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
         """Test plan."""

--- a/tests/unit/module/test_cdk.py
+++ b/tests/unit/module/test_cdk.py
@@ -3,14 +3,42 @@
 # pyright: basic
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
 from runway.config.models.runway.options.cdk import RunwayCdkModuleOptionsDataModel
-from runway.module.cdk import CloudDevelopmentKitOptions
+from runway.module.cdk import CloudDevelopmentKit, CloudDevelopmentKitOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import LogCaptureFixture
+
+    from runway.context import RunwayContext
+
+MODULE = "runway.module.cdk"
+
+
+class TestCloudDevelopmentKit:
+    """Test CloudDevelopmentKit."""
+
+    def test_init(
+        self, caplog: LogCaptureFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test init."""
+        caplog.set_level(logging.WARNING, logger=MODULE)
+        obj = CloudDevelopmentKit(runway_context, module_root=tmp_path)
+        assert not obj.init()
+        assert (
+            f"init not currently supported for {CloudDevelopmentKit.__name__}"
+            in caplog.messages
+        )
 
 
 class TestCloudDevelopmentKitOptions:
     """Test CloudDevelopmentKitOptions."""
 
-    def test_init(self) -> None:
+    def test___init__(self) -> None:
         """Test __init__."""
         data = RunwayCdkModuleOptionsDataModel(build_steps=["test"])
         obj = CloudDevelopmentKitOptions(data)

--- a/tests/unit/module/test_cloudformation.py
+++ b/tests/unit/module/test_cloudformation.py
@@ -3,6 +3,7 @@
 # pyright: basic
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Dict
 
 from runway.core.components import DeployEnvironment
@@ -13,7 +14,13 @@ from ..factories import MockRunwayContext
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
+
+    from runway.context import RunwayContext
+
+
+MODULE = "runway.module.cloudformation"
 
 
 class TestCloudFormation:
@@ -50,6 +57,18 @@ class TestCloudFormation:
         )
         module.destroy()
         mock_action.assert_called_once()
+
+    def test_init(
+        self, caplog: LogCaptureFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test init."""
+        caplog.set_level(logging.WARNING, logger=MODULE)
+        obj = CloudFormation(runway_context, module_root=tmp_path)
+        assert not obj.init()
+        assert (
+            f"init not currently supported for {CloudFormation.__name__}"
+            in caplog.messages
+        )
 
     def test_plan(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """Test plan."""

--- a/tests/unit/module/test_k8s.py
+++ b/tests/unit/module/test_k8s.py
@@ -3,6 +3,7 @@
 # pyright: basic
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, List
 
 import pytest
@@ -13,6 +14,7 @@ from runway.module.k8s import K8s, K8sOptions
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
     from ..factories import MockRunwayContext
@@ -22,6 +24,18 @@ MODULE = "runway.module.k8s"
 
 class TestK8s:
     """Test runway.module.k8s.K8s."""
+
+    def test_init(
+        self,
+        caplog: LogCaptureFixture,
+        runway_context: MockRunwayContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test init."""
+        caplog.set_level(logging.WARNING, logger=MODULE)
+        obj = K8s(runway_context, module_root=tmp_path)
+        assert not obj.init()
+        assert f"init not currently supported for {K8s.__name__}" in caplog.messages
 
     def test_skip(self, runway_context: MockRunwayContext, tmp_path: Path) -> None:
         """Test skip."""


### PR DESCRIPTION
# Summary

Add `.init()` method to all module handler classes and the base class.

# Why This Is Needed

Continued work to implement the feature outlined in #427.

# What Changed

## Added

- added `runway.module.base.RunwayModule.init()`
- added `runway.module.cdk.CloudDevelopmentKit.init()`
- added `runway.module.cloudformation.CloudFormation.init()`
- added `runway.module.k8s.K8s.init()`
- added `runway.module.serverless.Serverless.init()`
- added `runway.module.staticsite.handler.StaticSite.init()`
- added `runway.module.terraform.Terraform.init()`

## Changed

- updated documentation
