### PR TITLE
cfngin: add protocol for hook classes

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -62,6 +62,7 @@
     "maxNumberOfProblems": 100,
     "version": "0.1",
     "words": [
+        "abstractmethod",
         "codecov",
         "FQDNs",
         "fstring",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,9 @@ rst_epilog = """
 .. |Dict| replace::
   :data:`~typing.Dict`
 
+.. |Protocol| replace::
+  :class:`~typing.Protocol`
+
 .. |Stack| replace::
   :class:`~runway.cfngin.stack.Stack`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ exclude_lines = [
   "if TYPE_CHECKING:",  # excluded blocks
   "if __name__ == .__main__.:",
   "raise AssertionError",  # defensive exceptions
-  "raise NotImplimentedError",
+  "raise NotImplementedError",
   "from pathlib import Path",
   "@overload",
 ]

--- a/runway/cfngin/hooks/base.py
+++ b/runway/cfngin/hooks/base.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union, cast
 
-from pydantic import BaseModel
 from troposphere import Tags
 
 from ...config.models.cfngin import CfnginStackDefinitionModel
+from ...utils import BaseModel
 from ..actions import deploy
 from ..exceptions import StackFailed
 from ..stack import Stack
 from ..status import COMPLETE, FAILED, PENDING, SKIPPED, SUBMITTED
+from .protocols import CfnginHookProtocol
 
 if TYPE_CHECKING:
     from ..._logging import RunwayLogger
@@ -28,32 +29,8 @@ class HookArgsBaseModel(BaseModel):
 
     tags: Dict[str, str] = {}
 
-    def __contains__(self, name: str) -> bool:
-        """Implement evaluation of 'in' conditional.
 
-        Args:
-            name: The name to check for existence in the model.
-
-        """
-        return name in self.__dict__
-
-    def __getitem__(self, name: str) -> Any:
-        """Implement evaluation of self[name].
-
-        Args:
-            name: Attribute name to return the value for.
-
-        Returns:
-            The value associated with the provided name/attribute name.
-
-        Raises:
-            AttributeError: If attribute does not exist on this object.
-
-        """
-        return getattr(self, name)
-
-
-class Hook:
+class Hook(CfnginHookProtocol):
     """Base class for hooks.
 
     Not all hooks need to be classes and not all classes need to be hooks.
@@ -77,7 +54,9 @@ class Hook:
     stack: Optional[Stack] = None
     stack_name: str = "stack"
 
-    def __init__(self, context: CfnginContext, provider: Provider, **kwargs: Any):
+    def __init__(  # pylint: disable=super-init-not-called
+        self, context: CfnginContext, provider: Provider, **kwargs: Any
+    ) -> None:
         """Instantiate class.
 
         Args:

--- a/runway/cfngin/hooks/protocols.py
+++ b/runway/cfngin/hooks/protocols.py
@@ -7,12 +7,15 @@ For more information on protocols, refer to
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, overload
 
 from typing_extensions import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from ...context import CfnginContext
+
+
+_T = TypeVar("_T")
 
 
 class CfnginHookArgsProtocol(Protocol):
@@ -24,8 +27,18 @@ class CfnginHookArgsProtocol(Protocol):
 
     """
 
+    @overload
     @abstractmethod
-    def get(self, name: str, default: Any = None) -> Any:
+    def get(self, _name: str) -> Optional[Any]:
+        ...
+
+    @overload
+    @abstractmethod
+    def get(self, _name: str, default: Union[Any, _T]) -> Union[Any, _T]:
+        ...
+
+    @abstractmethod
+    def get(self, _name: str, default: Union[Any, _T] = None) -> Union[Any, _T]:
         """Safely get the value of an attribute.
 
         Args:
@@ -36,19 +49,19 @@ class CfnginHookArgsProtocol(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def __contains__(self, name: str) -> bool:
+    def __contains__(self, _name: str) -> bool:
         raise NotImplementedError
 
     @abstractmethod
-    def __getattribute__(self, name: str) -> Any:
+    def __getattribute__(self, _name: str) -> Any:
         raise NotImplementedError
 
     @abstractmethod
-    def __getitem__(self, name: str) -> Any:
+    def __getitem__(self, _name: str) -> Any:
         raise NotImplementedError
 
     @abstractmethod
-    def __setitem__(self, name: str, value: Any) -> None:
+    def __setitem__(self, _name: str, _value: Any) -> None:
         raise NotImplementedError
 
 

--- a/runway/cfngin/hooks/protocols.py
+++ b/runway/cfngin/hooks/protocols.py
@@ -1,4 +1,9 @@
-"""Protocols for structural typing."""
+"""Protocols for structural typing.
+
+For more information on protocols, refer to
+`PEP 544 <https://www.python.org/dev/peps/pep-0544/>`__.
+
+"""
 from __future__ import annotations
 
 from abc import abstractmethod
@@ -11,11 +16,17 @@ if TYPE_CHECKING:
 
 
 class CfnginHookArgsProtocol(Protocol):
-    """Protocol for CFNgin hook arguments class."""
+    """Protocol for CFNgin hook arguments class.
+
+    This class defines a structural interface for all CFNgin hook argument
+    classes. It is recommended to use the provided base class in place of this
+    when authoring a new argument class.
+
+    """
 
     @abstractmethod
     def get(self, name: str, default: Any = None) -> Any:
-        """Implement evaluation of self.get.
+        """Safely get the value of an attribute.
 
         Args:
             name: Attribute name to return the value for.
@@ -29,6 +40,10 @@ class CfnginHookArgsProtocol(Protocol):
         raise NotImplementedError
 
     @abstractmethod
+    def __getattribute__(self, name: str) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
     def __getitem__(self, name: str) -> Any:
         raise NotImplementedError
 
@@ -39,7 +54,14 @@ class CfnginHookArgsProtocol(Protocol):
 
 @runtime_checkable
 class CfnginHookProtocol(Protocol):
-    """Protocol for CFNgin hooks."""
+    """Protocol for CFNgin hooks.
+
+    This class defines a structural interface for all CFNgin hook classes.
+    Classes used for hooks do not need to subclass this hook. They only need to
+    implement a similar interface. While not required, it is still acceptable
+    to subclass this class for full type checking of a hook class.
+
+    """
 
     args: CfnginHookArgsProtocol
 
@@ -47,24 +69,55 @@ class CfnginHookProtocol(Protocol):
     def __init__(  # pylint: disable=super-init-not-called
         self, context: CfnginContext, **_kwargs: Any
     ) -> None:
-        """Structural __init__ method."""
+        """Structural __init__ method.
+
+        This should not be called. Pylint will erroneously warn about
+        "super-init-not-called" if using this class as a subclass. This should
+        be disabled in-line until the bug reports for this issue is resolved.
+
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def post_deploy(self) -> Any:
-        """Run during the **post_deploy** stage."""
+        """Run during the **post_deploy** stage.
+
+        Returns:
+            A "truthy" value if the hook was successful or a "falsy" value if the
+            hook failed.
+
+        """
         raise NotImplementedError
 
     @abstractmethod
     def post_destroy(self) -> Any:
-        """Run during the **post_destroy** stage."""
+        """Run during the **post_destroy** stage.
+
+        Returns:
+            A "truthy" value if the hook was successful or a "falsy" value if the
+            hook failed.
+
+        """
         raise NotImplementedError
 
     @abstractmethod
     def pre_deploy(self) -> Any:
-        """Run during the **pre_deploy** stage."""
+        """Run during the **pre_deploy** stage.
+
+        Returns:
+            A "truthy" value if the hook was successful or a "falsy" value if the
+            hook failed.
+
+        """
         raise NotImplementedError
 
     @abstractmethod
     def pre_destroy(self) -> Any:
-        """Run during the **pre_destroy** stage."""
+        """Run during the **pre_destroy** stage.
+
+        Returns:
+            A "truthy" value if the hook was successful or a "falsy" value if the
+            hook failed.
+
+        """
         raise NotImplementedError

--- a/runway/cfngin/hooks/protocols.py
+++ b/runway/cfngin/hooks/protocols.py
@@ -1,0 +1,70 @@
+"""Protocols for structural typing."""
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ...context import CfnginContext
+
+
+class CfnginHookArgsProtocol(Protocol):
+    """Protocol for CFNgin hook arguments class."""
+
+    @abstractmethod
+    def get(self, name: str, default: Any = None) -> Any:
+        """Implement evaluation of self.get.
+
+        Args:
+            name: Attribute name to return the value for.
+            default: Value to return if attribute is not found.
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def __contains__(self, name: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def __getitem__(self, name: str) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def __setitem__(self, name: str, value: Any) -> None:
+        raise NotImplementedError
+
+
+@runtime_checkable
+class CfnginHookProtocol(Protocol):
+    """Protocol for CFNgin hooks."""
+
+    args: CfnginHookArgsProtocol
+
+    @abstractmethod
+    def __init__(  # pylint: disable=super-init-not-called
+        self, context: CfnginContext, **_kwargs: Any
+    ) -> None:
+        """Structural __init__ method."""
+
+    @abstractmethod
+    def post_deploy(self) -> Any:
+        """Run during the **post_deploy** stage."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def post_destroy(self) -> Any:
+        """Run during the **post_destroy** stage."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def pre_deploy(self) -> Any:
+        """Run during the **pre_deploy** stage."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def pre_destroy(self) -> Any:
+        """Run during the **pre_destroy** stage."""
+        raise NotImplementedError

--- a/runway/cfngin/hooks/ssm/parameter.py
+++ b/runway/cfngin/hooks/ssm/parameter.py
@@ -10,6 +10,7 @@ from typing_extensions import Literal, TypedDict
 
 from ....compat import cached_property
 from ....utils import BaseModel, JsonEncoder
+from ..protocols import CfnginHookProtocol
 from ..utils import TagDataModel
 
 if TYPE_CHECKING:
@@ -106,10 +107,12 @@ class ArgsDataModel(BaseModel):
         )
 
 
