### PR TITLE
Update incorrect AWS CFN type

### DIFF
--- a/runway/cfngin/blueprints/variables/types.py
+++ b/runway/cfngin/blueprints/variables/types.py
@@ -341,8 +341,8 @@ class EC2SubnetIdList(CFNType):
     """An array of subnet IDs, such as subnet-123a351e, subnet-456b351e."""
 
     parameter_type: ClassVar[
-        Literal["List<AWS::EC2::SecurityGroup::Id>"]
-    ] = "List<AWS::EC2::SecurityGroup::Id>"
+        Literal["List<AWS::EC2::Subnet::Id>"]
+    ] = "List<AWS::EC2::Subnet::Id>"
 
 
 class EC2VolumeIdList(CFNType):


### PR DESCRIPTION
Updated incorrect AWS CFN type for Ec2SubnetIdList class

<!-- You can remove any parts of this template not applicable to your Pull Request.  -->

# Summary

Updated incorrect AWS CFN type for Ec2SubnetIdList class

# Why This Is Needed

Creation of resources with a Ec2SubnetIdList are failing in CFN indicating specified subnet values in the list do not exist as they are not valid SecurityGroups.

# What Changed

Updated incorrect AWS CFN type for Ec2SubnetIdList class.

## Added

N/A

## Changed

N/A

## Fixed

Bug: https://github.com/onicagroup/runway/issues/724

## Removed

N/A

# Screenshots

N/A

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [ x] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [ x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x ] Does your submission pass tests?
- [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ x] Have you successfully ran tests with your changes locally?
