### PR TITLE
cli: add `tfenv uninstall` command

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -440,6 +440,25 @@ tfenv run
 ----
 
 
+.. _command-tfenv-uninstall:
+
+*********
+tfenv uninstall
+*********
+
+.. file://./../../runway/_cli/commands/_tfenv/_uninstall.py
+
+.. command-output:: runway tfenv uninstall --help
+
+.. rubric:: Example
+.. code-block:: sh
+
+  $ runway tfenv uninstall 1.0.0
+  $ runway tfenv uninstall --all
+
+----
+
+
 .. _command-whichenv:
 
 ********

--- a/runway/_cli/commands/_tfenv/__init__.py
+++ b/runway/_cli/commands/_tfenv/__init__.py
@@ -8,10 +8,11 @@ from ... import options
 from ._install import install
 from ._list import list_installed
 from ._run import run
+from ._uninstall import uninstall
 
-__all__ = ["install", "list_installed", "run"]
+__all__ = ["install", "list_installed", "run", "uninstall"]
 
-COMMANDS = [install, list_installed, run]
+COMMANDS = [install, list_installed, run, uninstall]
 
 
 @click.group("tfenv", short_help="terraform (install|run)")

--- a/runway/_cli/commands/_tfenv/_install.py
+++ b/runway/_cli/commands/_tfenv/_install.py
@@ -1,8 +1,7 @@
 """Install a version of Terraform."""
 # docs: file://./../../../../docs/source/commands.rst
 import logging
-import sys
-from typing import Any
+from typing import Any, Optional
 
 import click
 
@@ -18,7 +17,8 @@ LOGGER = logging.getLogger(__name__.replace("._", "."))
 @options.debug
 @options.no_color
 @options.verbose
-def install(version: str, **_: Any) -> None:
+@click.pass_context
+def install(ctx: click.Context, version: Optional[str] = None, **_: Any) -> None:
     """Install the specified <version> of Terraform (e.g. 0.12.0).
 
     If no version is specified, Runway will attempt to find and read a
@@ -37,7 +37,7 @@ def install(version: str, **_: Any) -> None:
                 "unexpected error encountered when trying to install Terraform",
                 exc_info=True,
             )
-            sys.exit(1)
+            ctx.exit(1)
         else:
             LOGGER.error("unable to find a .terraform-version file")
             LOGGER.error(
@@ -45,4 +45,4 @@ def install(version: str, **_: Any) -> None:
                 "%s/page/terraform/advanced_features.html#version-management",
                 DOC_SITE,
             )
-        sys.exit(1)
+        ctx.exit(1)

--- a/runway/_cli/commands/_tfenv/_uninstall.py
+++ b/runway/_cli/commands/_tfenv/_uninstall.py
@@ -1,0 +1,58 @@
+"""Uninstall Terraform version(s) that were installed by Runway and/or tfenv."""
+# docs: file://./../../../../docs/source/commands.rst
+import logging
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+import click
+
+from ....env_mgr.tfenv import TFEnvManager
+from ... import options
+
+if TYPE_CHECKING:
+    from runway._logging import RunwayLogger
+
+LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
+
+
+@click.command("uninstall", short_help="uninstall terraform")
+@click.argument("version", metavar="[<version>]", default=None, required=False)
+@click.option(
+    "--all",
+    "all_versions",
+    default=False,
+    help="Uninstall all versions of Terraform.",
+    is_flag=True,
+    required=False,
+    show_default=True,
+)
+@options.debug
+@options.no_color
+@options.verbose
+@click.pass_context
+def uninstall(
+    ctx: click.Context,
+    *,
+    version: Optional[str] = None,
+    all_versions: bool = False,
+    **_: Any,
+) -> None:
+    """Uninstall the specified <version> of Terraform (e.g. 0.12.0) or all installed versions.
+
+    If no version is specified, Runway will attempt to find and read a
+    ".terraform-version" file in the current directory.
+
+    """
+    tfenv = TFEnvManager()
+    version = version or (str(tfenv.version) if tfenv.version else None)
+    if version and not all_versions:
+        if not tfenv.uninstall(version):
+            ctx.exit(1)
+        return
+    if all_versions:
+        LOGGER.notice("uninstalling all versions of Terraform...")
+        for v in tfenv.list_installed():
+            tfenv.uninstall(v.name)
+        LOGGER.success("all versions of Terraform have been uninstalled")
+        return
+    LOGGER.error("version not specified")
+    ctx.exit(1)

--- a/runway/env_mgr/__init__.py
+++ b/runway/env_mgr/__init__.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 import logging
 import os
 import platform
+import shutil
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Generator, Optional, cast
 
 from ..compat import cached_property
 
 if TYPE_CHECKING:
     from urllib.error import URLError
 
-LOGGER = logging.getLogger(__name__)
+    from runway._logging import RunwayLogger
+
+LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 
 
 def handle_bin_download_error(exc: URLError, name: str) -> None:
@@ -121,3 +124,37 @@ class EnvManager:
 
         """
         return self.env_dir / "versions"
