### PR TITLE
static site: add parameter for CloudFront.DefaultCacheBehavior.Compress

### DIFF
--- a/docs/source/staticsite/configuration.rst
+++ b/docs/source/staticsite/configuration.rst
@@ -212,6 +212,19 @@ Parameters
 
   .. versionadded:: 1.5.0
 
+.. data:: staticsite_compress
+  :type: Optional[bool]
+  :value: True
+  :noindex:
+
+  Whether the CloudFront default cache behavior will automatically compress certain files.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    parameters:
+      staticsite_compress: false
+
 .. data:: staticsite_cookie_settings
   :type: Optional[Dict[str, str]]
   :value: {"idToken": "Path=/; Secure; SameSite=Lax", "accessToken": "Path=/; Secure; SameSite=Lax", "refreshToken": "Path=/; Secure; SameSite=Lax", "nonce": "Path=/; Secure; HttpOnly; Max-Age=1800; SameSite=Lax"}

--- a/runway/blueprints/staticsite/auth_at_edge.py
+++ b/runway/blueprints/staticsite/auth_at_edge.py
@@ -336,7 +336,7 @@ class AuthAtEdge(StaticSite):
             ],
             "DefaultCacheBehavior": cloudfront.DefaultCacheBehavior(
                 AllowedMethods=["GET", "HEAD"],
-                Compress=True,
+                Compress=self.variables.get("Compress", True),
                 DefaultTTL="86400",
                 ForwardedValues=cloudfront.ForwardedValues(QueryString=True),
                 LambdaFunctionAssociations=default_cache_behavior_lambdas,

--- a/runway/blueprints/staticsite/staticsite.py
+++ b/runway/blueprints/staticsite/staticsite.py
@@ -64,6 +64,12 @@ class StaticSite(Blueprint):
             "default": [],
             "description": "(Optional) Domain aliases the " "distribution",
         },
+        "Compress": {
+            "type": bool,
+            "default": True,
+            "description": "Whether the CloudFront default cache behavior will "
+            "automatically compress certain files.",
+        },
         "DisableCloudFront": {
             "type": bool,
             "default": False,
@@ -245,7 +251,7 @@ class StaticSite(Blueprint):
             ],
             "DefaultCacheBehavior": cloudfront.DefaultCacheBehavior(
                 AllowedMethods=["GET", "HEAD"],
-                Compress=False,
+                Compress=self.variables.get("Compress", True),
                 DefaultTTL="86400",
                 ForwardedValues=cloudfront.ForwardedValues(
                     Cookies=cloudfront.Cookies(Forward="none"), QueryString=False

--- a/runway/module/staticsite/handler.py
+++ b/runway/module/staticsite/handler.py
@@ -429,6 +429,7 @@ class StaticSite(RunwayModule):
     def _get_site_stack_variables(self) -> Dict[str, Any]:
         site_stack_variables: Dict[str, Any] = {
             "Aliases": [],
+            "Compresss": self.parameters.compress,
             "DisableCloudFront": self.parameters.cf_disable,
             "RewriteDirectoryIndex": self.parameters.rewrite_directory_index or "",
             "RedirectPathSignIn": "${default staticsite_redirect_path_sign_in::/parseauth}",

--- a/runway/module/staticsite/handler.py
+++ b/runway/module/staticsite/handler.py
@@ -293,7 +293,7 @@ class StaticSite(RunwayModule):
                     "extra_files": [i.dict() for i in self.options.extra_files],
                     "cf_disabled": site_stack_variables["DisableCloudFront"],
                     "distribution_id": f"${{cfn ${{namespace}}-{self.name}.CFDistributionId"
-                    "::default=undefined}}",
+                    "::default=undefined}",
                     "distribution_domain": f"${{cfn ${{namespace}}-{self.name}."
                     "CFDistributionDomainName::default=undefined}}",
                 },

--- a/runway/module/staticsite/parameters/models.py
+++ b/runway/module/staticsite/parameters/models.py
@@ -62,6 +62,8 @@ class RunwayStaticSiteModuleParametersDataModel(ConfigProperty):
             an authorization wall.
         cf_disable: Wether deployment of the CloudFront Distribution should be
             disabled.
+        compress: Whether the CloudFront default cache behavior will automatically
+            compress certain files.
         cookie_settings: The default cookie settings for retrieved tokens and
             generated nonce’s.
         create_user_pool: Wether to create a User Pool for the Auth@Edge
@@ -104,6 +106,7 @@ class RunwayStaticSiteModuleParametersDataModel(ConfigProperty):
     aliases: List[str] = Field([], alias="staticsite_aliases")
     auth_at_edge: bool = Field(False, alias="staticsite_auth_at_edge")
     cf_disable: bool = Field(False, alias="staticsite_cf_disable")
+    compress: bool = Field(True, alias="staticsite_compress")
     cookie_settings: Dict[str, str] = Field(
         {
             "idToken": "Path=/; Secure; SameSite=Lax",


### PR DESCRIPTION
# Summary

Automatic compression for the default cache behavior of the CloudFront distribution created by the static site module is now configurable.

# Why This Is Needed

resolves #752 

# What Changed

## Added

- added `staticsite_compress` parameter for static site modules that allows configuring the value of `AWS::CloudFront::Distribution.DefaultCacheBehavior.Compress` _(default: `true`)_

## Fixed

- fixed an issue causing a `}` to be added to the distribution ID when syncing a static site with an S3 bucket when trying to invalidate the cache
