### PR TITLE
lookups: add `random.string` lookup

### DIFF
--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -261,6 +261,77 @@ Also, unlike the output_ lookup type, xref_ doesn't impact stack requirements.
 ----
 
 
+*************
+random.string
+*************
+
+Generate a random string of the given length.
+The ``<query>`` of this lookup is the desired length of the random string.
+
+.. rubric:: Arguments
+.. data:: digits
+  :type: bool
+  :value: True
+  :noindex:
+
+  When generating the random string, the string may contain digits (``[0-9]``).
+  If the string can contain digits, it will always contain at least one.
+
+.. data:: lowercase
+  :type: bool
+  :value: True
+  :noindex:
+
+  When generating the random string, the string may contain lowercase letters (``[a-z]``).
+  If the string can contain lowercase letters, it will always contain at least one.
+
+.. data:: punctuation
+  :type: bool
+  :value: False
+  :noindex:
+
+  When generating the random string, the string may contain ASCII punctuation (``[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]``).
+  If the string can contain ASCII punctuation, it will always contain at least one.
+
+.. data:: uppercase
+  :type: bool
+  :value: True
+  :noindex:
+
+  When generating the random string, the string may contain uppercase letters (``[A-Z]``).
+  If the string can contain uppercase letters, it will always contain at least one.
+
+
+This Lookup supports all :ref:`Common Lookup Arguments` but, the following have limited or no effect:
+
+- default
+- get
+- indent
+- load
+- region
+
+.. rubric:: Example
+
+This example shows the use of this lookup to create an SSM parameter that will retain value generated during the first deployment.
+Even through subsequent deployments generate a new value that is passed to the hook, the hook does not overwrite the value of an existing parameter.
+
+.. code-block:: yaml
+
+  pre_deploy: &hooks
+    - path: runway.cfngin.hooks.ssm.parameter.SecureString
+      args:
+        name: /${namespace}/password
+        overwrite: false
+        value: ${random.string 12::punctuation=true}
+
+  post_destroy: *hooks
+
+.. versionadded:: 2.2.0
+
+
+----
+
+
 .. _`rxref lookup`:
 
 *****

--- a/docs/source/lookups.rst
+++ b/docs/source/lookups.rst
@@ -319,6 +319,74 @@ This Lookup supports all :ref:`Common Lookup Arguments`.
 ----
 
 
+.. _random.string lookup:
+
+*************
+random.string
+*************
+
+Generate a random string of the given length.
+The ``<query>`` of this lookup is the desired length of the random string.
+
+.. rubric:: Arguments
+.. data:: digits
+  :type: bool
+  :value: True
+  :noindex:
+
+  When generating the random string, the string may contain digits (``[0-9]``).
+  If the string can contain digits, it will always contain at least one.
+
+.. data:: lowercase
+  :type: bool
+  :value: True
+  :noindex:
+
+  When generating the random string, the string may contain lowercase letters (``[a-z]``).
+  If the string can contain lowercase letters, it will always contain at least one.
+
+.. data:: punctuation
+  :type: bool
+  :value: False
+  :noindex:
+
+  When generating the random string, the string may contain ASCII punctuation (``[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]``).
+  If the string can contain ASCII punctuation, it will always contain at least one.
+
+.. data:: uppercase
+  :type: bool
+  :value: True
+  :noindex:
+
+  When generating the random string, the string may contain uppercase letters (``[A-Z]``).
+  If the string can contain uppercase letters, it will always contain at least one.
+
+
+This Lookup supports all :ref:`Common Lookup Arguments` but, the following have limited or no effect:
+
+- default
+- get
+- indent
+- load
+- region
+
+.. rubric:: Example
+.. code-block:: yaml
+
+  deployment:
+    - modules:
+      - path: sampleapp.cfn
+        parameters:
+          secret_value: ${random.string 32::punctuation=true}
+      env_vars:
+        SOME_VARIABLE: ${random.string 8::digits=false}
+
+.. versionadded:: 2.2.0
+
+
+----
+
+
 .. _var lookup:
 .. _var-lookup:
 

--- a/runway/cfngin/lookups/registry.py
+++ b/runway/cfngin/lookups/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, Type, Union, cast
 
-from ...lookups.handlers import cfn, ecr, ssm
+from ...lookups.handlers import cfn, ecr, random_string, ssm
 from ...lookups.handlers.base import LookupHandler
 from ...utils import DOC_SITE, load_object_from_string
 from .handlers import ami, default, dynamodb, envvar
