### PR TITLE
cli: add `kbenv list` command

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -65,6 +65,7 @@
         "codecov",
         "FQDNs",
         "fstring",
+        "markexpr",
         "Ngin",
         "rglob"
     ]

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -169,6 +169,25 @@ kbenv install
 ----
 
 
+.. _command-kbenv-list:
+
+**********
+kbenv list
+**********
+
+.. file://./../../runway/_cli/commands/_kbenv/_list.py
+
+.. command-output:: runway kbenv list --help
+
+.. rubric:: Example
+.. code-block:: sh
+
+  $ runway kbenv list
+
+
+----
+
+
 .. _command-kbenv-run:
 
 *********

--- a/runway/_cli/commands/_kbenv/__init__.py
+++ b/runway/_cli/commands/_kbenv/__init__.py
@@ -6,11 +6,12 @@ import click
 
 from ... import options
 from ._install import install
+from ._list import list_installed
 from ._run import run
 
-__all__ = ["install", "run"]
+__all__ = ["install", "list_installed", "run"]
 
-COMMANDS = [install, run]
+COMMANDS = [install, list_installed, run]
 
 
 @click.group("kbenv", short_help="kubectl (install|run)")

--- a/runway/_cli/commands/_kbenv/_list.py
+++ b/runway/_cli/commands/_kbenv/_list.py
@@ -1,0 +1,30 @@
+"""List the versions of kubectl that have been installed by Runway and/or kbenv."""
+# docs: file://./../../../../docs/source/commands.rst
+import logging
+from typing import Any
+
+import click
+
+from ....env_mgr.kbenv import KBEnvManager
+from ... import options
+
+LOGGER = logging.getLogger(__name__.replace("._", "."))
+
+
+@click.command("list", short_help="list installed versions")
+@options.debug
+@options.no_color
+@options.verbose
+def list_installed(**_: Any) -> None:
+    """List the versions of kubectl that have been installed by Runway and/or kbenv."""
+    kbenv = KBEnvManager()
+    versions = list(kbenv.list_installed())
+    versions.sort()
+
+    if versions:
+        LOGGER.info("kubectl versions installed:")
+        click.echo("\n".join(v.name for v in versions))
+    else:
+        LOGGER.warning(
+            "no versions of kubectl installed at path %s", kbenv.versions_dir
+        )

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -8,7 +8,7 @@ import re
 import shutil
 import sys
 import tempfile
-from typing import TYPE_CHECKING, NamedTuple, Optional, cast
+from typing import TYPE_CHECKING, Generator, NamedTuple, Optional, cast
 from urllib.error import URLError
 from urllib.request import urlretrieve
 
@@ -272,6 +272,16 @@ class KBEnvManager(EnvManager):
         LOGGER.verbose("downloaded kubectl %s successfully", version_requested)
         self.current_version = version_requested
         return str(self.bin)
