### PR TITLE
cfngin.hooks: add `ssm.parameter.SecureString` hook

### DIFF
--- a/docs/source/cfngin/hooks.rst
+++ b/docs/source/cfngin/hooks.rst
@@ -1355,6 +1355,155 @@ Create a domain within route53.
 ----
 
 
+ssm
+===
+
+A collection of hooks that interact with AWS SSM.
+
+
+ssm.parameter.SecureString
+--------------------------
+
+.. rubric:: Description
+
+Create, update, and delete a **SecureString** SSM parameter.
+
+A SecureString parameter is any sensitive data that needs to be stored and referenced in a secure manner.
+If you have data that you don't want users to alter or reference in plaintext, such as passwords or license keys, create those parameters using the SecureString datatype.
+
+When used in the :attr:`~cfngin.config.pre_deploy` or :attr:`~cfngin.config.post_deploy` stage this hook will create or update an SSM parameter.
+
+When used in the :attr:`~cfngin.config.pre_destroy` or :attr:`~cfngin.config.post_destroy` stage this hook will delete an SSM parameter.
+
+.. rubric:: Hook Path
+
+:class:`runway.cfngin.hooks.ssm.parameter.SecureString`
+
+.. rubric:: Args
+.. data:: allowed_pattern
+  :type: Optional[str]
+  :value: None
+  :noindex:
+
+  A regular expression used to validate the parameter value.
+
+.. data:: data_type
+  :type: Optional[Literal["aws:ec2:image", "text"]]
+  :value: None
+  :noindex:
+
+  The data type for a String parameter.
+  Supported data types include plain text and Amazon Machine Image IDs.
+
+.. data:: description
+  :type: Optional[str]
+  :value: None
+  :noindex:
+
+  Information about the parameter.
+
+.. data:: force
+  :type: bool
+  :value: False
+  :noindex:
+
+  Skip checking the current value of the parameter, just put it.
+  Can be used alongside **overwrite** to always update a parameter.
+
+.. data:: key_id
+  :type: Optional[str]
+  :value: None
+  :noindex:
+
+  The KMS Key ID that you want to use to encrypt a parameter.
+  Either the default AWS Key Management Service (AWS KMS) key automatically assigned to your AWS account or a custom key.
+
+.. data:: name
+  :type: str
+  :noindex:
+
+  The fully qualified name of the parameter that you want to add to the system.
+
+.. data:: overwrite
+  :type: bool
+  :value: True
+  :noindex:
+
+  Allow overwriting an existing parameter.
+  If this is set to ``False`` and the parameter already exists, an error will be raised.
+
+.. data:: policies
+  :type: Optional[Union[List[Dict[str, Any]], str]]
+  :value: None
+  :noindex:
+
+  One or more policies to apply to a parameter.
+  This field takes a JSON array.
+
+.. data:: tags
+  :type: Optional[Union[Dict[str, str], List[TagTypeDef]]]
+  :value: None
+  :noindex:
+
+  Tags to be applied to the parameter.
+
+.. data:: tier
+  :type: Literal["Advanced", "Intelligent-Tiering", "Standard"]
+  :value: "Standard"
+  :noindex:
+
+  The parameter tier to assign to a parameter.
+
+.. data:: value
+  :type: Optional[str]
+  :value: None
+  :noindex:
+
+  The parameter value that you want to add to the system.
+  Standard parameters have a value limit of 4 KB.
+  Advanced parameters have a value limit of 8 KB.
+
+  If the value of this field is falsy, the parameter will not be created or updated.
+
+  If the value of this field matches what is already in SSM Parameter Store, it will not be updated unless **force** is ``True``.
+
+.. rubric:: Example
+.. code-block:: yaml
+
+  pre_deploy: &hooks
+    - path: runway.cfngin.hooks.ssm.parameter.SecureString
+      args:
+        name: /example/foo
+        value: bar
+    - path: runway.cfngin.hooks.ssm.parameter.SecureString
+      args:
+        name: /example/parameter1
+        description: This is an example.
+        tags:
+          tag-key: tag-value
+        tier: Advanced
+        value: ${value_may_be_none}
+    - path: runway.cfngin.hooks.ssm.parameter.SecureString
+      args:
+        name: /example/parameter2
+        policies:
+          - Type: Expiration
+            Version: 1.0
+            Attributes:
+              Timestamp: 2018-12-02T21:34:33.000Z
+        tags:
+          - Key: tag-key
+            Value: tag-value
+        value: ${something_else}
+
+  post_destroy: *hooks
+
+.. versionadded:: 2.2.0
+
+
+----
+
+
 upload_staticsite.sync
 ======================
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,9 @@ html_css_files = ["css/custom.css"]  # files relative to html_static_path
 html_favicon = None
 html_logo = None
 html_theme = "sphinx_rtd_theme"  # theme to use for HTML and HTML Help pages
