### PR TITLE
cfngin: fix incorrect variable type conversions & add tests

### DIFF
--- a/runway/cfngin/blueprints/variables/types.py
+++ b/runway/cfngin/blueprints/variables/types.py
@@ -231,9 +231,7 @@ class EC2ImageId(CFNType):
 
     """
 
-    parameter_type: ClassVar[
-        Literal["AWS::EC2::AvailabilityZone::Name"]
-    ] = "AWS::EC2::AvailabilityZone::Name"
+    parameter_type: ClassVar[Literal["AWS::EC2::Image::Id"]] = "AWS::EC2::Image::Id"
 
 
 class EC2InstanceId(CFNType):
@@ -264,8 +262,8 @@ class EC2SecurityGroupId(CFNType):
     """A security group ID, such as sg-a123fd85."""
 
     parameter_type: ClassVar[
-        Literal["AWS::EC2::SecurityGroup::GroupName"]
-    ] = "AWS::EC2::SecurityGroup::GroupName"
+        Literal["AWS::EC2::SecurityGroup::Id"]
+    ] = "AWS::EC2::SecurityGroup::Id"
 
 
 class EC2SubnetId(CFNType):
@@ -310,23 +308,25 @@ class EC2ImageIdList(CFNType):
 
     """
 
-    parameter_type: ClassVar[Literal["EC2ImageIdList"]] = "EC2ImageIdList"
+    parameter_type: ClassVar[
+        Literal["List<AWS::EC2::Image::Id>"]
+    ] = "List<AWS::EC2::Image::Id>"
 
 
 class EC2InstanceIdList(CFNType):
     """An array of Amazon EC2 instance IDs, such as i-1e731a32, i-1e731a34."""
 
     parameter_type: ClassVar[
-        Literal["List<AWS::EC2::Image::Id>"]
-    ] = "List<AWS::EC2::Image::Id>"
+        Literal["List<AWS::EC2::Instance::Id>"]
+    ] = "List<AWS::EC2::Instance::Id>"
 
 
 class EC2SecurityGroupGroupNameList(CFNType):
     """An array of EC2-Classic or default VPC security group names."""
 
     parameter_type: ClassVar[
-        Literal["List<AWS::EC2::Instance::Id>"]
-    ] = "List<AWS::EC2::Instance::Id>"
+        Literal["List<AWS::EC2::SecurityGroup::GroupName>"]
+    ] = "List<AWS::EC2::SecurityGroup::GroupName>"
 
 
 class EC2SecurityGroupIdList(CFNType):
@@ -348,13 +348,17 @@ class EC2SubnetIdList(CFNType):
 class EC2VolumeIdList(CFNType):
     """An array of Amazon EBS volume IDs, such as vol-3cdd3f56, vol-4cdd3f56."""
 
-    parameter_type: ClassVar[Literal["EC2VolumeIdList"]] = "EC2VolumeIdList"
+    parameter_type: ClassVar[
+        Literal["List<AWS::EC2::Volume::Id>"]
+    ] = "List<AWS::EC2::Volume::Id>"
 
 
 class EC2VPCIdList(CFNType):
     """An array of VPC IDs, such as vpc-a123baa3, vpc-b456baa3."""
 
-    parameter_type: ClassVar[Literal["EC2VPCIdList"]] = "EC2VPCIdList"
+    parameter_type: ClassVar[
+        Literal["List<AWS::EC2::VPC::Id>"]
+    ] = "List<AWS::EC2::VPC::Id>"
 
 
 class Route53HostedZoneIdList(CFNType):

--- a/runway/cfngin/blueprints/variables/types.py
+++ b/runway/cfngin/blueprints/variables/types.py
@@ -341,8 +341,8 @@ class EC2SubnetIdList(CFNType):
     """An array of subnet IDs, such as subnet-123a351e, subnet-456b351e."""
 
     parameter_type: ClassVar[
-        Literal["List<AWS::EC2::SecurityGroup::Id>"]
-    ] = "List<AWS::EC2::SecurityGroup::Id>"
+        Literal["List<AWS::EC2::Subnet::Id>"]
+    ] = "List<AWS::EC2::Subnet::Id>"
 
 
 class EC2VolumeIdList(CFNType):

--- a/tests/unit/cfngin/blueprints/variables/__init__.py
+++ b/tests/unit/cfngin/blueprints/variables/__init__.py
@@ -1,0 +1,1 @@
+"""Import modules."""

--- a/tests/unit/cfngin/blueprints/variables/test_types.py
+++ b/tests/unit/cfngin/blueprints/variables/test_types.py
@@ -1,0 +1,56 @@
+"""Test runway.cfngin.blueprints.variables.types."""
+from __future__ import annotations
+
+import re
+from typing import Type
+
+import pytest
+
+from runway.cfngin.blueprints.variables.types import CFNType
+
+PATTERN_LIST = r"(AWS|CFN)?(?P<type>.*)List?"
+PATTERN_SUB_AWS_PARAMETER_TYPE = r"(AWS|::)"
+
+AWS_CLASSES = [
+    kls for kls in CFNType.__subclasses__() if not kls.__name__.startswith("CFN")
+]
+CFN_CLASSES = [
+    kls for kls in CFNType.__subclasses__() if kls.__name__.startswith("CFN")
+]
+
+
+def handle_ssm_parameter_value(value: str) -> str:
+    """Handle SSMParameterValue types."""
+    if "SSMParameterValue" in value:
+        return f"SSMParameterValue<{value.replace('SSMParameterValue', '')}>"
+    return value
+
+
+@pytest.mark.parametrize("kls", AWS_CLASSES)
+def test_aws_types(kls: Type[CFNType]) -> None:
+    """Test variable types for parameter types beginning with ``AWS::``.
+
+    This does not test the formatting of the value.
+
+    """
+    if kls.__name__.endswith("List") and "CommaDelimited" not in kls.__name__:
+        match = re.search(PATTERN_LIST, kls.__name__)
+        assert match
+        assert re.sub(
+            PATTERN_SUB_AWS_PARAMETER_TYPE, "", kls.parameter_type
+        ) == handle_ssm_parameter_value(f"List<{match.group('type')}>")
+    else:
+        assert re.sub(
+            PATTERN_SUB_AWS_PARAMETER_TYPE, "", kls.parameter_type
+        ) == handle_ssm_parameter_value(kls.__name__)
+
+
+@pytest.mark.parametrize("kls", CFN_CLASSES)
+def test_cfn_types(kls: Type[CFNType]) -> None:
+    """Test variable types beginning with CFN."""
+    if kls.__name__.endswith("List") and "CommaDelimited" not in kls.__name__:
+        match = re.search(PATTERN_LIST, kls.__name__)
+        assert match
+        assert kls.parameter_type == f"List<{match.group('type')}>"
+    else:
+        assert kls.parameter_type == kls.__name__[3:]


### PR DESCRIPTION
# Why This Is Needed

resolves #724

when looking into the issue and writing tests for it, more incorrect variable types were found.

# What Changed

## Fixed

- fixed issue causing CFNgin variable types to be converted into incorrect CFN parameter types when rendering a blueprint
