### PR TITLE
cli: add `tfenv list` command

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -65,6 +65,7 @@
         "codecov",
         "FQDNs",
         "fstring",
-        "Ngin"
+        "Ngin",
+        "rglob"
     ]
 }

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -384,6 +384,24 @@ tfenv install
 ----
 
 
+.. _command-tfenv-list:
+
+**********
+tfenv list
+**********
+
+.. file://./../../runway/_cli/commands/_tfenv/_list.py
+
+.. command-output:: runway tfenv list --help
+
+.. rubric:: Example
+.. code-block:: sh
+
+  $ runway tfenv list
+
+----
+
+
 .. _command-tfenv-run:
 
 *********

--- a/runway/_cli/commands/_tfenv/__init__.py
+++ b/runway/_cli/commands/_tfenv/__init__.py
@@ -6,11 +6,12 @@ import click
 
 from ... import options
 from ._install import install
+from ._list import list_installed
 from ._run import run
 
-__all__ = ["install", "run"]
+__all__ = ["install", "list_installed", "run"]
 
-COMMANDS = [install, run]
+COMMANDS = [install, list_installed, run]
 
 
 @click.group("tfenv", short_help="terraform (install|run)")

--- a/runway/_cli/commands/_tfenv/_list.py
+++ b/runway/_cli/commands/_tfenv/_list.py
@@ -1,0 +1,30 @@
+"""List the versions of Terraform that have been installed by Runway and/or tfenv."""
+# docs: file://./../../../../docs/source/commands.rst
+import logging
+from typing import Any
+
+import click
+
+from ....env_mgr.tfenv import TFEnvManager
+from ... import options
+
+LOGGER = logging.getLogger(__name__.replace("._", "."))
+
+
+@click.command("list", short_help="list installed versions")
+@options.debug
+@options.no_color
+@options.verbose
+def list_installed(**_: Any) -> None:
+    """List the versions of Terraform that have been installed by Runway and/or tfenv."""
+    tfenv = TFEnvManager()
+    versions = list(tfenv.list_installed())
+    versions.sort()
+
+    if versions:
+        LOGGER.info("Terraform versions installed:")
+        click.echo("\n".join(v.name for v in versions))
+    else:
+        LOGGER.warning(
+            "no versions of Terraform installed at path %s", tfenv.versions_dir
+        )

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -16,6 +16,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Generator,
     List,
     NamedTuple,
     Optional,
@@ -387,6 +388,16 @@ class TFEnvManager(EnvManager):
         download_tf_release(str(self.version), self.versions_dir, self.command_suffix)
         LOGGER.verbose("downloaded Terraform %s successfully", self.version)
         return str(self.bin)
