### PR TITLE
cli: add `kbenv uninstall` command

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -184,7 +184,6 @@ kbenv list
 
   $ runway kbenv list
 
-
 ----
 
 
@@ -204,6 +203,24 @@ kbenv run
   $ runway kbenv run version --client
   $ runway kbenv run -- --help
 
+----
+
+
+.. _command-kbenv-uninstall:
+
+***************
+kbenv uninstall
+***************
+
+.. file://./../../runway/_cli/commands/_kbenv/_uninstall.py
+
+.. command-output:: runway kbenv uninstall --help
+
+.. rubric:: Example
+.. code-block:: sh
+
+  $ runway kbenv uninstall v1.21.0
+  $ runway kbenv uninstall --all
 
 ----
 
@@ -223,7 +240,6 @@ new
 
   $ runway new
   $ runway new --debug
-
 
 ----
 
@@ -265,7 +281,6 @@ preflight
 
   $ runway preflight
 
-
 ----
 
 
@@ -283,7 +298,6 @@ run-python
 .. code-block:: sh
 
   $ runway run-python my_script.py
-
 
 ----
 
@@ -303,7 +317,6 @@ schema cfngin
 
   $ runway schema cfngin --output cfngin-schema.json
 
-
 ----
 
 
@@ -321,7 +334,6 @@ schema runway
 .. code-block:: sh
 
   $ runway schema runway --output runway-schema.json
-
 
 ----
 
@@ -442,9 +454,9 @@ tfenv run
 
 .. _command-tfenv-uninstall:
 
-*********
+***************
 tfenv uninstall
-*********
+***************
 
 .. file://./../../runway/_cli/commands/_tfenv/_uninstall.py
 

--- a/runway/_cli/commands/_kbenv/__init__.py
+++ b/runway/_cli/commands/_kbenv/__init__.py
@@ -1,6 +1,6 @@
 """``runway kbenv`` command group."""
 # docs: file://./../../../../docs/source/commands.rst
-from typing import Any
+from typing import Any, List
 
 import click
 
@@ -8,10 +8,11 @@ from ... import options
 from ._install import install
 from ._list import list_installed
 from ._run import run
+from ._uninstall import uninstall
 
-__all__ = ["install", "list_installed", "run"]
+__all__ = ["install", "list_installed", "run", "uninstall"]
 
-COMMANDS = [install, list_installed, run]
+COMMANDS: List[click.Command] = [install, list_installed, run, uninstall]
 
 
 @click.group("kbenv", short_help="kubectl (install|run)")

--- a/runway/_cli/commands/_kbenv/_uninstall.py
+++ b/runway/_cli/commands/_kbenv/_uninstall.py
@@ -1,0 +1,62 @@
+"""Uninstall kubectl version(s) that were installed by Runway and/or kbenv."""
+# docs: file://./../../../../docs/source/commands.rst
+import logging
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+import click
+
+from ....env_mgr.kbenv import KBEnvManager
+from ... import options
+
+if TYPE_CHECKING:
+    from runway._logging import RunwayLogger
+
+LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
+
+
+@click.command("uninstall", short_help="uninstall kubectl")
+@click.argument("version", metavar="[<version>]", default=None, required=False)
+@click.option(
+    "--all",
+    "all_versions",
+    default=False,
+    help="Uninstall all versions of kubectl.",
+    is_flag=True,
+    required=False,
+    show_default=True,
+)
+@options.debug
+@options.no_color
+@options.verbose
+@click.pass_context
+def uninstall(
+    ctx: click.Context,
+    *,
+    version: Optional[str] = None,
+    all_versions: bool = False,
+    **_: Any,
+) -> None:
+    """Uninstall the specified <version> of kubectl (e.g. v1.14.0) or all installed versions.
+
+    If no version is specified, Runway will attempt to find and read a
+    ".kubectl-version" file in the current directory.
+
+    """
+    kbenv = KBEnvManager()
+    version = version or (str(kbenv.version) if kbenv.version else None)
+    if version:
+        version_tuple = KBEnvManager.parse_version_string(version)
+    else:
+        version_tuple = kbenv.version
+    if version_tuple and not all_versions:
+        if not kbenv.uninstall(version_tuple):
+            ctx.exit(1)
+        return
+    if all_versions:
+        LOGGER.notice("uninstalling all versions of kubectl...")
+        for v in kbenv.list_installed():
+            kbenv.uninstall(v.name)
+        LOGGER.success("all versions of kubectl have been uninstalled")
+        return
+    LOGGER.error("version not specified")
+    ctx.exit(1)

--- a/runway/env_mgr/__init__.py
+++ b/runway/env_mgr/__init__.py
@@ -7,7 +7,7 @@ import platform
 import shutil
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Generator, Optional, cast
+from typing import TYPE_CHECKING, Any, Generator, Optional, Tuple, Union, cast
 
 from ..compat import cached_property
 
@@ -143,7 +143,7 @@ class EnvManager:
         """List installed versions of <bin>."""
         raise NotImplementedError
 