@@ -75,6 +75,7 @@ register_lookup_handler(file_handler.TYPE_NAME, file_handler.FileLookup)
 register_lookup_handler(hook_data.TYPE_NAME, hook_data.HookDataLookup)
 register_lookup_handler(kms.TYPE_NAME, kms.KmsLookup)
 register_lookup_handler(output.TYPE_NAME, output.OutputLookup)
+register_lookup_handler(random_string.TYPE_NAME, random_string.RandomStringLookup)
 register_lookup_handler(rxref.TYPE_NAME, rxref.RxrefLookup)
 register_lookup_handler(split.TYPE_NAME, split.SplitLookup)
 register_lookup_handler(ssm.TYPE_NAME, ssm.SsmLookup)

--- a/runway/lookups/handlers/__init__.py
+++ b/runway/lookups/handlers/__init__.py
@@ -1,4 +1,4 @@
 """Import classes."""
-from . import cfn, ecr, env, ssm, var
+from . import cfn, ecr, env, random_string, ssm, var
 
-__all__ = ["cfn", "ecr", "env", "ssm", "var"]
+__all__ = ["cfn", "ecr", "env", "random_string", "ssm", "var"]

--- a/runway/lookups/handlers/random_string.py
+++ b/runway/lookups/handlers/random_string.py
@@ -1,0 +1,120 @@
+"""Generate a random string."""
+# pyright: reportIncompatibleMethodOverride=none
+from __future__ import annotations
+
+import logging
+import secrets
+import string
+from typing import TYPE_CHECKING, Any, Callable, List, Sequence, Union
+
+from ...utils import BaseModel
+from .base import LookupHandler
+
+if TYPE_CHECKING:
+    from ...context import CfnginContext, RunwayContext
+
+TYPE_NAME = "random.string"
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ArgsDataModel(BaseModel):
+    """Arguments data model."""
+
+    digits: bool = True
+    lowercase: bool = True
+    punctuation: bool = False
+    uppercase: bool = True
+
+
+class RandomStringLookup(LookupHandler):
+    """Random string lookup."""
+
+    @staticmethod
+    def calculate_char_set(args: ArgsDataModel) -> str:
+        """Calculate character set from the provided arguments."""
+        char_set = ""
+        if args.digits:
+            char_set += string.digits
+        if args.lowercase:
+            char_set += string.ascii_lowercase
+        if args.punctuation:
+            char_set += string.punctuation
+        if args.uppercase:
+            char_set += string.ascii_uppercase
+        LOGGER.debug("character set: %s", char_set)
+        return char_set
+
+    @staticmethod
+    def generate_random_string(char_set: Sequence[str], length: int) -> str:
+        """Generate a random string of a set length from a set of characters."""
+        return "".join(secrets.choice(char_set) for _ in range(length))
+
+    @staticmethod
+    def has_digit(value: str) -> bool:
+        """Check if value contains a digit."""
+        return any(v.isdigit() for v in value)
+
+    @staticmethod
+    def has_lowercase(value: str) -> bool:
+        """Check if value contains lowercase."""
+        return any(v.islower() for v in value)
+
+    @staticmethod
+    def has_punctuation(value: str) -> bool:
+        """Check if value contains uppercase."""
+        return any(v in string.punctuation for v in value)
+
+    @staticmethod
+    def has_uppercase(value: str) -> bool:
+        """Check if value contains uppercase."""
+        return any(v.isupper() for v in value)
+
+    @classmethod
+    def ensure_has_one_of(cls, args: ArgsDataModel, value: str) -> bool:
+        """Ensure value has at least one of each required character.
+
+        Args:
+            args: Hook args.
+            value: Value to check.
+
+        """
+        checks: List[Callable[[str], bool]] = []
+        if args.digits:
+            checks.append(cls.has_digit)
+        if args.lowercase:
+            checks.append(cls.has_lowercase)
+        if args.punctuation:
+            checks.append(cls.has_punctuation)
+        if args.uppercase:
+            checks.append(cls.has_uppercase)
+        return sum(c(value) for c in checks) == len(checks)
+
+    @classmethod
+    def handle(  # pylint: disable=arguments-differ
+        cls,
+        value: str,
+        context: Union[CfnginContext, RunwayContext],
+        *__args: Any,
+        **__kwargs: Any,
+    ) -> Any:
+        """Generate a random string.
+
+        Args:
+            value: The value passed to the Lookup.
+            context: The current context object.
+
+        Raises:
+            ValueError: Unable to find a value for the provided query and
+                a default value was not provided.
+
+        """
+        raw_length, raw_args = cls.parse(value)
+        length = int(raw_length)
+        args = ArgsDataModel.parse_obj(raw_args)
+        char_set = cls.calculate_char_set(args)
+        while True:
+            result = cls.generate_random_string(char_set, length)
+            if cls.ensure_has_one_of(args, result):
+                break
+        return cls.format_results(result, **raw_args)

