### PR TITLE
remove botocore as an explicit dependency - implicit from use of boto3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ python = ">=3.7, <4"
 "backports.cached_property" = { version = "*", python = "<3.8" }
 awacs = "*"
 boto3 = "^1.16"
-botocore = "^1.19"
 cfn-lint = "*"
 cfn_flip = "^1.2"  # only used in runway._cli.commands._gen_sample.utils
 click = "^8.0"


### PR DESCRIPTION
# Summary

Remove `botocore` as an explicit dependency. It is an implicit dependency through the use of `boto3`.

# Why This Is Needed

This will allow dependabot to properly update our lock file. When both `botocore` and `boto3` are defined, only `botocore` is updated as an update to `boto3` is dependent upon updating `botocore`.

# What Changed

## Removed

- remove `botocore` as an explicit dependency