-html_theme_options = {}
+html_theme_options = {
+    "navigation_depth": -1,  # unlimited depth
+}
 html_short_title = f"{project} v{release}"
 html_title = f"{project} v{release}"
 html_show_copyright = True

--- a/runway/cfngin/hooks/ssm/__init__.py
+++ b/runway/cfngin/hooks/ssm/__init__.py
@@ -1,0 +1,1 @@
+"""AWS SSM hooks."""

--- a/runway/cfngin/hooks/ssm/parameter.py
+++ b/runway/cfngin/hooks/ssm/parameter.py
@@ -1,0 +1,274 @@
+"""AWS SSM Parameter Store hooks."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+
+from pydantic import Extra, Field, validator
+from typing_extensions import Literal
+
+from ....compat import cached_property
+from ....utils import BaseModel, JsonEncoder
+from ..utils import TagDataModel
+
+if TYPE_CHECKING:
+    from mypy_boto3_ssm.client import SSMClient
+    from mypy_boto3_ssm.type_defs import (
+        ParameterTypeDef,
+        PutParameterResultTypeDef,
+        TagTypeDef,
+    )
+
+    from ...._logging import RunwayLogger
+    from ....context import CfnginContext
+
+LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
+
+
+class ArgsDataModel(BaseModel):
+    """Parameter hook args.
+
+    Attributes:
+        allowed_pattern: A regular expression used to validate the parameter value.
+        data_type: The data type for a String parameter. Supported data types
+            include plain text and Amazon Machine Image IDs.
+        description: Information about the parameter.
+        force: Skip checking the current value of the parameter, just put it.
+            Can be used alongside ``overwrite`` to always update a parameter.
+        key_id: The KMS Key ID that you want to use to encrypt a parameter.
+            Either the default AWS Key Management Service (AWS KMS) key automatically
+            assigned to your AWS account or a custom key.
+            Required for parameters that use the ``SecureString`` data type.
+        name: The fully qualified name of the parameter that you want to add to
+            the system.
+        overwrite: Allow overwriting an existing parameter.
+        policies: One or more policies to apply to a parameter.
+            This field takes a JSON array.
+        tags: Optional metadata that you assign to a resource.
+        tier: The parameter tier to assign to a parameter.
+        type: The type of parameter.
+        value: The parameter value that you want to add to the system.
+            Standard parameters have a value limit of 4 KB.
+            Advanced parameters have a value limit of 8 KB.
+
+    """
+
+    allowed_pattern: Optional[str] = Field(None, alias="AllowedPattern")
+    data_type: Optional[Literal["aws:ec2:image", "text"]] = Field(
+        None, alias="DataType"
+    )
+    description: Optional[str] = Field(None, alias="Description")
+    force: bool = False
+    key_id: Optional[str] = Field(None, alias="KeyId")
+    name: str = Field(..., alias="Name")
+    overwrite: bool = Field(True, alias="Overwrite")
+    policies: Optional[str] = Field(None, alias="Policies")
+    tags: Optional[List[TagDataModel]] = Field(None, alias="Tags")
+    tier: Literal["Advanced", "Intelligent-Tiering", "Standard"] = Field(
+        "Standard", alias="Tier"
+    )
+    type: Literal["String", "StringList", "SecureString"] = Field(..., alias="Type")
+    value: Optional[str] = Field(None, alias="Value")
+
+    class Config:
+        """Model configuration."""
+
+        allow_population_by_field_name = True
+        extra = Extra.ignore
+
+    @validator("policies", pre=True)
+    @classmethod
+    def _convert_policies(cls, v: Union[List[Dict[str, Any]], str, Any]) -> str:
+        """Convert policies to acceptable value."""
+        if isinstance(v, str):
+            return v
+        if isinstance(v, list):
+            return json.dumps(v, cls=JsonEncoder)
+        raise TypeError(
+            f"unexpected type {type(v)}; permitted: Optional[Union[List[Dict[str, Any]], str]]"
+        )
+
+    @validator("tags", pre=True)
+    @classmethod
+    def _convert_tags(
+        cls, v: Union[Dict[str, str], List[Dict[str, str]], Any]
+    ) -> List[Dict[str, str]]:
+        """Convert tags to acceptable value."""
+        if isinstance(v, list):
+            return v
+        if isinstance(v, dict):
+            return [{"Key": k, "Value": v} for k, v in v.items()]
+        raise TypeError(
+            f"unexpected type {type(v)}; permitted: "
+            "Optional[Union[Dict[str, str], List[Dict[str, str]]]"
+        )
+
+
+class _Parameter:
+    """AWS SSM Parameter Store Parameter."""
+
+    def __init__(
+        self,
+        context: CfnginContext,
+        *,
+        name: str,
+        type: Literal[  # pylint: disable=redefined-builtin
+            "String", "StringList", "SecureString"
+        ],
+        **kwargs: Any,
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            context: CFNgin context object.
+            name: The fully qualified name of the parameter that you want to add to
+                the system.
+            type: The type of parameter.
+
+        """
+        self.args = ArgsDataModel.parse_obj({"name": name, "type": type, **kwargs})
+        self.ctx = context
+
+    @cached_property
+    def client(self) -> SSMClient:
+        """AWS SSM client."""
+        return self.ctx.get_session().client("ssm")
+
+    def delete(self) -> bool:
+        """Delete parameter."""
+        try:
+            self.client.delete_parameter(Name=self.args.name)
+            LOGGER.info("deleted SSM Parameter %s", self.args.name)
+        except self.client.exceptions.ParameterNotFound:
+            LOGGER.warning("delete parameter skipped; %s not found", self.args.name)
+        return True
+
+    def get(self) -> ParameterTypeDef:
+        """Get parameter."""
+        if self.args.force:  # bypass getting current value
+            return {}
+        try:
+            return self.client.get_parameter(
+                Name=self.args.name, WithDecryption=True
+            ).get("Parameter", {})
+        except self.client.exceptions.ParameterNotFound:
+            LOGGER.info("parameter %s does not exist", self.args.name)
+            return {}
+
+    def get_current_tags(self) -> List[TagTypeDef]:
+        """Get Tags currently applied to Parameter."""
+        try:
+            return self.client.list_tags_for_resource(
+                ResourceId=self.args.name, ResourceType="Parameter"
+            ).get("TagList", [])
+        except (
+            self.client.exceptions.InvalidResourceId,
+            self.client.exceptions.ParameterNotFound,
+        ):
+            return []
+
+    def post_deploy(self) -> PutParameterResultTypeDef:
+        """Run during the *post_deploy* stage."""
+        result = self.put()
+        self.update_tags()
+        return result
+
+    def post_destroy(self) -> bool:
+        """Run during the *post_destroy* stage."""
+        return self.delete()
+
+    def pre_deploy(self) -> PutParameterResultTypeDef:
+        """Run during the *pre_deploy* stage."""
+        result = self.put()
+        self.update_tags()
+        return result
+
+    def pre_destroy(self) -> bool:
+        """Run during the *pre_destroy* stage."""
+        return self.delete()
+
+    def put(self) -> PutParameterResultTypeDef:
+        """Put parameter."""
+        if not self.args.value:
+            LOGGER.warning(
+                "skipped putting SSM Parameter; value provided for %s is falsy",
+                self.args.name,
+            )
+            return {"Tier": self.args.tier, "Version": 0}
+        current_param = self.get()
+        if current_param.get("Value") != self.args.value:
+            result: PutParameterResultTypeDef = self.client.put_parameter(
+                **self.args.dict(
+                    by_alias=True, exclude_none=True, exclude={"force", "tags"}
+                )
+            )
+        else:
+            result = {
+                "Tier": current_param.get("Tier", self.args.tier),
+                "Version": current_param.get("Version", 0),
+            }
+        LOGGER.info("put SSM Parameter %s", self.args.name)
+        return result
+
+    def update_tags(self) -> None:
+        """Update tags."""
+        current_tags = self.get_current_tags()
+        if self.args.tags and current_tags:
+            diff_tag_keys = list(
+                set(i["Key"] for i in current_tags) ^ set(i.key for i in self.args.tags)
+            )
+        elif self.args.tags:
+            diff_tag_keys = []
+        else:
+            diff_tag_keys = [i["Key"] for i in current_tags]
+
+        if diff_tag_keys:
+            diff_tag_keys.sort()
+            self.client.remove_tags_from_resource(
+                ResourceId=self.args.name,
+                ResourceType="Parameter",
+                TagKeys=diff_tag_keys,
+            )
+            LOGGER.debug(
+                "removed tags for parameter %s: %s", self.args.name, diff_tag_keys
+            )
+
+        if self.args.tags:
+            tags_to_add = [
+                cast("TagTypeDef", tag.dict(by_alias=True)) for tag in self.args.tags
+            ]
+            self.client.add_tags_to_resource(
+                ResourceId=self.args.name,
+                ResourceType="Parameter",
+                Tags=tags_to_add,
+            )
+            LOGGER.debug(
+                "added tags to parameter %s: %s",
+                self.args.name,
+                [tag["Key"] for tag in tags_to_add],
+            )
+        LOGGER.info("updated tags for parameter %s", self.args.name)
+
+
+class SecureString(_Parameter):
+    """AWS SSM Parameter Store SecureString Parameter."""
+
+    def __init__(
+        self,
+        context: CfnginContext,
+        *,
+        name: str,
+        **kwargs: Any,
+    ) -> None:
+        """Instantiate class.
+
+        Args:
+            context: CFNgin context object.
+            name: The fully qualified name of the parameter that you want to add to
+                the system.
+
+        """
+        for k in ["Type", "type"]:  # ensure neither of these are set
+            kwargs.pop(k, None)
+        super().__init__(context, name=name, type="SecureString", **kwargs)

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -7,8 +7,10 @@ import os
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, cast
 