--- a/runway/lookups/registry.py
+++ b/runway/lookups/registry.py
@@ -5,7 +5,7 @@ import logging
 from typing import Dict, Type, Union, cast
 
 from ..utils import load_object_from_string
-from .handlers import cfn, ecr, env, ssm, var
+from .handlers import cfn, ecr, env, random_string, ssm, var
 from .handlers.base import LookupHandler
 
 RUNWAY_LOOKUP_HANDLERS: Dict[str, Type[LookupHandler]] = {}
@@ -57,5 +57,6 @@ def unregister_lookup_handler(lookup_type: str) -> None:
 register_lookup_handler(cfn.TYPE_NAME, cfn.CfnLookup)
 register_lookup_handler(ecr.TYPE_NAME, ecr.EcrLookup)
 register_lookup_handler(env.TYPE_NAME, env.EnvLookup)
+register_lookup_handler(random_string.TYPE_NAME, random_string.RandomStringLookup)
 register_lookup_handler(ssm.TYPE_NAME, ssm.SsmLookup)
 register_lookup_handler(var.TYPE_NAME, var.VarLookup)

--- a/tests/unit/cfngin/lookups/test_registry.py
+++ b/tests/unit/cfngin/lookups/test_registry.py
@@ -32,6 +32,7 @@ def test_autoloaded_lookup_handlers(mocker: MockerFixture) -> None:
         "hook_data",
         "kms",
         "output",
+        "random.string",
         "rxref",
         "split",
         "ssm",

