### PR TITLE
hooks: fix issue causing `ssm.parameter` to fail if param does not exist

### DIFF
--- a/runway/cfngin/hooks/ssm/parameter.py
+++ b/runway/cfngin/hooks/ssm/parameter.py
@@ -237,32 +237,39 @@ class _Parameter(CfnginHookProtocol):
         else:
             diff_tag_keys = [i["Key"] for i in current_tags]
 
-        if diff_tag_keys:
-            diff_tag_keys.sort()
-            self.client.remove_tags_from_resource(
-                ResourceId=self.args.name,
-                ResourceType="Parameter",
-                TagKeys=diff_tag_keys,
-            )
-            LOGGER.debug(
-                "removed tags for parameter %s: %s", self.args.name, diff_tag_keys
-            )
+        try:
+            if diff_tag_keys:
+                diff_tag_keys.sort()
+                self.client.remove_tags_from_resource(
+                    ResourceId=self.args.name,
+                    ResourceType="Parameter",
+                    TagKeys=diff_tag_keys,
+                )
+                LOGGER.debug(
+                    "removed tags for parameter %s: %s", self.args.name, diff_tag_keys
+                )
 
-        if self.args.tags:
-            tags_to_add = [
-                cast("TagTypeDef", tag.dict(by_alias=True)) for tag in self.args.tags
-            ]
-            self.client.add_tags_to_resource(
-                ResourceId=self.args.name,
-                ResourceType="Parameter",
-                Tags=tags_to_add,
+            if self.args.tags:
+                tags_to_add = [
+                    cast("TagTypeDef", tag.dict(by_alias=True))
+                    for tag in self.args.tags
+                ]
+                self.client.add_tags_to_resource(
+                    ResourceId=self.args.name,
+                    ResourceType="Parameter",
+                    Tags=tags_to_add,
+                )
+                LOGGER.debug(
+                    "added tags to parameter %s: %s",
+                    self.args.name,
+                    [tag["Key"] for tag in tags_to_add],
+                )
+        except self.client.exceptions.InvalidResourceId:
+            LOGGER.info(
+                "skipped updating tags; parameter %s does not exist", self.args.name
             )
-            LOGGER.debug(
-                "added tags to parameter %s: %s",
-                self.args.name,
-                [tag["Key"] for tag in tags_to_add],
-            )
-        LOGGER.info("updated tags for parameter %s", self.args.name)
+        else:
+            LOGGER.info("updated tags for parameter %s", self.args.name)
 
 
 class SecureString(_Parameter):

--- a/tests/unit/cfngin/hooks/ssm/test_parameter.py
+++ b/tests/unit/cfngin/hooks/ssm/test_parameter.py
@@ -597,6 +597,7 @@ class TestParameter:
             ).update_tags()
         ssm_stubber.assert_no_pending_responses()
         assert "skipped updating tags; parameter test does not exist" in caplog.messages
+        assert "updated tags for parameter test" not in caplog.messages
 
 
 class TestSecureString:

--- a/tests/unit/cfngin/hooks/ssm/test_parameter.py
+++ b/tests/unit/cfngin/hooks/ssm/test_parameter.py
@@ -522,6 +522,22 @@ class TestParameter:
                 cfngin_context, name="test", tags=new_tags, type="String"
             ).update_tags()
 
+    def test_update_tags_add_only_raise_client_error(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture, ssm_stubber: Stubber
+    ) -> None:
+        """Test update_tags raise ClientError."""
+        new_tags = [
+            {"Key": "new", "Value": "new-value"},
+            {"Key": "retain", "Value": "retain"},
+        ]
+        mocker.patch.object(Parameter, "get_current_tags", return_value=[])
+        ssm_stubber.add_client_error("add_tags_to_resource")
+        with ssm_stubber, pytest.raises(ClientError):
+            assert Parameter(
+                cfngin_context, name="test", tags=new_tags, type="String"
+            ).update_tags()
+        ssm_stubber.assert_no_pending_responses()
+
     def test_update_tags_delete_only(
         self, cfngin_context: CfnginContext, mocker: MockerFixture, ssm_stubber: Stubber
     ) -> None:
@@ -545,6 +561,42 @@ class TestParameter:
             assert not Parameter(
                 cfngin_context, name="test", type="String"
             ).update_tags()
+
+    def test_update_tags_delete_only_raise_client_error(
+        self, cfngin_context: CfnginContext, mocker: MockerFixture, ssm_stubber: Stubber
+    ) -> None:
+        """Test update_tags raise ClientError."""
+        current_tags = [
+            {"Key": "new", "Value": "current-value"},
+            {"Key": "retain", "Value": "retain"},
+        ]
+        mocker.patch.object(Parameter, "get_current_tags", return_value=current_tags)
+        ssm_stubber.add_client_error("remove_tags_from_resource")
+        with ssm_stubber, pytest.raises(ClientError):
+            assert Parameter(cfngin_context, name="test", type="String").update_tags()
+        ssm_stubber.assert_no_pending_responses()
+
+    def test_update_tags_handle_invalid_resource_id(
+        self,
+        caplog: LogCaptureFixture,
+        cfngin_context: CfnginContext,
+        mocker: MockerFixture,
+        ssm_stubber: Stubber,
+    ) -> None:
+        """Test update_tags handle InvalidResourceId. Can only happen during add."""
+        caplog.set_level(LogLevels.INFO, logger=MODULE)
+        new_tags = [
+            {"Key": "new", "Value": "new-value"},
+            {"Key": "retain", "Value": "retain"},
+        ]
+        mocker.patch.object(Parameter, "get_current_tags", return_value=[])
+        ssm_stubber.add_client_error("add_tags_to_resource", "InvalidResourceId")
+        with ssm_stubber:
+            assert not Parameter(
+                cfngin_context, name="test", tags=new_tags, type="String"
+            ).update_tags()
+        ssm_stubber.assert_no_pending_responses()
+        assert "skipped updating tags; parameter test does not exist" in caplog.messages
 
 
 class TestSecureString:


### PR DESCRIPTION
# Why This Is Needed

When using `runway.cfngin.hooks.ssm.parameter`, if the parameter does not exist and it was not created by the hook the following exception is raised:

```
botocore.errorfactory.InvalidResourceId: An error occurred (InvalidResourceId) when calling the AddTagsToResource operation: 
```

The is because adding/removing tags is not skipped if the parameter does not exist and the method did not catch the exception raised when it does not exist.

# What Changed

## Fixed

- fixed issue causing `runway.cfngin.hooks.ssm.parameter` to fail if the parameter does not exist or was not created
  - the error is now correctly caught and an appropriate skip message is logged 