+from pydantic import Extra, Field
+
 from ...exceptions import FailedVariableLookup
-from ...utils import load_object_from_string
+from ...utils import BaseModel, load_object_from_string
 from ...variables import Variable, resolve_variables
 from ..blueprints.base import Blueprint
 
@@ -25,6 +27,19 @@ class BlankBlueprint(Blueprint):
 
     def create_template(self) -> None:
         """Create template without raising NotImplementedError."""
+
+
+class TagDataModel(BaseModel):
+    """AWS Resource Tag data model."""
+
+    key: str = Field(..., alias="Key")
+    value: str = Field(..., alias="Value")
+
+    class Config:
+        """Model configuration."""
+
+        allow_population_by_field_name = True
+        extra = Extra.forbid
 
 
 def full_path(path: str) -> str:

--- a/tests/unit/cfngin/hooks/ssm/__init__.py
+++ b/tests/unit/cfngin/hooks/ssm/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/unit/cfngin/hooks/ssm/conftest.py
+++ b/tests/unit/cfngin/hooks/ssm/conftest.py
@@ -1,0 +1,25 @@
+"""Pytest fixtures and plugins."""
+# pylint: disable=redefined-outer-name,unused-argument
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+if TYPE_CHECKING:
+    from botocore.stub import Stubber
+    from mypy_boto3_ssm.client import SSMClient
+
+    from ....factories import MockCFNginContext
+
+
+@pytest.fixture(scope="function")
+def ssm_client(cfngin_context: MockCFNginContext, ssm_stubber: Stubber) -> SSMClient:
+    """Create SSM client."""
+    return cast("SSMClient", cfngin_context.get_session().client("ssm"))
+
+
+@pytest.fixture(scope="function")
+def ssm_stubber(cfngin_context: MockCFNginContext) -> Stubber:
+    """Create SSM stubber."""
+    return cfngin_context.add_stubber("ssm")