--- a/tests/unit/lookups/handlers/test_random_string.py
+++ b/tests/unit/lookups/handlers/test_random_string.py
@@ -1,0 +1,224 @@
+"""Test runway.lookups.handlers.random_string."""
+# pylint: disable=no-self-use
+from __future__ import annotations
+
+import string
+from typing import TYPE_CHECKING
+
+import pytest
+from mock import Mock
+
+from runway.lookups.handlers.random_string import ArgsDataModel, RandomStringLookup
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+MODULE = "runway.lookups.handlers.random_string"
+
+
+class TestArgsDataModel:
+    """Test ArgsDataModel."""
+
+    def test_field_defaults(self) -> None:
+        """Test field default values."""
+        obj = ArgsDataModel()
+        assert obj.digits
+        assert obj.lowercase
+        assert not obj.punctuation
+        assert obj.uppercase
+
+
+class TestRandomStringLookup:
+    """Test RandomStringLookup."""
+
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            (
+                {
+                    "digits": False,
+                    "lowercase": False,
+                    "punctuation": False,
+                    "uppercase": False,
+                },
+                "",
+            ),
+            (
+                {
+                    "digits": True,
+                    "lowercase": False,
+                    "punctuation": False,
+                    "uppercase": False,
+                },
+                string.digits,
+            ),
+            (
+                {
+                    "digits": True,
+                    "lowercase": True,
+                    "punctuation": False,
+                    "uppercase": False,
+                },
+                string.digits + string.ascii_lowercase,
+            ),
+            (
+                {
+                    "digits": True,
+                    "lowercase": True,
+                    "punctuation": True,
+                    "uppercase": False,
+                },
+                string.digits + string.ascii_lowercase + string.punctuation,
+            ),
+            (
+                {
+                    "digits": True,
+                    "lowercase": True,
+                    "punctuation": True,
+                    "uppercase": True,
+                },
+                string.digits
+                + string.ascii_lowercase
+                + string.punctuation
+                + string.ascii_uppercase,
+            ),
+            (
+                {
+                    "digits": False,
+                    "lowercase": True,
+                    "punctuation": True,
+                    "uppercase": True,
+                },
+                string.ascii_lowercase + string.punctuation + string.ascii_uppercase,
+            ),
+        ],
+    )
+    def test_calculate_char_set(self, args: object, expected: str) -> None:
+        """Test calculate_char_set."""
+        assert (
+            RandomStringLookup.calculate_char_set(ArgsDataModel.parse_obj(args))
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        "args, value, expected",
+        [
+            ({}, "12ab?!", False),
+            ({"uppercase": False}, "12ab?!", True),
+            ({}, "Abc123", True),
+            ({}, "Abc", False),
+            ({"digits": False}, "Abc", True),
+            ({"punctuation": True}, "Abc123", False),
+            ({"punctuation": True}, "12ab?!", False),
+            ({"punctuation": True, "uppercase": False}, "12ab?!", True),
+            ({"punctuation": True}, "12Ab?!", True),
+            (
+                {
+                    "digits": False,
+                    "lowercase": False,
+                    "punctuation": False,
+                    "uppercase": False,
+                },
+                "",
+                True,
+            ),
+        ],
+    )
+    def test_ensure_has_one_of(self, args: object, expected: bool, value: str) -> None:
+        """Test ensure_has_one_of."""
+        assert (
+            RandomStringLookup.ensure_has_one_of(ArgsDataModel.parse_obj(args), value)
+            is expected
+        )
+
+    @pytest.mark.parametrize("length", [1, 3, 5, 7, 8, 9])
+    def test_generate_random_string(self, length: int, mocker: MockerFixture) -> None:
+        """Test generate_random_string."""
+        char_set = "0123456789"
+        choice = Mock(side_effect=list(char_set))
+        mocker.patch(f"{MODULE}.secrets", choice=choice)
+        assert (
+            RandomStringLookup.generate_random_string(char_set, length)
+            == char_set[:length]
+        )
+        assert choice.call_count == length
+        choice.assert_called_with(char_set)
+
+    def test_handle(self, mocker: MockerFixture) -> None:
+        """Test handle."""
+        args = ArgsDataModel()
+        calculate_char_set = mocker.patch.object(
+            RandomStringLookup, "calculate_char_set", return_value="char_set"
+        )
+        ensure_has_one_of = mocker.patch.object(
+            RandomStringLookup, "ensure_has_one_of", return_value=True
+        )
+        format_results = mocker.patch.object(
+            RandomStringLookup, "format_results", return_value="success"
+        )
+        generate_random_string = mocker.patch.object(
+            RandomStringLookup, "generate_random_string", return_value="random string"
+        )
+        assert RandomStringLookup.handle("12", Mock()) == format_results.return_value
+        calculate_char_set.assert_called_once_with(args)
+        generate_random_string.assert_called_once_with(
+            calculate_char_set.return_value, 12
+        )
+        ensure_has_one_of.assert_called_once_with(
+            args, generate_random_string.return_value
+        )
+        format_results.assert_called_once_with(generate_random_string.return_value)
+
+    def test_handle_digit(self, mocker: MockerFixture) -> None:
+        """Test handle digit."""
+        args = ArgsDataModel(lowercase=False, punctuation=False, uppercase=False)
+        calculate_char_set = mocker.patch.object(
+            RandomStringLookup, "calculate_char_set", return_value="char_set"
+        )
+        mocker.patch.object(RandomStringLookup, "ensure_has_one_of", return_value=True)
+        format_results = mocker.patch.object(
+            RandomStringLookup, "format_results", return_value="success"
+        )
+        generate_random_string = mocker.patch.object(
+            RandomStringLookup, "generate_random_string", return_value="random string"
+        )
+        assert (
+            RandomStringLookup.handle(
+                "12::lowercase=false, punctuation=false, uppercase=false, transform=str",
+                Mock(),
+            )
+            == format_results.return_value
+        )
+        calculate_char_set.assert_called_once_with(args)
+        format_results.assert_called_once_with(
+            generate_random_string.return_value,
+            lowercase="false",
+            punctuation="false",
+            uppercase="false",
+            transform="str",
+        )
+
+    def test_handle_raise_value_error(self) -> None:
+        """Test handle."""
+        with pytest.raises(ValueError):
+            RandomStringLookup.handle("test", Mock())
+
+    @pytest.mark.parametrize("value, expected", [(">!?test", False), ("t3st", True)])
+    def test_has_digit(self, expected: bool, value: str) -> None:
+        """Test has_digit."""
+        assert RandomStringLookup.has_digit(value) is expected
+
+    @pytest.mark.parametrize("value, expected", [("TEST!", False), ("032/>,Ab", True)])
+    def test_has_lowercase(self, expected: bool, value: str) -> None:
+        """Test has_lowercase."""
+        assert RandomStringLookup.has_lowercase(value) is expected
+
+    @pytest.mark.parametrize("value, expected", [("Test", False), ("032/>,Ab", True)])
+    def test_has_punctuation(self, expected: bool, value: str) -> None:
+        """Test has_punctuation."""
+        assert RandomStringLookup.has_punctuation(value) is expected
+
+    @pytest.mark.parametrize("value, expected", [("test?!", False), ("032/>,Ab", True)])
+    def test_has_uppercase(self, expected: bool, value: str) -> None:
+        """Test has_uppercase."""
+        assert RandomStringLookup.has_uppercase(value) is expected


### PR DESCRIPTION
# Summary

Add a lookup capable of generating a random string. This can be useful for generating secrets that will be stored in SSM Parameter Store.

# Why This Is Needed

resolves #608

# What Changed

## Added

- added `runway.lookups.handlers.random_string` which is registered as the `random.string` lookup for CFNgin and Runway
