### PR TITLE
serverless: refactor deploy_package

### DIFF
--- a/docs/source/serverless/advanced_features.rst
+++ b/docs/source/serverless/advanced_features.rst
@@ -115,7 +115,7 @@ Promoting Builds Through Environments
 Serverless build ``.zips`` can be used between environments by setting the ``promotezip`` module option and providing a bucket name in which to cache the builds.
 
 The first time the Serverless module is deployed using this option, it will build/deploy as normal and cache the artifact on S3.
-On subsequent deploys, Runway will used that cached artifact (finding it by comparing the module source code).
+On subsequent deploys, Runway will use the cached artifact (finding it by comparing the module source code).
 
 This enables a common build account to deploy new builds in a dev/test environment, and then promote that same zip through other environments.
 Any of these environments can be in the same or different AWS accounts.

--- a/runway/type_defs.py
+++ b/runway/type_defs.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
+from typing import TypeVar, Union
 
 from typing_extensions import TypedDict
 
 AnyPath = Union[Path, str]
+AnyPathConstrained = TypeVar("AnyPathConstrained", Path, str)
 
 
 class Boto3CredentialsTypeDef(TypedDict, total=False):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, cast
 
 import pytest
 import yaml
+from mock import MagicMock
 
 from runway.config import RunwayConfig
 from runway.core.components import DeployEnvironment
@@ -98,6 +99,15 @@ def fx_deployments() -> YamlLoaderDeployment:
 def mock_docker_client() -> DockerClient:
     """Create a docker client with mock API backend."""
     return make_fake_client()
+
+
+@pytest.fixture(scope="function")
+def tempfile_temporary_directory(mocker: MockerFixture, tmp_path: Path) -> MagicMock:
+    """Mock tempfile.TemporaryDirectory."""
+    return mocker.patch(
+        "tempfile.TemporaryDirectory",
+        return_value=MagicMock(__enter__=MagicMock(return_value=str(tmp_path))),
+    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
# Summary

Refactor `runway.module.serverless.deploy_package` into a method of the `Serverless` class and add tests.

# Why This Is Needed

resolves #275 

# What Changed

## Added

- added `runway.module.serverless.ServerlessArtifact` class
- added `runway.type_defs.AnyPathConstrained` constrained type variable

## Removed

- removed `runway.module.serverless.deploy_package` function
- removed `runway.module.serverless.get_src_hash` function
- removed `runway.module.serverless.run_sls_print` function