--- a/tests/unit/cfngin/hooks/ssm/test_parameter.py
+++ b/tests/unit/cfngin/hooks/ssm/test_parameter.py
@@ -1,0 +1,536 @@
+"""Test runway.cfngin.hooks.ssm.parameter."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+from botocore.exceptions import ClientError
+from pydantic import ValidationError
+
+from runway.cfngin.hooks.ssm.parameter import ArgsDataModel, SecureString
+from runway.cfngin.hooks.ssm.parameter import _Parameter as Parameter
+from runway.cfngin.hooks.utils import TagDataModel
+
+if TYPE_CHECKING:
+    from botocore.stub import Stubber
+    from mypy_boto3_ssm.client import SSMClient
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+    from runway.context import CfnginContext
+
+MODULE = "runway.cfngin.hooks.ssm.parameter"
+
+
+class TestArgsDataModel:
+    """Test ArgsDataModel."""
+
+    def test_field_defaults(self) -> None:
+        """Test field values."""
+        obj = ArgsDataModel(name="test", type="String")
+        assert not obj.allowed_pattern
+        assert not obj.data_type
+        assert not obj.description
+        assert obj.force is False
+        assert not obj.key_id
+        assert obj.name == "test"
+        assert obj.overwrite is True
+        assert not obj.policies
+        assert not obj.tags
+        assert obj.tier == "Standard"
+        assert obj.type == "String"
+        assert not obj.value
+
+    def test_name_required(self) -> None:
+        """Test name."""
+        with pytest.raises(ValidationError, match="Name\n  field required"):
+            ArgsDataModel(type="String")
+
+    def test_policies_raise_type_error(self) -> None:
+        """Test policies."""
+        with pytest.raises(ValidationError, match="Policies"):
+            assert not ArgsDataModel(name="test", policies=True, type="String")
+
+    def test_policies_json(self) -> None:
+        """Test policies."""
+        data = [
+            {
+                "Type": "Expiration",
+                "Version": "1.0",
+                "Attributes": {"Timestamp": "2018-12-02T21:34:33.000Z"},
+            }
+        ]
+        assert ArgsDataModel(
+            name="test", policies=data, type="String"
+        ).policies == json.dumps(data)
+
+    def test_policies_string(self) -> None:
+        """Test policies."""
+        data = json.dumps(
+            [
+                {
+                    "Type": "Expiration",
+                    "Version": "1.0",
+                    "Attributes": {"Timestamp": "2018-12-02T21:34:33.000Z"},
+                }
+            ]
+        )
+        assert ArgsDataModel(name="test", policies=data, type="String").policies == data
+
+    def test_tags_dict(self) -> None:
+        """Test tags."""
+        assert ArgsDataModel(
+            name="test", tags={"tag-key": "tag-value"}, type="String"
+        ).tags == [TagDataModel(Key="tag-key", Value="tag-value")]
+
+    def test_tags_raise_type_error(self) -> None:
+        """Test tags."""
+        with pytest.raises(ValidationError, match="Tags"):
+            assert not ArgsDataModel(name="test", tags="", type="String")
+
+    def test_tier_invalid(self) -> None:
+        """Test tier."""
+        with pytest.raises(ValidationError, match="Tier\n  unexpected value"):
+            ArgsDataModel(name="test", tier="invalid", type="String")
+
+    def test_type_invalid(self) -> None:
+        """Test name."""
+        with pytest.raises(ValidationError, match="Type\n  unexpected value"):
+            ArgsDataModel(name="test", type="invalid")
+
+    def test_type_required(self) -> None:
+        """Test name."""
+        with pytest.raises(ValidationError, match="Type\n  field required"):
+            ArgsDataModel(name="test")
+
+
+class TestParameter:
+    """Test Parameter."""
+
+    def test___init__(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture
+    ) -> None:
+        """Test __init__."""
+        args = mocker.patch(f"{MODULE}.ArgsDataModel")
+        args.parse_obj.return_value = args
+        data = {"key": "val"}
+        obj = Parameter(cfngin_context, name="test", type="String", **data)
+        assert obj.args == args
+        assert obj.ctx == cfngin_context
+        args.parse_obj.assert_called_once_with(
+            {"name": "test", "type": "String", **data}
+        )
+
+    def test_client(
+        self,
+        cfngin_context: CfnginContext,
+        mocker: MockerFixture,
+        ssm_client: SSMClient,
+    ) -> None:
+        """Test client."""
+        mocker.patch(f"{MODULE}.ArgsDataModel")
+        assert (
+            Parameter(cfngin_context, name="test", type="String").client == ssm_client
+        )
+
+    def test_delete(
+        self,
+        caplog: LogCaptureFixture,
+        cfngin_context: CfnginContext,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test delete."""
+        caplog.set_level(logging.INFO, logger=MODULE)
+        ssm_stubber.add_response("delete_parameter", {}, {"Name": "test"})
+        with ssm_stubber:
+            assert Parameter(cfngin_context, name="test", type="String").delete()
+        ssm_stubber.assert_no_pending_responses()
+        assert "deleted SSM Parameter test" in caplog.messages
+
+    def test_delete_handle_parameter_not_found(
+        self,
+        caplog: LogCaptureFixture,
+        cfngin_context: CfnginContext,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test delete."""
+        caplog.set_level(logging.INFO, logger=MODULE)
+        ssm_stubber.add_client_error("delete_parameter", "ParameterNotFound")
+        with ssm_stubber:
+            assert Parameter(cfngin_context, name="test", type="String").delete()
+        ssm_stubber.assert_no_pending_responses()
+        assert "delete parameter skipped; test not found" in caplog.messages
+
+    def test_delete_raise_client_error(
+        self,
+        cfngin_context: CfnginContext,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test delete."""
+        ssm_stubber.add_client_error("delete_parameter")
+        with ssm_stubber, pytest.raises(ClientError):
+            assert not Parameter(cfngin_context, name="test", type="String").delete()
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_get(
+        self,
+        cfngin_context: CfnginContext,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test get."""
+        data = {
+            "Name": "test",
+            "Type": "String",
+            "Value": "test",
+            "Version": 1,
+        }
+        ssm_stubber.add_response(
+            "get_parameter",
+            {"Parameter": data},
+            {"Name": "test", "WithDecryption": True},
+        )
+        with ssm_stubber:
+            assert Parameter(cfngin_context, name="test", type="String").get() == data
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_get_force(
+        self,
+        cfngin_context: CfnginContext,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test get."""
+        ssm_stubber.add_response(
+            "get_parameter",
+            {
+                "Parameter": {
+                    "Name": "test",
+                    "Type": "String",
+                    "Value": "test",
+                    "Version": 1,
+                }
+            },
+        )
+        with ssm_stubber:
+            assert (
+                Parameter(cfngin_context, force=True, name="test", type="String").get()
+                == {}
+            )
+
+    def test_get_handle_parameter_not_found(
+        self,
+        caplog: LogCaptureFixture,
+        cfngin_context: CfnginContext,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test get."""
+        caplog.set_level(logging.INFO, logger=MODULE)
+        ssm_stubber.add_client_error("get_parameter", "ParameterNotFound")
+        with ssm_stubber:
+            assert Parameter(cfngin_context, name="test", type="String").get() == {}
+        ssm_stubber.assert_no_pending_responses()
+        assert "parameter test does not exist" in caplog.messages
+
+    def test_get_raise_client_error(
+        self,
+        cfngin_context: CfnginContext,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test get."""
+        ssm_stubber.add_client_error("get_parameter")
+        with ssm_stubber, pytest.raises(ClientError):
+            assert not Parameter(cfngin_context, name="test", type="String").get()
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_get_current_tags(
+        self, cfngin_context: CfnginContext, ssm_stubber: Stubber
+    ) -> None:
+        """Test get_current_tags."""
+        data = [{"Key": "test-key", "Value": "test-val"}]
+        ssm_stubber.add_response(
+            "list_tags_for_resource",
+            {"TagList": data},
+            {"ResourceId": "test", "ResourceType": "Parameter"},
+        )
+        with ssm_stubber:
+            assert (
+                Parameter(cfngin_context, name="test", type="String").get_current_tags()
+                == data
+            )
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_get_current_tags_empty(
+        self, cfngin_context: CfnginContext, ssm_stubber: Stubber
+    ) -> None:
+        """Test get_current_tags."""
+        ssm_stubber.add_response("list_tags_for_resource", {})
+        with ssm_stubber:
+            assert (
+                Parameter(cfngin_context, name="test", type="String").get_current_tags()
+                == []
+            )
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_get_current_tags_handle_invalid_resource_id(
+        self, cfngin_context: CfnginContext, ssm_stubber: Stubber
+    ) -> None:
+        """Test get_current_tags."""
+        ssm_stubber.add_client_error("list_tags_for_resource", "InvalidResourceId")
+        with ssm_stubber:
+            assert (
+                Parameter(cfngin_context, name="test", type="String").get_current_tags()
+                == []
+            )
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_get_current_tags_handle_parameter_not_found(
+        self, cfngin_context: CfnginContext, ssm_stubber: Stubber
+    ) -> None:
+        """Test get_current_tags."""
+        ssm_stubber.add_client_error("list_tags_for_resource", "ParameterNotFound")
+        with ssm_stubber:
+            assert (
+                Parameter(cfngin_context, name="test", type="String").get_current_tags()
+                == []
+            )
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_get_current_tags_raise_client_error(
+        self, cfngin_context: CfnginContext, ssm_stubber: Stubber
+    ) -> None:
+        """Test get_current_tags."""
+        ssm_stubber.add_client_error("list_tags_for_resource")
+        with ssm_stubber, pytest.raises(ClientError):
+            assert Parameter(
+                cfngin_context, name="test", type="String"
+            ).get_current_tags()
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_post_deploy(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture
+    ) -> None:
+        """Test post_deploy."""
+        mock_put = mocker.patch.object(Parameter, "put", return_value="success")
+        mock_update_tags = mocker.patch.object(
+            Parameter, "update_tags", return_value=None
+        )
+        assert (
+            Parameter(cfngin_context, name="test", type="String").post_deploy()
+            == mock_put.return_value
+        )
+        mock_put.assert_called_once_with()
+        mock_update_tags.assert_called_once_with()
+
+    def test_post_destroy(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture
+    ) -> None:
+        """Test post_destroy."""
+        mock_delete = mocker.patch.object(Parameter, "delete", return_value="success")
+        assert (
+            Parameter(cfngin_context, name="test", type="String").post_destroy()
+            == mock_delete.return_value
+        )
+        mock_delete.assert_called_once_with()
+
+    def test_pre_deploy(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture
+    ) -> None:
+        """Test pre_deploy."""
+        mock_put = mocker.patch.object(Parameter, "put", return_value="success")
+        mock_update_tags = mocker.patch.object(
+            Parameter, "update_tags", return_value=None
+        )
+        assert (
+            Parameter(cfngin_context, name="test", type="String").pre_deploy()
+            == mock_put.return_value
+        )
+        mock_put.assert_called_once_with()
+        mock_update_tags.assert_called_once_with()
+
+    def test_pre_destroy(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture
+    ) -> None:
+        """Test pre_destroy."""
+        mock_delete = mocker.patch.object(Parameter, "delete", return_value="success")
+        assert (
+            Parameter(cfngin_context, name="test", type="String").pre_destroy()
+            == mock_delete.return_value
+        )
+        mock_delete.assert_called_once_with()
+
+    def test_put(
+        self,
+        caplog: LogCaptureFixture,
+        cfngin_context: CfnginContext,
+        mocker: MockerFixture,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test put."""
+        caplog.set_level(logging.INFO, MODULE)
+        expected = {"Tier": "Standard", "Version": 1}
+        mock_get = mocker.patch.object(Parameter, "get", return_value={})
+        ssm_stubber.add_response(
+            "put_parameter",
+            expected,
+            {
+                "Name": "test",
+                "Overwrite": True,
+                "Tier": "Standard",
+                "Type": "String",
+                "Value": "foo",
+            },
+        )
+        with ssm_stubber:
+            assert (
+                Parameter(
+                    cfngin_context,
+                    name="test",
+                    tags=[{"Key": "k", "Value": "v"}],
+                    type="String",
+                    value="foo",
+                ).put()
+                == expected
+            )
+        mock_get.assert_called_once_with()
+        ssm_stubber.assert_no_pending_responses()
+        assert "put SSM Parameter test" in caplog.messages
+
+    def test_put_no_value(
+        self,
+        caplog: LogCaptureFixture,
+        cfngin_context: CfnginContext,
+    ) -> None:
+        """Test put."""
+        caplog.set_level(logging.WARNING, MODULE)
+        assert Parameter(
+            cfngin_context, name="test", type="String", value=None
+        ).put() == {"Tier": "Standard", "Version": 0}
+        assert (
+            "skipped putting SSM Parameter; value provided for test is falsy"
+            in caplog.messages
+        )
+
+    def test_put_raise_client_error(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture, ssm_stubber: Stubber
+    ) -> None:
+        """Test put."""
+        mocker.patch.object(
+            Parameter,
+            "get",
+            return_value={},
+        )
+        ssm_stubber.add_client_error("put_parameter")
+        with ssm_stubber, pytest.raises(ClientError):
+            assert not Parameter(
+                cfngin_context, name="test", type="String", value="foo"
+            ).put()
+
+    def test_put_same_value(
+        self,
+        cfngin_context: CfnginContext,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test put."""
+        expected = {"Tier": "Advanced", "Version": 10}
+        mock_get = mocker.patch.object(
+            Parameter,
+            "get",
+            return_value={"Value": "foo", **expected},
+        )
+        assert (
+            Parameter(cfngin_context, name="test", type="String", value="foo").put()
+            == expected
+        )
+        mock_get.assert_called_once_with()
+
+    def test_update_tags(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture, ssm_stubber: Stubber
+    ) -> None:
+        """Test update_tags."""
+        current_tags = [
+            {"Key": "current", "Value": "current-value"},
+            {"Key": "retain", "Value": "retain"},
+        ]
+        new_tags = [
+            {"Key": "new", "Value": "new-value"},
+            {"Key": "retain", "Value": "retain"},
+        ]
+        get_current_tags = mocker.patch.object(
+            Parameter, "get_current_tags", return_value=current_tags
+        )
+        ssm_stubber.add_response(
+            "remove_tags_from_resource",
+            {},
+            {
+                "ResourceId": "test",
+                "ResourceType": "Parameter",
+                "TagKeys": ["current", "new"],
+            },
+        )
+        ssm_stubber.add_response(
+            "add_tags_to_resource",
+            {},
+            {"ResourceId": "test", "ResourceType": "Parameter", "Tags": new_tags},
+        )
+        with ssm_stubber:
+            assert not Parameter(
+                cfngin_context, name="test", tags=new_tags, type="String"
+            ).update_tags()
+        get_current_tags.assert_called_once_with()
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_update_tags_add_only(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture, ssm_stubber: Stubber
+    ) -> None:
+        """Test update_tags."""
+        new_tags = [
+            {"Key": "new", "Value": "new-value"},
+            {"Key": "retain", "Value": "retain"},
+        ]
+        mocker.patch.object(Parameter, "get_current_tags", return_value=[])
+        ssm_stubber.add_response(
+            "add_tags_to_resource",
+            {},
+            {"ResourceId": "test", "ResourceType": "Parameter", "Tags": new_tags},
+        )
+        with ssm_stubber:
+            assert not Parameter(
+                cfngin_context, name="test", tags=new_tags, type="String"
+            ).update_tags()
+
+    def test_update_tags_delete_only(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture, ssm_stubber: Stubber
+    ) -> None:
+        """Test update_tags."""
+        current_tags = [
+            {"Key": "current", "Value": "current-value"},
+            {"Key": "retain", "Value": "retain"},
+        ]
+        mocker.patch.object(Parameter, "get_current_tags", return_value=current_tags)
+        ssm_stubber.add_response(
+            "remove_tags_from_resource",
+            {},
+            {
+                "ResourceId": "test",
+                "ResourceType": "Parameter",
+                "TagKeys": ["current", "retain"],
+            },
+        )
+        ssm_stubber.add_client_error("add_tags_to_resource")
+        with ssm_stubber:
+            assert not Parameter(
+                cfngin_context, name="test", type="String"
+            ).update_tags()
+
+
+class TestSecureString:
+    """Test SecureString."""
+
+    def test___init__(self, cfngin_context: CfnginContext) -> None:
+        """Test __init__."""
+        obj = SecureString(cfngin_context, name="test")
+        assert obj.ctx == cfngin_context
+        assert obj.args.name == "test"
+        assert obj.args.type == "SecureString"


### PR DESCRIPTION
# Summary

Add CFNgin hook for creating encrypted SSM Parameters.

# Why This Is Needed

resolves #607

# What Changed

## Added

- added `runway.cfngin.hooks.ssm.parameter.SecureString`
- added `runway.cfngin.hooks.utils.TagDataModel` for parsing/validating tag dicts passed into hook args
