### PR TITLE
hooks: fix issue preventing `ssm.parameter` from being used more than once

### DIFF
--- a/runway/cfngin/hooks/ssm/parameter.py
+++ b/runway/cfngin/hooks/ssm/parameter.py
@@ -1,4 +1,5 @@
 """AWS SSM Parameter Store hooks."""
+# pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
 import json
@@ -79,8 +80,7 @@ class ArgsDataModel(BaseModel):
         allow_population_by_field_name = True
         extra = Extra.ignore
 
-    @validator("policies", pre=True)
-    @classmethod
+    @validator("policies", allow_reuse=True, pre=True)
     def _convert_policies(cls, v: Union[List[Dict[str, Any]], str, Any]) -> str:
         """Convert policies to acceptable value."""
         if isinstance(v, str):
@@ -91,8 +91,7 @@ class ArgsDataModel(BaseModel):
             f"unexpected type {type(v)}; permitted: Optional[Union[List[Dict[str, Any]], str]]"
         )
 
-    @validator("tags", pre=True)
-    @classmethod
+    @validator("tags", allow_reuse=True, pre=True)
     def _convert_tags(
         cls, v: Union[Dict[str, str], List[Dict[str, str]], Any]
     ) -> List[Dict[str, str]]:

--- a/runway/utils/__init__.py
+++ b/runway/utils/__init__.py
@@ -27,9 +27,11 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Optional,
+    Set,
     Type,
     Union,
     cast,
@@ -354,10 +356,10 @@ class SafeHaven(ContextManager["SafeHaven"]):
     # pylint: disable=redefined-outer-name
     def __init__(
         self,
-        argv: Optional[List[str]] = None,
+        argv: Optional[Iterable[str]] = None,
         environ: Optional[Dict[str, str]] = None,
-        sys_modules_exclude: Optional[List[str]] = None,
-        sys_path: Optional[List[str]] = None,
+        sys_modules_exclude: Optional[Iterable[str]] = None,
+        sys_path: Optional[Iterable[str]] = None,
     ) -> None:
         """Instantiate class.
 
@@ -378,7 +380,10 @@ class SafeHaven(ContextManager["SafeHaven"]):
         self.__sys_path = list(sys.path)
         # more informative origin for log statements
         self.logger = logging.getLogger("runway." + self.__class__.__name__)
-        self.sys_modules_exclude = sys_modules_exclude or []
+        self.sys_modules_exclude: Set[str] = (
+            set(sys_modules_exclude) if sys_modules_exclude else set()
+        )
+        self.sys_modules_exclude.add("runway")
 
         if isinstance(argv, list):
             sys.argv = argv


### PR DESCRIPTION
# Why This Is Needed

If `runway.cfngin.hooks.ssm.parameter.SecureString` is used more than once, the following error is raised.

```
pydantic.errors.ConfigError: duplicate validator function "runway.cfngin.hooks.ssm.parameter.ArgsDataModel._convert_policies"; if this is intended, set `allow_reuse=True`
```

The is due to how Runway imports/"reloads" hooks.

Related to https://github.com/samuelcolvin/pydantic/issues/940.

# What Changed

## Fixed

- fixed an issue preventing `runway.cfngin.hooks.ssm.parameter` from being used more than once