-class _Parameter:
+class _Parameter(CfnginHookProtocol):
     """AWS SSM Parameter Store Parameter."""
 
-    def __init__(
+    args: ArgsDataModel
+
+    def __init__(  # pylint: disable=super-init-not-called
         self,
         context: CfnginContext,
         *,

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -13,7 +13,6 @@ from ...exceptions import FailedVariableLookup
 from ...utils import BaseModel, load_object_from_string
 from ...variables import Variable, resolve_variables
 from ..blueprints.base import Blueprint
-from .protocols import CfnginHookProtocol
 
 if TYPE_CHECKING:
     from ...config.models.cfngin import CfnginHookDefinitionModel
@@ -111,7 +110,7 @@ def handle_hooks(  # pylint: disable=too-many-statements
             kwargs = {}
 
         try:
-            if isinstance(method, CfnginHookProtocol):
+            if isinstance(method, type):
                 result = getattr(
                     method(context=context, provider=provider, **kwargs), stage
                 )()

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -13,6 +13,7 @@ from ...exceptions import FailedVariableLookup
 from ...utils import BaseModel, load_object_from_string
 from ...variables import Variable, resolve_variables
 from ..blueprints.base import Blueprint
+from .protocols import CfnginHookProtocol
 
 if TYPE_CHECKING:
     from ...config.models.cfngin import CfnginHookDefinitionModel
@@ -110,7 +111,7 @@ def handle_hooks(  # pylint: disable=too-many-statements
             kwargs = {}
 
         try:
-            if isinstance(method, type):
+            if isinstance(method, CfnginHookProtocol):
                 result = getattr(
                     method(context=context, provider=provider, **kwargs), stage
                 )()

--- a/runway/utils.py
+++ b/runway/utils.py
@@ -55,7 +55,7 @@ class BaseModel(_BaseModel):
     """Base class for Runway models."""
 
     def get(self, name: str, default: Any = None) -> Any:
-        """Implement evaluation of self.get.
+        """Safely get the value of an attribute.
 
         Args:
             name: Attribute name to return the value for.

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ extend-ignore =
     E203,
     # line break before operator
     W503
-ignore-decorators = overload
+ignore-decorators = abstractmethod|overload
 max-line-length = 98
 show-source = true
 statistics = true

--- a/tests/unit/cfngin/hooks/test_utils.py
+++ b/tests/unit/cfngin/hooks/test_utils.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from mock import call, patch
 
+from runway.cfngin.hooks.protocols import CfnginHookProtocol
 from runway.cfngin.hooks.utils import handle_hooks
 from runway.config.models.cfngin import CfnginHookDefinitionModel
 
@@ -230,11 +231,14 @@ class TestHooks(unittest.TestCase):
         )
 
 
-class MockHook:
+class MockHook(CfnginHookProtocol):
     """Mock hook class."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    args: Dict[str, Any]
+
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Instantiate class."""
+        self.args = {}
 
     def post_deploy(self) -> Dict[str, str]:
         """Run during the **post_deploy** stage."""


### PR DESCRIPTION
# Summary

Use a `typing.Protocol` to define a structural base class for CFNgin hook classes. This provides fewer restrictions when creating CFNgin hook classes while still providing a standardized structure that can be type-checked.

# What Changed

## Added

- added `runway.cfngin.hooks.protocols`

## Changed

- `runway.cfngin.hooks.base.Hook` is now a subclass of `runway.cfngin.hooks.protocols.CfnginHookProtocol` for structural type checking
- `runway.cfngin.hooks.base.HookArgsBaseModel` is now a subclass of `runway.utils.BaseModel` to remove redundent code
- `runway.cfngin.hooks.ssm.parameter._Parameter` is now a subclass of `runway.cfngin.hooks.protocols.CfnginHookProtocol` for structural type checking