+
+    def list_installed(self) -> Generator[Path, None, None]:
+        """List installed versions of kubectl.
+
+        Only lists versions of kubectl that have been installed by an instance
+        if this class or by kbenv.
+
+        """
+        LOGGER.verbose("checking %s for kubectl versions...", self.versions_dir)
+        return self.versions_dir.rglob("v*.*.*")
 
     def set_version(self, version: str) -> None:
         """Set current version.

--- a/tests/integration/cli/commands/kbenv/__init__.py
+++ b/tests/integration/cli/commands/kbenv/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/integration/cli/commands/kbenv/test_install.py
+++ b/tests/integration/cli/commands/kbenv/test_install.py
@@ -6,13 +6,21 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
 from click.testing import CliRunner
 
 from runway._cli import cli
-from runway.env_mgr.kbenv import KB_VERSION_FILENAME
+from runway.env_mgr.kbenv import KB_VERSION_FILENAME, KBEnvManager
 
 if TYPE_CHECKING:
     from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True, scope="function")
+def patch_versions_dir(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Patch TFEnvManager.versions_dir."""
+    mocker.patch.object(KBEnvManager, "versions_dir", tmp_path)
 
 
 def test_kbenv_install(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:

--- a/tests/integration/cli/commands/kbenv/test_install.py
+++ b/tests/integration/cli/commands/kbenv/test_install.py
@@ -1,0 +1,61 @@
+"""Test ``runway kbenv install`` command."""
+# pylint: disable=unused-argument
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from runway._cli import cli
+from runway.env_mgr.kbenv import KB_VERSION_FILENAME
+
+if TYPE_CHECKING:
+    from pytest import LogCaptureFixture
+
+
+def test_kbenv_install(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    """Test ``runway kbenv install`` reading version from a file.
+
+    For best results, remove any existing installs.
+
+    """
+    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.kbenv")
+    (cd_tmp_path / KB_VERSION_FILENAME).write_text("v1.14.1")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "install"])
+    assert result.exit_code == 0
+
+    kb_bin = Path(caplog.messages[-1].replace("kubectl path: ", ""))
+    assert kb_bin.exists()
+
+
+def test_kbenv_install_no_version_file(
+    cd_tmp_path: Path, caplog: LogCaptureFixture
+) -> None:
+    """Test ``runway kbenv install`` no version file."""
+    caplog.set_level(logging.WARNING, logger="runway")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "install"])
+    assert result.exit_code == 1
+
+    assert (
+        f"kubectl version not specified and {KB_VERSION_FILENAME} file not found"
+        in caplog.messages[0]
+    )
+
+
+def test_kbenv_install_version(caplog: LogCaptureFixture) -> None:
+    """Test ``runway kbenv install <version>``.
+
+    For best results, remove any existing installs.
+
+    """
+    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.kbenv")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "install", "v1.14.0"])
+    assert result.exit_code == 0
+
+    kb_bin = Path(caplog.messages[-1].replace("kubectl path: ", ""))
+    assert kb_bin.exists()

--- a/tests/integration/cli/commands/kbenv/test_list.py
+++ b/tests/integration/cli/commands/kbenv/test_list.py
@@ -1,0 +1,48 @@
+"""Test ``runway kbenv list`` command."""
+# pylint: disable=unused-argument
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from runway._cli import cli
+from runway.env_mgr.kbenv import KBEnvManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+
+def test_kbenv_list(
+    caplog: LogCaptureFixture, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Test ``runway kbenv list``."""
+    caplog.set_level(logging.INFO, logger="runway.cli.commands.kbenv")
+    mocker.patch.object(KBEnvManager, "versions_dir", tmp_path)
+    version_dirs = [tmp_path / "v1.14.0", tmp_path / "v1.21.0"]
+    for v_dir in version_dirs:
+        v_dir.mkdir()
+    (tmp_path / "something.txt").touch()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "list"])
+    assert result.exit_code == 0
+    assert caplog.messages == ["kubectl versions installed:"]
+    assert result.stdout == "\n".join(
+        ["[runway] kubectl versions installed:", "v1.14.0", "v1.21.0", ""]
+    )
+
+
+def test_kbenv_list_none(
+    caplog: LogCaptureFixture, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Test ``runway kbenv list`` no versions installed."""
+    caplog.set_level(logging.WARNING, logger="runway.cli.commands.kbenv")
+    mocker.patch.object(KBEnvManager, "versions_dir", tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "list"])
+    assert result.exit_code == 0
+    assert caplog.messages == [f"no versions of kubectl installed at path {tmp_path}"]

--- a/tests/integration/cli/commands/kbenv/test_run.py
+++ b/tests/integration/cli/commands/kbenv/test_run.py
@@ -1,4 +1,4 @@
-"""Test ``runway kbenv`` command."""
+"""Test ``runway kbenv run`` command."""
 # pylint: disable=unused-argument
 from __future__ import annotations
 
@@ -13,52 +13,6 @@ from runway.env_mgr.kbenv import KB_VERSION_FILENAME
 
 if TYPE_CHECKING:
     from pytest import CaptureFixture, LogCaptureFixture
