### PR TITLE
cdk: catch `cdk diff` error, clean exit with explanation

### DIFF
--- a/docs/source/cdk/configuration.rst
+++ b/docs/source/cdk/configuration.rst
@@ -20,6 +20,38 @@ Prerequisites
 We strongly recommend you commit the package-lock.json that is generated after running ``npm install``.
 
 
+***************
+Recommendations
+***************
+
+
+Feature Flags
+=============
+
+The AWS CDK uses `feature flags <https://docs.aws.amazon.com/cdk/latest/guide/featureflags.html>`__ to enable potentially breaking behaviors prior to the next major release that makes them default behaviors.
+Flags are stored as Runtime context values in ``cdk.json`` (or ``~/.cdk.json``).
+
+.. sphinx doesn't like displaying these feature flags as `data` so they have to be headers
+
+aws-cdk:enableDiffNoFail
+------------------------
+
+This feature flag is available in version ``^1.0.0``.
+
+If this is set to ``true`` (recommend), ``cdk diff`` will always exit with ``0``.
+With this set to ``false``, ``cdk diff`` will exit with a non-zero exit code if there is a diff.
+This will result in Runway exiting before all stacks/modules/deployments are processed.
+
+.. rubric:: Example
+.. code-block:: json
+
+  {
+    "context": {
+      "aws-cdk:enableDiffNoFail": true
+    },
+  }
+
+
 ************
 Environments
 ************

--- a/runway/module/utils.py
+++ b/runway/module/utils.py
@@ -77,7 +77,17 @@ def run_module_command(
     exit_on_error: bool = True,
     logger: Union[logging.Logger, logging.LoggerAdapter] = LOGGER,
 ) -> None:
-    """Shell out to provisioner command."""
+    """Shell out to provisioner command.
+
+    Args:
+        cmd_list: Command to run.
+        env_vars: Environment variables.
+        exit_on_error: If true, ``subprocess.CalledProcessError`` will be caught
+            and the resulting exit code will be passed to ``sys.exit()``.
+            If false, the error will not be caught within this function.
+            logger: Optionally, supply a logger to use.
+
+    """
     logger.debug("running command: %s", " ".join(cmd_list))
     if exit_on_error:
         try:


### PR DESCRIPTION
# Summary

`cdk diff` returns a non-zero exit code when there is a diff. The same exit code is returned if there is an error. Rather than hiding errors to also hide the existence of a diff Runway will let the exit code bubble up, log an explanation with the reasons that could result in an early exit, and log how to avoid the early exit if it was caused by a diff.

# Why This Is Needed

resolves #819

# What Changed

## Added

- added handling for `cdk diff` call to exit cleanly (without a stack trace)

## Changed

- Runway recommends enabling the [CDK feature flag](https://docs.aws.amazon.com/cdk/latest/guide/featureflags.html) `aws-cdk:enableDiffNoFail` when using CDK ^1.0.0