+
+    def list_installed(self) -> Generator[Path, None, None]:
+        """List installed versions of Terraform.
+
+        Only lists versions of Terraform that have been installed by an instance
+        if this class or by tfenv.
+
+        """
+        LOGGER.verbose("checking %s for Terraform versions...", self.versions_dir)
+        return self.versions_dir.rglob("*.*.*")
 
     def set_version(self, version: str) -> None:
         """Set current version.

--- a/tests/integration/cli/commands/tfenv/__init__.py
+++ b/tests/integration/cli/commands/tfenv/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/integration/cli/commands/tfenv/test_install.py
+++ b/tests/integration/cli/commands/tfenv/test_install.py
@@ -1,0 +1,57 @@
+"""Test ``runway tfenv`` command."""
+# pylint: disable=unused-argument
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from runway._cli import cli
+
+if TYPE_CHECKING:
+    from pytest import LogCaptureFixture
+
+
+def test_tfenv_install(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    """Test ``runway tfenv install`` reading version from a file.
+
+    For best results, remove any existing installs.
+
+    """
+    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.tfenv")
+    (cd_tmp_path / ".terraform-version").write_text("0.12.0")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "install"])
+    assert result.exit_code == 0
+
+    tf_bin = Path(caplog.messages[-1].replace("terraform path: ", ""))
+    assert tf_bin.exists()
+
+
+def test_tfenv_install_no_version_file(
+    cd_tmp_path: Path, caplog: LogCaptureFixture
+) -> None:
+    """Test ``runway tfenv install`` no version file."""
+    caplog.set_level(logging.ERROR, logger="runway")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "install"])
+    assert result.exit_code == 1
+
+    assert "unable to find a .terraform-version file" in "\n".join(caplog.messages)
+
+
+def test_tfenv_install_version(caplog: LogCaptureFixture) -> None:
+    """Test ``runway tfenv install <version>``.
+
+    For best results, remove any existing installs.
+
+    """
+    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.tfenv")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "install", "0.12.1"])
+    assert result.exit_code == 0
+
+    kb_bin = Path(caplog.messages[-1].replace("terraform path: ", ""))
+    assert kb_bin.exists()

--- a/tests/integration/cli/commands/tfenv/test_list.py
+++ b/tests/integration/cli/commands/tfenv/test_list.py
@@ -1,0 +1,48 @@
+"""Test ``runway tfenv`` command."""
+# pylint: disable=unused-argument
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from runway._cli import cli
+from runway.env_mgr.tfenv import TFEnvManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+
+def test_tfenv_list(
+    caplog: LogCaptureFixture, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Test ``runway tfenv list``."""
+    caplog.set_level(logging.INFO, logger="runway.cli.commands.tfenv")
+    mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+    version_dirs = [tmp_path / "0.13.0", tmp_path / "1.0.0"]
+    for v_dir in version_dirs:
+        v_dir.mkdir()
+    (tmp_path / "something.txt").touch()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "list"])
+    assert result.exit_code == 0
+    assert caplog.messages == ["Terraform versions installed:"]
+    assert result.stdout == "\n".join(
+        ["[runway] Terraform versions installed:", "0.13.0", "1.0.0", ""]
+    )
+
+
+def test_tfenv_list_none(
+    caplog: LogCaptureFixture, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Test ``runway tfenv list`` no versions installed."""
+    caplog.set_level(logging.WARNING, logger="runway.cli.commands.tfenv")
+    mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "list"])
+    assert result.exit_code == 0
+    assert caplog.messages == [f"no versions of Terraform installed at path {tmp_path}"]

--- a/tests/integration/cli/commands/tfenv/test_run.py
+++ b/tests/integration/cli/commands/tfenv/test_run.py
@@ -14,49 +14,6 @@ if TYPE_CHECKING:
     from pytest import CaptureFixture, LogCaptureFixture
 
 
-def test_tfenv_install(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
-    """Test ``runway tfenv install`` reading version from a file.
-
-    For best results, remove any existing installs.
-
-    """
-    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.tfenv")
-    (cd_tmp_path / ".terraform-version").write_text("0.12.0")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["tfenv", "install"])
-    assert result.exit_code == 0
-
-    tf_bin = Path(caplog.messages[-1].replace("terraform path: ", ""))
-    assert tf_bin.exists()
-
-
-def test_tfenv_install_no_version_file(
-    cd_tmp_path: Path, caplog: LogCaptureFixture
-) -> None:
-    """Test ``runway tfenv install`` no version file."""
-    caplog.set_level(logging.ERROR, logger="runway")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["tfenv", "install"])
-    assert result.exit_code == 1
-
-    assert "unable to find a .terraform-version file" in "\n".join(caplog.messages)
-
-
-def test_tfenv_install_version(caplog: LogCaptureFixture) -> None:
-    """Test ``runway tfenv install <version>``.
-
-    For best results, remove any existing installs.
-
-    """
-    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.tfenv")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["tfenv", "install", "0.12.1"])
-    assert result.exit_code == 0
-
-    kb_bin = Path(caplog.messages[-1].replace("terraform path: ", ""))
-    assert kb_bin.exists()
-
-
 def test_tfenv_run_no_version_file(
     cd_tmp_path: Path, caplog: LogCaptureFixture
 ) -> None:

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -288,6 +288,22 @@ class TestTFEnvManager:
         ):
             tfenv.install()
 
+    def test_list_installed(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test list_installed."""
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        version_dirs = [tmp_path / "0.13.0", tmp_path / "1.0.0"]
+        for v_dir in version_dirs:
+            v_dir.mkdir()
+        (tmp_path / "something.txt").touch()
+        result = list(TFEnvManager().list_installed())  # convert generator to list
+        result.sort()  # sort list for comparison
+        assert result == version_dirs
+
+    def test_list_installed_none(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test list_installed."""
+        mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+        assert list(TFEnvManager().list_installed()) == []
+
     @pytest.mark.parametrize(
         "provided, expected",
         [


### PR DESCRIPTION
# Summary

Add `runway tfenv list` command to list all available versions of Terraform that have been installed by Runway or tfenv.

# What Changed

## Added

- added `tfenv list` command
- added `runway.env_mgr.tfenv.TFEnvManager.list_installed()`