-
-
-def test_kbenv_install(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:
-    """Test ``runway kbenv install`` reading version from a file.
-
-    For best results, remove any existing installs.
-
-    """
-    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.kbenv")
-    (cd_tmp_path / KB_VERSION_FILENAME).write_text("v1.14.1")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["kbenv", "install"])
-    assert result.exit_code == 0
-
-    kb_bin = Path(caplog.messages[-1].replace("kubectl path: ", ""))
-    assert kb_bin.exists()
-
-
-def test_kbenv_install_no_version_file(
-    cd_tmp_path: Path, caplog: LogCaptureFixture
-) -> None:
-    """Test ``runway kbenv install`` no version file."""
-    caplog.set_level(logging.WARNING, logger="runway")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["kbenv", "install"])
-    assert result.exit_code == 1
-
-    assert (
-        f"kubectl version not specified and {KB_VERSION_FILENAME} file not found"
-        in caplog.messages[0]
-    )
-
-
-def test_kbenv_install_version(caplog: LogCaptureFixture) -> None:
-    """Test ``runway kbenv install <version>``.
-
-    For best results, remove any existing installs.
-
-    """
-    caplog.set_level(logging.DEBUG, logger="runway.cli.commands.kbenv")
-    runner = CliRunner()
-    result = runner.invoke(cli, ["kbenv", "install", "v1.14.0"])
-    assert result.exit_code == 0
-
-    kb_bin = Path(caplog.messages[-1].replace("kubectl path: ", ""))
-    assert kb_bin.exists()
 
 
 def test_kbenv_run_no_version_file(

--- a/tests/integration/cli/commands/kbenv/test_run.py
+++ b/tests/integration/cli/commands/kbenv/test_run.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
@@ -12,6 +11,8 @@ from runway._cli import cli
 from runway.env_mgr.kbenv import KB_VERSION_FILENAME
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest import CaptureFixture, LogCaptureFixture
 
 

--- a/tests/integration/cli/commands/tfenv/test_install.py
+++ b/tests/integration/cli/commands/tfenv/test_install.py
@@ -6,12 +6,21 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
 from click.testing import CliRunner
 
 from runway._cli import cli
+from runway.env_mgr.tfenv import TFEnvManager
 
 if TYPE_CHECKING:
     from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True, scope="function")
+def patch_versions_dir(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Patch TFEnvManager.versions_dir."""
+    mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
 
 
 def test_tfenv_install(cd_tmp_path: Path, caplog: LogCaptureFixture) -> None:

--- a/tests/integration/cli/commands/tfenv/test_run.py
+++ b/tests/integration/cli/commands/tfenv/test_run.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
@@ -11,6 +10,8 @@ from click.testing import CliRunner
 from runway._cli import cli
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest import CaptureFixture, LogCaptureFixture
 
 
@@ -22,7 +23,6 @@ def test_tfenv_run_no_version_file(
     runner = CliRunner()
     result = runner.invoke(cli, ["tfenv", "run", "--", "--help"])
     assert result.exit_code == 1
-
     assert "unable to find a .terraform-version file" in "\n".join(caplog.messages)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,6 +21,8 @@ def pytest_ignore_collect(path: Any, config: Config) -> bool:
     """Determine if this directory should have its tests collected."""
     if config.option.functional:
         return True
+    if config.option.markexpr and "wip" in config.option.markexpr:
+        return False  # collect when looking for markers
     return not (config.option.integration or config.option.integration_only)
 
 

--- a/tests/unit/env_mgr/test_kbenv.py
+++ b/tests/unit/env_mgr/test_kbenv.py
@@ -33,6 +33,22 @@ class TestKBEnvManager:
         version_file.write_text("v1.22.0")
         assert obj.get_version_from_file(version_file) == "v1.22.0"
 
+    def test_list_installed(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test list_installed."""
+        mocker.patch.object(KBEnvManager, "versions_dir", tmp_path)
+        version_dirs = [tmp_path / "v1.14.0", tmp_path / "v1.21.0"]
+        for v_dir in version_dirs:
+            v_dir.mkdir()
+        (tmp_path / "something.txt").touch()
+        result = list(KBEnvManager().list_installed())  # convert generator to list
+        result.sort()  # sort list for comparison
+        assert result == version_dirs
+
+    def test_list_installed_none(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        """Test list_installed."""
+        mocker.patch.object(KBEnvManager, "versions_dir", tmp_path)
+        assert list(KBEnvManager().list_installed()) == []
+
     @pytest.mark.parametrize(
         "provided, expected",
         [


### PR DESCRIPTION
# Summary

Add `runway kbenv list` command to list all available versions of kubectl that have been installed by Runway or kbenv.

# Why This Is Needed

<!-- Explain why this change is needed. Can be omitted if covered in the summary. -->

# What Changed

## Added

- added `kbenv list` command
- added `runway.env_mgr.kbenv.KBEnvManager.list_installed()`
