### PR TITLE
pass default docker version to fake client

### DIFF
--- a/tests/unit/mock_docker/fake_api_client.py
+++ b/tests/unit/mock_docker/fake_api_client.py
@@ -60,6 +60,6 @@ def make_fake_api_client(
 
 def make_fake_client(overrides: Optional[Dict[str, Any]] = None) -> docker.DockerClient:
     """Return a Client with a fake APIClient."""
-    client = docker.DockerClient()
+    client = docker.DockerClient(version=DEFAULT_DOCKER_API_VERSION)
     client.api = make_fake_api_client(overrides)
     return client


### PR DESCRIPTION
# Why This Is Needed

without doing this, creating the client will try to get the version from docker causing tests to fail if docker is not installed

# What Changed

## Fixed

- fixed an issue causing tests that use the mock docker api/client to fail if docker is not installed
