### PR TITLE
context: `.get_session()` now correctly uses creds from deploy environment

### DIFF
--- a/runway/config/models/runway/__init__.py
+++ b/runway/config/models/runway/__init__.py
@@ -502,7 +502,7 @@ class RunwayVariablesDefinitionModel(ConfigProperty):
         "merged with the variables defined here.",
     )
     sys_path: Path = Field(
-        Path.cwd(),
+        "./",
         description="Directory to use as the root of a relative 'file_path'. "
         "If not provided, the current working directory is used.",
     )

--- a/runway/context/_base.py
+++ b/runway/context/_base.py
@@ -87,6 +87,11 @@ class BaseContext:
     ) -> boto3.Session:
         """Create a thread-safe boto3 session.
 
+        If ``profile`` is provided, it will take priority.
+
+        If no credential arguments are passed, will attempt to find them in
+        environment variables.
+
         Args:
             aws_access_key_id: AWS Access Key ID.
             aws_secret_access_key: AWS secret Access Key.
@@ -104,17 +109,27 @@ class BaseContext:
                 profile,
                 region or "default",
             )
-        elif aws_access_key_id:
-            self.logger.debug(
-                'building session with Access Key "%s" in region "%s"',
-                aws_access_key_id,
-                region or "default",
+        else:  # use explicit values or grab values from env vars
+            aws_access_key_id = aws_access_key_id or self.env.vars.get(
+                "AWS_ACCESS_KEY_ID"
             )
+            aws_secret_access_key = aws_secret_access_key or self.env.vars.get(
+                "AWS_SECRET_ACCESS_KEY"
+            )
+            aws_session_token = aws_session_token or self.env.vars.get(
+                "AWS_SESSION_TOKEN"
+            )
+            if aws_access_key_id:
+                self.logger.debug(
+                    'building session with Access Key "%s" in region "%s"',
+                    aws_access_key_id,
+                    region or "default",
+                )
         session = boto3.Session(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
-            botocore_session=Session(),  # type: ignore
+            botocore_session=Session(),
             region_name=region,
             profile_name=profile,
         )

--- a/tests/functional/cfngin/test_assume_role/__init__.py
+++ b/tests/functional/cfngin/test_assume_role/__init__.py
@@ -1,0 +1,1 @@
+"""Empty module for python import traversal."""

--- a/tests/functional/cfngin/test_assume_role/cfngin.yml
+++ b/tests/functional/cfngin/test_assume_role/cfngin.yml
@@ -1,0 +1,8 @@
+namespace: ${namespace}
+cfngin_bucket: ""
+
+sys_path: ../fixtures
+
+stacks:
+  - name: test-assume-role
+    class_path: blueprints.Dummy

--- a/tests/functional/cfngin/test_assume_role/runway.variables.yml
+++ b/tests/functional/cfngin/test_assume_role/runway.variables.yml
@@ -1,0 +1,6 @@
+account_id:
+  test: "523485371024"
+  test-alt: "395611358874"
+
+runner_role:
+  test-alt: arn:aws:iam::395611358874:role/runway-test-infrastructure-gh-action-runner

--- a/tests/functional/cfngin/test_assume_role/runway.yml
+++ b/tests/functional/cfngin/test_assume_role/runway.yml
@@ -1,0 +1,15 @@
+deployments:
+  - modules:
+      - name: test_assume_role
+        path: ./
+        parameters:
+          namespace: ${env RUNWAY_TEST_NAMESPACE::default=${env USER::default=user}-local}
+    account_id: ${var account_id.test-alt}
+    assume_role: ${var runner_role.test-alt}
+    environments:
+      test: true
+    parameters:
+      cfngin_bucket: runway-testing-lab-cfngin-bucket-${env AWS_REGION}
+      namespace: ${env RUNWAY_TEST_NAMESPACE::default=${env USER::default=user}-local}
+    regions:
+      - us-east-1

--- a/tests/functional/cfngin/test_assume_role/test_runner.py
+++ b/tests/functional/cfngin/test_assume_role/test_runner.py
@@ -1,0 +1,105 @@
+"""Test Runway assume role."""
+# pylint: disable=redefined-outer-name,unused-argument
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Generator
+
+import boto3
+import pytest
+import yaml
+from botocore.exceptions import ClientError
+
+from runway._cli import cli
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner, Result
+
+AWS_REGION = "us-east-1"
+CURRENT_DIR = Path(__file__).parent
+
+
+def assert_session_belongs_to_account(session: boto3.Session, account_id: str) -> None:
+    """Assert boto3.Session belongs to expected account."""
+    assert session.client("sts").get_caller_identity()["Account"] == account_id
+
+
+@pytest.fixture(scope="module")
+def assumed_session(
+    main_session: boto3.Session, variables: Dict[str, Any]
+) -> boto3.Session:
+    """boto3 session for assumed account."""
+    role_arn = variables["runner_role"]["test-alt"]
+    sts_client = main_session.client("sts")
+
+    creds = sts_client.assume_role(
+        DurationSeconds=3600, RoleArn=role_arn, RoleSessionName=__name__
+    )["Credentials"]
+    return boto3.Session(
+        aws_access_key_id=creds["AccessKeyId"],
+        aws_secret_access_key=creds["SecretAccessKey"],
+        aws_session_token=creds["SessionToken"],
+        region_name=AWS_REGION,
+    )
+
+
+@pytest.fixture(scope="module")
+def main_session() -> boto3.Session:
+    """boto3 session for main account."""
+    return boto3.Session(region_name=AWS_REGION)
+
+
+@pytest.fixture(scope="module")
+def variables() -> Dict[str, Any]:
+    """Contents of ruinway.variables.yml."""
+    return yaml.safe_load((CURRENT_DIR / "runway.variables.yml").read_bytes())
+
+
+@pytest.fixture(scope="module")
+def deploy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
+    """Execute `runway deploy` with `runway destory` as a cleanup step."""
+    yield cli_runner.invoke(cli, ["deploy", "--debug"], env={"CI": "1"})
+
+
+@pytest.fixture(scope="module")
+def destroy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
+    """Execute `runway deploy` with `runway destory` as a cleanup step."""
+    yield cli_runner.invoke(cli, ["destroy"], env={"CI": "1"})
+    shutil.rmtree(CURRENT_DIR / ".runway", ignore_errors=True)
+
+
+@pytest.mark.order("first")
+def test_deploy_exit_code(deploy_result: Result) -> None:
+    """Test deploy exit code."""
+    assert deploy_result.exit_code == 0
+
+
+def test_does_not_exist_in_main_account(
+    main_session: boto3.Session, namespace: str, variables: Dict[str, Any]
+) -> None:
+    """Test that the deployed stack does not exist in the main test account."""
+    assert_session_belongs_to_account(main_session, variables["account_id"]["test"])
+    with pytest.raises(ClientError) as excinfo:
+        main_session.client("cloudformation").describe_stacks(
+            StackName=f"{namespace}-test-assume-role"
+        )
+    assert "does not exist" in str(excinfo.value)
+
+
+def test_exists_in_assumed_account(
+    assumed_session: boto3.Session, namespace: str, variables: Dict[str, Any]
+) -> None:
+    """Test that the deployed stack exists in the assumed account."""
+    assert_session_belongs_to_account(
+        assumed_session, variables["account_id"]["test-alt"]
+    )
+    assert assumed_session.client("cloudformation").describe_stacks(
+        StackName=f"{namespace}-test-assume-role"
+    )["Stacks"]
+
+
+@pytest.mark.order("last")
+def test_destroy_exit_code(destroy_result: Result) -> None:
+    """Test destroy exit code."""
+    assert destroy_result.exit_code == 0

--- a/tests/unit/context/test_base.py
+++ b/tests/unit/context/test_base.py
@@ -47,7 +47,16 @@ def mock_sso_botocore_session(mocker: MockerFixture) -> MagicMock:
 class TestBaseContext:
     """Test runway.context._base.BaseContext."""
 
-    env = DeployEnvironment(explicit_name="test")
+    env = DeployEnvironment(
+        environ={
+            "AWS_ACCESS_KEY_ID": "testing",
+            "AWS_SECRET_ACCESS_KEY": "testing",
+            "AWS_SESSION_TOKEN": "foobar",
+            "AWS_DEFAULT_REGION": "us-east-1",
+            "AWS_REGION": "us-east-1",
+        },
+        explicit_name="test",
+    )
 
     def test_boto3_credentials(self, mocker: MockerFixture) -> None:
         """Test boto3_credentials."""
@@ -99,9 +108,9 @@ class TestBaseContext:
         ctx = BaseContext(deploy_environment=self.env)
         assert ctx.get_session() == mock_boto3_session.return_value
         mock_boto3_session.assert_called_once_with(
-            aws_access_key_id=None,
-            aws_secret_access_key=None,
-            aws_session_token=None,
+            aws_access_key_id=self.env.vars["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key=self.env.vars["AWS_SECRET_ACCESS_KEY"],
+            aws_session_token=self.env.vars["AWS_SESSION_TOKEN"],
             botocore_session=mock_sso_botocore_session.return_value,
             region_name=None,
             profile_name=None,
@@ -154,9 +163,9 @@ class TestBaseContext:
         ctx = BaseContext(deploy_environment=self.env)
         assert ctx.get_session(region="us-east-2") == mock_boto3_session.return_value
         mock_boto3_session.assert_called_once_with(
-            aws_access_key_id=None,
-            aws_secret_access_key=None,
-            aws_session_token=None,
+            aws_access_key_id=self.env.vars["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key=self.env.vars["AWS_SECRET_ACCESS_KEY"],
+            aws_session_token=self.env.vars["AWS_SESSION_TOKEN"],
             botocore_session=mock_sso_botocore_session.return_value,
             region_name="us-east-2",
             profile_name=None,


### PR DESCRIPTION
# Why This Is Needed

`runway.context._base.BaseContext.get_session()` was ignoring credentials stored in `self.env`.
This caused assumed roles to be ignored by Runway and CFNgin.

This resolves #821

# What Changed

## Added

- added a function test for Runway assuming and using a role

## Changed

- `runway.context._base.BaseContext.get_session()` will now attempt to pull values from `self.env` if they wern't explicitly provided
	- this occurs before passing off credential resolution responsibilities to `boto3`/`botocore`

## Fixed

- fixed issue causing assumed roles to be ignored by Runway and CFNgin