### PR TITLE
flake8: set `classmethod-decorators` for pydantic validators

### DIFF
--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -161,18 +161,14 @@ class CfnginStackDefinitionModel(ConfigProperty):
     )(utils.resolve_path_field)
 
     @root_validator(pre=True)
-    def _validate_class_and_template(
-        cls, values: Dict[str, Any]  # noqa: N805
-    ) -> Dict[str, Any]:
+    def _validate_class_and_template(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate class_path and template_path are not both provided."""
         if values.get("class_path") and values.get("template_path"):
             raise ValueError("only one of class_path or template_path can be defined")
         return values
 
     @root_validator(pre=True)
-    def _validate_class_or_template(
-        cls, values: Dict[str, Any]  # noqa: N805
-    ) -> Dict[str, Any]:
+    def _validate_class_or_template(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Ensure that either class_path or template_path is defined."""
         # if the stack is disabled or locked, it is ok that these are missing
         required = values.get("enabled", True) and not values.get("locked", False)
@@ -291,7 +287,7 @@ class CfnginConfigDefinitionModel(ConfigProperty):
 
     @validator("post_deploy", "post_destroy", "pre_deploy", "pre_destroy", pre=True)
     def _convert_hook_definitions(
-        cls, v: Union[Dict[str, Any], List[Dict[str, Any]]]  # noqa: N805
+        cls, v: Union[Dict[str, Any], List[Dict[str, Any]]]
     ) -> List[Dict[str, Any]]:
         """Convert hooks defined as a dict to a list."""
         if isinstance(v, list):
@@ -300,7 +296,7 @@ class CfnginConfigDefinitionModel(ConfigProperty):
 
     @validator("stacks", pre=True)
     def _convert_stack_definitions(
-        cls, v: Union[Dict[str, Any], List[Dict[str, Any]]]  # noqa: N805
+        cls, v: Union[Dict[str, Any], List[Dict[str, Any]]]
     ) -> List[Dict[str, Any]]:
         """Convert stacks defined as a dict to a list."""
         if isinstance(v, list):
@@ -313,7 +309,7 @@ class CfnginConfigDefinitionModel(ConfigProperty):
 
     @validator("stacks")
     def _validate_unique_stack_names(
-        cls, stacks: List[CfnginStackDefinitionModel]  # noqa: N805
+        cls, stacks: List[CfnginStackDefinitionModel]
     ) -> List[CfnginStackDefinitionModel]:
         """Validate that each stack has a unique name."""
         stack_names = [stack.name for stack in stacks]

--- a/runway/config/models/cfngin/_package_sources.py
+++ b/runway/config/models/cfngin/_package_sources.py
@@ -55,7 +55,7 @@ class GitCfnginPackageSourceDefinitionModel(ConfigProperty):
         title = "CFNgin Git Repository Package Source Definition"
 
     @root_validator
-    def _validate_one_ref(cls, values: Dict[str, Any]) -> Dict[str, Any]:  # noqa: N805
+    def _validate_one_ref(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Ensure that only one ref is defined."""
         ref_keys = ["branch", "commit", "tag"]
         count_ref_defs = sum(bool(values.get(i)) for i in ref_keys)

--- a/runway/config/models/runway/__init__.py
+++ b/runway/config/models/runway/__init__.py
@@ -124,13 +124,13 @@ class RunwayAssumeRoleDefinitionModel(ConfigProperty):
         title = "Runway Deployment.assume_role Definition"
 
     @validator("arn")
-    def _convert_arn_null_value(cls, v: Optional[str]) -> Optional[str]:  # noqa: N805
+    def _convert_arn_null_value(cls, v: Optional[str]) -> Optional[str]:
         """Convert a "nul" string into type(None)."""
         null_strings = ["null", "none", "undefined"]
         return None if isinstance(v, str) and v.lower() in null_strings else v
 
     @validator("duration", pre=True)
-    def _validate_duration(cls, v: Union[int, str]) -> Union[int, str]:  # noqa: N805
+    def _validate_duration(cls, v: Union[int, str]) -> Union[int, str]:
         """Validate duration is within the range allowed by AWS."""
         if isinstance(v, str):
             return v
@@ -294,9 +294,7 @@ class RunwayDeploymentDefinitionModel(ConfigProperty):
             ]
 
     @root_validator(pre=True)
-    def _convert_simple_module(
-        cls, values: Dict[str, Any]  # noqa: N805
-    ) -> Dict[str, Any]:
+    def _convert_simple_module(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Convert simple modules to dicts."""
         modules = values.get("modules", [])
         result: List[Dict[str, Any]] = []
@@ -309,7 +307,7 @@ class RunwayDeploymentDefinitionModel(ConfigProperty):
         return values
 
     @root_validator(pre=True)
-    def _validate_regions(cls, values: Dict[str, Any]) -> Dict[str, Any]:  # noqa: N805
+    def _validate_regions(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate & simplify regions."""
         raw_regions = values.get("regions", [])
         parallel_regions = values.get("parallel_regions", [])
@@ -448,7 +446,7 @@ class RunwayModuleDefinitionModel(ConfigProperty):
         use_enum_values = True
 
     @root_validator(pre=True)
-    def _validate_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:  # noqa: N805
+    def _validate_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate module name."""
         if "name" in values:
             return values
@@ -461,7 +459,7 @@ class RunwayModuleDefinitionModel(ConfigProperty):
         return values
 
     @root_validator(pre=True)
-    def _validate_path(cls, values: Dict[str, Any]) -> Dict[str, Any]:  # noqa: N805
+    def _validate_path(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate path and sets a default value if needed."""
         if not values.get("path") and not values.get("parallel"):
             values["path"] = Path.cwd()
@@ -469,7 +467,7 @@ class RunwayModuleDefinitionModel(ConfigProperty):
 
     @validator("parallel", pre=True)
     def _validate_parallel(
-        cls, v: List[Union[Dict[str, Any], str]], values: Dict[str, Any]  # noqa: N805
+        cls, v: List[Union[Dict[str, Any], str]], values: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
         """Validate parallel."""
         if v and values.get("path"):
@@ -602,9 +600,7 @@ class RunwayConfigDefinitionModel(ConfigProperty):
         validate_assignment = True
 
     @root_validator(pre=True)
-    def _add_deployment_names(
-        cls, values: Dict[str, Any]  # noqa: N805
-    ) -> Dict[str, Any]:
+    def _add_deployment_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Add names to deployments that are missing them."""
         deployments = values.get("deployments", [])
         for i, deployment in enumerate(deployments):

--- a/runway/config/models/runway/options/terraform.py
+++ b/runway/config/models/runway/options/terraform.py
@@ -61,7 +61,7 @@ class RunwayTerraformModuleOptionsDataModel(ConfigProperty):
 
     @validator("args", pre=True)
     def _convert_args(
-        cls, v: Union[List[str], Dict[str, List[str]]]  # noqa: N805
+        cls, v: Union[List[str], Dict[str, List[str]]]
     ) -> Dict[str, List[str]]:
         """Convert args from list to dict."""
         if isinstance(v, list):

--- a/runway/module/staticsite/options/models.py
+++ b/runway/module/staticsite/options/models.py
@@ -37,7 +37,7 @@ class RunwayStaticSiteExtraFileDataModel(ConfigProperty):
 
     @root_validator
     def _autofill_content_type(  # pylint: disable=no-self-argument,no-self-use
-        cls, values: Dict[str, Any]  # noqa: N805
+        cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Attempt to fill content_type if not provided."""
         if values.get("content_type"):
@@ -51,7 +51,7 @@ class RunwayStaticSiteExtraFileDataModel(ConfigProperty):
 
     @root_validator(pre=True)
     def _validate_content_or_file(  # pylint: disable=no-self-argument,no-self-use
-        cls, values: Dict[str, Any]  # noqa: N805
+        cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Validate that content or file is provided."""
         content = values.get("content")

--- a/runway/module/staticsite/parameters/models.py
+++ b/runway/module/staticsite/parameters/models.py
@@ -177,9 +177,7 @@ class RunwayStaticSiteModuleParametersDataModel(ConfigProperty):
         "supported_identity_providers",
         pre=True,
     )
-    def _convert_comma_delimited_list(
-        cls, v: Union[List[str], str]  # noqa: N805
-    ) -> List[str]:
+    def _convert_comma_delimited_list(cls, v: Union[List[str], str]) -> List[str]:
         """Convert comma delimited lists to a string."""
         if isinstance(v, str):
             return [i.strip() for i in v.split(",")]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,8 @@
 [flake8]
+classmethod-decorators =
+    classmethod,
+    root_validator,
+    validator
 docstring-convention = all
 exclude =
     *.egg-info,


### PR DESCRIPTION
# What Changed

## Added

- added `classmethod-decorators` section to flake8 config with pydantic decorators

## Removed

- removed inline `# noqa: N805` comments as they are no longer needed