-    def uninstall(self, version: str) -> bool:
+    def uninstall(self, version: Union[str, Tuple[Any, ...]]) -> bool:
         """Uninstall a version of the managed binary.
 
         Args:
@@ -153,7 +153,7 @@ class EnvManager:
             Whether a version of the binary was uninstalled or not.
 
         """
-        version_dir = self.versions_dir / version
+        version_dir = self.versions_dir / str(version)
         if version_dir.is_dir():
             LOGGER.notice(
                 "uninstalling %s %s from %s...",

--- a/tests/integration/cli/commands/kbenv/test_uninstall.py
+++ b/tests/integration/cli/commands/kbenv/test_uninstall.py
@@ -1,0 +1,120 @@
+"""Test ``runway kbenv uninstall`` command."""
+# pylint: disable=unused-argument
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from runway._cli import cli
+from runway.env_mgr.kbenv import KB_VERSION_FILENAME, KBEnvManager
+
+if TYPE_CHECKING:
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+LOGGER = "runway.cli.commands.kbenv"
+
+
+@pytest.fixture(autouse=True, scope="function")
+def patch_versions_dir(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Patch KBEnvManager.versions_dir."""
+    mocker.patch.object(KBEnvManager, "versions_dir", tmp_path)
+
+
+def test_kbenv_uninstall(cd_tmp_path: Path) -> None:
+    """Test ``runway kbenv uninstall``."""
+    version = "v1.21.0"
+    version_dir = cd_tmp_path / version
+    version_dir.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall", version])
+    assert result.exit_code == 0
+    assert not version_dir.exists()
+
+
+def test_kbenv_uninstall_all(caplog: LogCaptureFixture, cd_tmp_path: Path) -> None:
+    """Test ``runway kbenv uninstall --all``."""
+    caplog.set_level(logging.INFO, logger=LOGGER)
+    version_dirs = [cd_tmp_path / "v1.14.0", cd_tmp_path / "v1.21.0"]
+    for v in version_dirs:
+        v.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall", "--all"])
+    assert result.exit_code == 0
+    assert "uninstalling all versions of kubectl..." in caplog.messages
+    assert "all versions of kubectl have been uninstalled" in caplog.messages
+    assert all(not v.exists() for v in version_dirs)
+
+
+def test_kbenv_uninstall_all_takes_precedence(
+    caplog: LogCaptureFixture, cd_tmp_path: Path
+) -> None:
+    """Test ``runway kbenv uninstall --all`` takes precedence over arg."""
+    caplog.set_level(logging.INFO, logger=LOGGER)
+    version_dirs = [cd_tmp_path / "v1.14.0", cd_tmp_path / "v1.21.0"]
+    for v in version_dirs:
+        v.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall", "0.13.0", "--all"])
+    assert result.exit_code == 0
+    assert "uninstalling all versions of kubectl..." in caplog.messages
+    assert "all versions of kubectl have been uninstalled" in caplog.messages
+    assert all(not v.exists() for v in version_dirs)
+
+
+def test_kbenv_uninstall_all_none_installed(
+    caplog: LogCaptureFixture, cd_tmp_path: Path
+) -> None:
+    """Test ``runway kbenv uninstall --all`` none installed."""
+    caplog.set_level(logging.INFO, logger=LOGGER)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall", "--all"])
+    assert result.exit_code == 0
+    assert "uninstalling all versions of kubectl..." in caplog.messages
+    assert "all versions of kubectl have been uninstalled" in caplog.messages
+
+
+def test_kbenv_uninstall_arg_takes_precedence(cd_tmp_path: Path) -> None:
+    """Test ``runway kbenv uninstall`` arg takes precedence over file."""
+    version = "v1.21.0"
+    version_dir = cd_tmp_path / version
+    version_dir.mkdir()
+    (cd_tmp_path / KB_VERSION_FILENAME).write_text("v1.14.0")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall", version])
+    assert result.exit_code == 0
+    assert not version_dir.exists()
+
+
+def test_kbenv_uninstall_no_version(
+    caplog: LogCaptureFixture, cd_tmp_path: Path
+) -> None:
+    """Test ``runway kbenv uninstall`` no version."""
+    caplog.set_level(logging.ERROR, logger=LOGGER)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall"])
+    assert result.exit_code != 0
+    assert "version not specified" in caplog.messages
+
+
+def test_kbenv_uninstall_not_installed(cd_tmp_path: Path) -> None:
+    """Test ``runway kbenv uninstall`` not installed."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall", "1.21.0"])
+    assert result.exit_code != 0
+
+
+def test_kbenv_uninstall_version_file(cd_tmp_path: Path) -> None:
+    """Test ``runway kbenv uninstall`` version file."""
+    version = "v1.21.0"
+    version_dir = cd_tmp_path / version
+    version_dir.mkdir()
+    (cd_tmp_path / KB_VERSION_FILENAME).write_text(version)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kbenv", "uninstall"])
+    assert result.exit_code == 0
+    assert not version_dir.exists()


### PR DESCRIPTION
# Summary

Add `runway kbenv uninstall` command to uninstall versions of kubectl.

# What Changed

## Added

- added `kbenv uninstall` command.