### PR TITLE
cfngin.hooks: expanded types of hook_data to include pydantic models

### DIFF
--- a/docs/source/cfngin/hooks.rst
+++ b/docs/source/cfngin/hooks.rst
@@ -45,7 +45,7 @@ Only the following actions allow pre/post hooks:
     :type: Optional[str]
     :value: None
 
-    If set, and the hook returns data (a dictionary), the results will be stored in :attr:`CfnginContext.hook_data <runway.context.CfnginContext.hook_data>` with the ``data_key`` as its key.
+    If set, and the hook returns data (a dictionary or ``pydantic.BaseModel``), the results will be stored in :attr:`CfnginContext.hook_data <runway.context.CfnginContext.hook_data>` with the ``data_key`` as its key.
 
     .. rubric:: Example
     .. code-block:: yaml
@@ -1546,7 +1546,7 @@ It must return ``False`` or a falsy object if it failed.
 This signifies to CFNgin whether or not to halt execution if the hook is :attr:`~cfngin.hook.required`.
 If a |Dict| or :class:`~runway.utils.MutableMap` is returned, it can be accessed by subsequent hooks, lookups, or Blueprints from the context object.
 It will be stored as ``context.hook_data[data_key]`` where :attr:`~cfngin.hook.data_key` is the value set in the hook definition.
-If :attr:`~cfngin.hook.data_key` is not provided or the type of the returned data is not a |Dict| or :class:`~runway.utils.MutableMap`, it will not be added to the context object.
+If :attr:`~cfngin.hook.data_key` is not provided or the type of the returned data is not a |Dict|, :class:`~runway.utils.MutableMap`, or ``pydantic.BaseModel``, it will not be added to the context object.
 
 If using boto3 in a hook, use :meth:`context.get_session() <runway.context.CfnginContext.get_session>` instead of creating a new session to ensure the correct credentials are used.
 

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -5,9 +5,9 @@ import collections.abc
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, cast
+from typing import TYPE_CHECKING, Any, Dict, List
 
-from pydantic import Extra, Field
+import pydantic
 
 from ...exceptions import FailedVariableLookup
 from ...utils import BaseModel, load_object_from_string
@@ -32,14 +32,14 @@ class BlankBlueprint(Blueprint):
 class TagDataModel(BaseModel):
     """AWS Resource Tag data model."""
 
-    key: str = Field(..., alias="Key")
-    value: str = Field(..., alias="Value")
+    key: str = pydantic.Field(..., alias="Key")
+    value: str = pydantic.Field(..., alias="Value")
 
     class Config:
         """Model configuration."""
 
         allow_population_by_field_name = True
-        extra = Extra.forbid
+        extra = pydantic.Extra.forbid
 
 
 def full_path(path: str) -> str:
@@ -132,16 +132,14 @@ def handle_hooks(  # pylint: disable=too-many-statements
                 "non-required hook %s failed; return value: %s", hook.path, result
             )
         else:
-            if isinstance(result, collections.abc.Mapping):
+            if isinstance(result, (collections.abc.Mapping, pydantic.BaseModel)):
                 if hook.data_key:
                     LOGGER.debug(
                         "adding result for hook %s to context in data_key %s",
                         hook.path,
                         hook.data_key,
                     )
-                    context.set_hook_data(
-                        hook.data_key, cast(Mapping[str, Any], result)
-                    )
+                    context.set_hook_data(hook.data_key, result)
                 else:
                     LOGGER.debug(
                         "hook %s returned result data but no data key set; ignoring",

--- a/runway/utils.py
+++ b/runway/utils.py
@@ -64,7 +64,7 @@ class BaseModel(_BaseModel):
         """
         return getattr(self, name, default)
 
-    def __contains__(self, name: str) -> bool:
+    def __contains__(self, name: object) -> bool:
         """Implement evaluation of 'in' conditional.
 
         Args:


### PR DESCRIPTION
# Summary

CFNgin hooks can now return instances of `pydantic.BaseModel` and have the data added to the context object.

# Why This Is Needed

More flexibility when writing hooks that should be paired with a specific lookup.

# What Changed

## Changed

- hooks that return instances of `pydantic.BaseModel` can now have their return data added to `CfnginContext.hook_data`