+
+    @cached_property
+    def version_file(self) -> Optional[Path]:
+        """Find and return a "<bin version file>" file if one is present.
+
+        Returns:
+            Path to the <bin> version file.
+
+        """
+        raise NotImplementedError
+
+    def install(self, version_requested: Optional[str] = None) -> str:
+        """Ensure <bin> is installed."""
+        raise NotImplementedError
+
+    def list_installed(self) -> Generator[Path, None, None]:
+        """List installed versions of <bin>."""
+        raise NotImplementedError
+
+    def uninstall(self, version: str) -> bool:
+        """Uninstall a version of the managed binary."""
+        version_dir = self.versions_dir / version
+        if version_dir.is_dir():
+            LOGGER.notice(
+                "uninstalling %s %s from %s...",
+                self._bin_name,
+                version,
+                self.versions_dir,
+            )
+            shutil.rmtree(version_dir)
+            LOGGER.success("uninstalled %s %s", self._bin_name, version)
+            return True
+        LOGGER.error("%s %s not installed", self._bin_name, version)
+        return False

--- a/runway/env_mgr/__init__.py
+++ b/runway/env_mgr/__init__.py
@@ -144,7 +144,15 @@ class EnvManager:
         raise NotImplementedError
 
     def uninstall(self, version: str) -> bool:
-        """Uninstall a version of the managed binary."""
+        """Uninstall a version of the managed binary.
+
+        Args:
+            version: Version of binary to uninstall.
+
+        Returns:
+            Whether a version of the binary was uninstalled or not.
+
+        """
         version_dir = self.versions_dir / version
         if version_dir.is_dir():
             LOGGER.notice(

--- a/tests/integration/cli/commands/tfenv/test_install.py
+++ b/tests/integration/cli/commands/tfenv/test_install.py
@@ -1,4 +1,4 @@
-"""Test ``runway tfenv`` command."""
+"""Test ``runway tfenv install`` command."""
 # pylint: disable=unused-argument
 from __future__ import annotations
 

--- a/tests/integration/cli/commands/tfenv/test_list.py
+++ b/tests/integration/cli/commands/tfenv/test_list.py
@@ -1,4 +1,4 @@
-"""Test ``runway tfenv`` command."""
+"""Test ``runway tfenv list`` command."""
 # pylint: disable=unused-argument
 from __future__ import annotations
 

--- a/tests/integration/cli/commands/tfenv/test_run.py
+++ b/tests/integration/cli/commands/tfenv/test_run.py
@@ -1,4 +1,4 @@
-"""Test ``runway tfenv`` command."""
+"""Test ``runway tfenv run`` command."""
 # pylint: disable=unused-argument
 from __future__ import annotations
 

--- a/tests/integration/cli/commands/tfenv/test_uninstall.py
+++ b/tests/integration/cli/commands/tfenv/test_uninstall.py
@@ -101,6 +101,13 @@ def test_tfenv_uninstall_no_version(
     assert "version not specified" in caplog.messages
 
 
+def test_tfenv_uninstall_not_installed(cd_tmp_path: Path) -> None:
+    """Test ``runway tfenv uninstall`` not installed."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall", "1.0.0"])
+    assert result.exit_code != 0
+
+
 def test_tfenv_uninstall_version_file(cd_tmp_path: Path) -> None:
     """Test ``runway tfenv uninstall`` version file."""
     version = "1.0.0"

--- a/tests/integration/cli/commands/tfenv/test_uninstall.py
+++ b/tests/integration/cli/commands/tfenv/test_uninstall.py
@@ -1,0 +1,113 @@
+"""Test ``runway tfenv uninstall`` command."""
+# pylint: disable=unused-argument
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from runway._cli import cli
+from runway.env_mgr.tfenv import TF_VERSION_FILENAME, TFEnvManager
+
+if TYPE_CHECKING:
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+LOGGER = "runway.cli.commands.tfenv"
+
+
+@pytest.fixture(autouse=True, scope="function")
+def patch_versions_dir(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Patch TFEnvManager.versions_dir."""
+    mocker.patch.object(TFEnvManager, "versions_dir", tmp_path)
+
+
+def test_tfenv_uninstall(cd_tmp_path: Path) -> None:
+    """Test ``runway tfenv uninstall``."""
+    version = "1.0.0"
+    version_dir = cd_tmp_path / version
+    version_dir.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall", "1.0.0"])
+    assert result.exit_code == 0
+    assert not version_dir.exists()
+
+
+def test_tfenv_uninstall_all(caplog: LogCaptureFixture, cd_tmp_path: Path) -> None:
+    """Test ``runway tfenv uninstall --all``."""
+    caplog.set_level(logging.INFO, logger=LOGGER)
+    version_dirs = [cd_tmp_path / "0.12.0", cd_tmp_path / "1.0.0"]
+    for v in version_dirs:
+        v.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall", "--all"])
+    assert result.exit_code == 0
+    assert "uninstalling all versions of Terraform..." in caplog.messages
+    assert "all versions of Terraform have been uninstalled" in caplog.messages
+    assert all(not v.exists() for v in version_dirs)
+
+
+def test_tfenv_uninstall_all_takes_precedence(
+    caplog: LogCaptureFixture, cd_tmp_path: Path
+) -> None:
+    """Test ``runway tfenv uninstall --all`` takes precedence over arg."""
+    caplog.set_level(logging.INFO, logger=LOGGER)
+    version_dirs = [cd_tmp_path / "0.12.0", cd_tmp_path / "1.0.0"]
+    for v in version_dirs:
+        v.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall", "0.13.0", "--all"])
+    assert result.exit_code == 0
+    assert "uninstalling all versions of Terraform..." in caplog.messages
+    assert "all versions of Terraform have been uninstalled" in caplog.messages
+    assert all(not v.exists() for v in version_dirs)
+
+
+def test_tfenv_uninstall_all_none_installed(
+    caplog: LogCaptureFixture, cd_tmp_path: Path
+) -> None:
+    """Test ``runway tfenv uninstall --all`` none installed."""
+    caplog.set_level(logging.INFO, logger=LOGGER)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall", "--all"])
+    assert result.exit_code == 0
+    assert "uninstalling all versions of Terraform..." in caplog.messages
+    assert "all versions of Terraform have been uninstalled" in caplog.messages
+
+
+def test_tfenv_uninstall_arg_takes_precedence(cd_tmp_path: Path) -> None:
+    """Test ``runway tfenv uninstall`` arg takes precedence over file."""
+    version = "1.0.0"
+    version_dir = cd_tmp_path / version
+    version_dir.mkdir()
+    (cd_tmp_path / TF_VERSION_FILENAME).write_text("0.12.0")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall", "1.0.0"])
+    assert result.exit_code == 0
+    assert not version_dir.exists()
+
+
+def test_tfenv_uninstall_no_version(
+    caplog: LogCaptureFixture, cd_tmp_path: Path
+) -> None:
+    """Test ``runway tfenv uninstall`` no version."""
+    caplog.set_level(logging.ERROR, logger=LOGGER)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall"])
+    assert result.exit_code != 0
+    assert "version not specified" in caplog.messages
+
+
+def test_tfenv_uninstall_version_file(cd_tmp_path: Path) -> None:
+    """Test ``runway tfenv uninstall`` version file."""
+    version = "1.0.0"
+    version_dir = cd_tmp_path / version
+    version_dir.mkdir()
+    (cd_tmp_path / TF_VERSION_FILENAME).write_text(version)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tfenv", "uninstall"])
+    assert result.exit_code == 0
+    assert not version_dir.exists()

--- a/tests/unit/env_mgr/test_env_mgr.py
+++ b/tests/unit/env_mgr/test_env_mgr.py
@@ -3,35 +3,27 @@
 # pyright: basic
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import pytest
 
 from runway.env_mgr import EnvManager
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pytest import MonkeyPatch
+    from pytest import LogCaptureFixture, MonkeyPatch
     from pytest_mock import MockerFixture
 
 
 class TestEnvManager:
     """Test runway.env_mgr.EnvManager."""
 
-    def test_bin(
+    def test___init___darwin(
         self, platform_darwin: None, cd_tmp_path: Path, mocker: MockerFixture
     ) -> None:
-        """Test bin."""
-        home = cd_tmp_path / "home"
-        mocker.patch("runway.env_mgr.Path.home", return_value=home)
-        obj = EnvManager("test-bin", "test-dir")
-        obj.current_version = "1.0.0"
-
-        assert obj.bin == home / ".test-dir" / "versions" / "1.0.0" / "test-bin"
-
-    def test_darwin(
-        self, platform_darwin: None, cd_tmp_path: Path, mocker: MockerFixture
-    ) -> None:
-        """Test init on Darwin platform."""
+        """Test __init__ on Darwin platform."""
         home = cd_tmp_path / "home"
         mocker.patch("runway.env_mgr.Path.home", return_value=home)
         obj = EnvManager("test-bin", "test-dir")
@@ -42,19 +34,14 @@ class TestEnvManager:
         assert obj.env_dir == home / ".test-dir"
         assert obj.versions_dir == home / ".test-dir" / "versions"
 
-    def test_path(self, cd_tmp_path: Path) -> None:
-        """Test how path attribute is set."""
-        assert EnvManager("", "", path=cd_tmp_path).path == cd_tmp_path
-        assert EnvManager("", "").path == cd_tmp_path
-
-    def test_windows(
+    def test___init___windows(
         self,
         platform_windows: None,
         cd_tmp_path: Path,
         mocker: MockerFixture,
         monkeypatch: MonkeyPatch,
     ) -> None:
-        """Test init on Windows platform."""
+        """Test __init__ on Windows platform."""
         home = cd_tmp_path / "home"
         mocker.patch("runway.env_mgr.Path.home", return_value=home)
         monkeypatch.delenv("APPDATA", raising=False)
@@ -68,10 +55,10 @@ class TestEnvManager:
         assert obj.env_dir == expected_env_dir
         assert obj.versions_dir == expected_env_dir / "versions"
 
-    def test_windows_appdata(
+    def test___init___windows_appdata(
         self, platform_windows: None, cd_tmp_path: Path, monkeypatch: MonkeyPatch
     ) -> None:
-        """Test init on Windows platform."""
+        """Test __init__ on Windows platform."""
         monkeypatch.setenv("APPDATA", str(cd_tmp_path / "custom_path"))
         obj = EnvManager("test-bin", "test-dir")
 
@@ -82,3 +69,60 @@ class TestEnvManager:
         assert obj.env_dir_name == "test-dir"
         assert obj.env_dir == expected_env_dir
         assert obj.versions_dir == expected_env_dir / "versions"
+
+    def test_bin(
+        self, platform_darwin: None, cd_tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Test bin."""
+        home = cd_tmp_path / "home"
+        mocker.patch("runway.env_mgr.Path.home", return_value=home)
+        obj = EnvManager("test-bin", "test-dir")
+        obj.current_version = "1.0.0"
+
+        assert obj.bin == home / ".test-dir" / "versions" / "1.0.0" / "test-bin"
+
+    @pytest.mark.parametrize("version", ["1.0.0", None])
+    def test_install(self, version: Optional[str]) -> None:
+        """Test install."""
+        with pytest.raises(NotImplementedError):
+            assert EnvManager("", "").install(version)
+
+    def test_list_installed(self) -> None:
+        """Test list_installed."""
+        with pytest.raises(NotImplementedError):
+            assert EnvManager("", "").list_installed()
+
+    def test_path(self, cd_tmp_path: Path) -> None:
+        """Test how path attribute is set."""
+        assert EnvManager("", "", path=cd_tmp_path).path == cd_tmp_path
+        assert EnvManager("", "").path == cd_tmp_path
+
+    @pytest.mark.parametrize("exists", [False, True])
+    def test_uninstall(
+        self,
+        caplog: LogCaptureFixture,
+        exists: bool,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Test uninstall."""
+        caplog.set_level(logging.INFO, logger="runway.env_mgr")
+        mocker.patch.object(EnvManager, "versions_dir", tmp_path)
+        obj = EnvManager("foo", "")
+        version = "1.0.0"
+        version_dir = tmp_path / version
+
+        if exists:
+            version_dir.mkdir()
+            (version_dir / "foo").touch()
+            assert obj.uninstall(version)
+            assert f"uninstalling foo {version} from {tmp_path}..." in caplog.messages
+            assert f"uninstalled foo {version}" in caplog.messages
+        else:
+            assert not obj.uninstall(version)
+            assert f"foo {version} not installed"
+
+    def test_version_file(self) -> None:
+        """Test version_file."""
+        with pytest.raises(NotImplementedError):
+            assert EnvManager("", "").version_file


### PR DESCRIPTION
# Summary

Add `runway tfenv uninstall` command to uninstall versions of Terraform.

# What Changed

## Added

- added `tfenv uninstall` command.
- added `runway.env_mgr.EnvManager.version_file` as an abstract cached property
- added `runway.env_mgr.EnvManager.install()` as an abstract method
- added `runway.env_mgr.EnvManager.list_installed()` as an abstract method
- added `runway.env_mgr.EnvManager.uninstall()`