### PR TITLE
staticsite: add support for CloudFormation service role

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -67,8 +67,10 @@
         "codecov",
         "FQDNs",
         "fstring",
+        "hashextra",
         "markexpr",
         "Ngin",
+        "openid",
         "rglob",
         "typeshed",
         "unsubscriptable"

--- a/docs/source/cfngin/configuration.rst
+++ b/docs/source/cfngin/configuration.rst
@@ -380,7 +380,7 @@ Top-Level Fields
     By default CFNgin doesn't specify a service role when executing changes to CloudFormation stacks.
     If you would prefer that it do so, you define the IAM Role ARN that CFNgin should use when executing CloudFormation changes.
 
-    This is the equivalent of setting ``RoleARN`` on a call to the following CloudFormation api calls: ``CreateStack``, ``UpdateStack``, ``CreateChangeSet``.
+    This is the equivalent of setting ``RoleARN`` on a call to the following CloudFormation API calls: ``CreateStack``, ``UpdateStack``, ``CreateChangeSet``.
 
     See the `AWS CloudFormation service role <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html?icmpid=docs_cfn_console>`__ for more information.
 

--- a/docs/source/staticsite/configuration.rst
+++ b/docs/source/staticsite/configuration.rst
@@ -130,6 +130,22 @@ Options
 Parameters
 **********
 
+.. data:: cloudformation_service_role
+  :type: Optional[str]
+  :value: None
+  :noindex:
+
+  IAM Role ARN that CloudFormation will use when creating, deleting and updating
+  the CloudFormation stack resources.
+
+  See the `AWS CloudFormation service role <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html?icmpid=docs_cfn_console>`__ for more information.
+
+  .. rubric:: Example
+  .. code-block:: yaml
+
+    parameters:
+      cloudformation_service_role: arn:aws:iam::123456789012:role/name
+
 .. data:: namespace
   :type: str
   :noindex:

--- a/runway/module/staticsite/handler.py
+++ b/runway/module/staticsite/handler.py
@@ -580,9 +580,10 @@ class StaticSite(RunwayModule):
     def _get_client_updater_variables(
         self, name: str, site_stack_variables: Dict[str, Any]
     ) -> Dict[str, Any]:
-        aliases = [add_url_scheme(x) for x in site_stack_variables["Aliases"]]
         return {
-            "alternate_domains": aliases,
+            "alternate_domains": [
+                add_url_scheme(x) for x in site_stack_variables["Aliases"]
+            ],
             "client_id": f"${{rxref {self.name}-dependencies::AuthAtEdgeClient}}",
             "distribution_domain": f"${{rxref {name}::CFDistributionDomainName}}",
             "oauth_scopes": site_stack_variables["OAuthScopes"],

--- a/runway/module/staticsite/parameters/models.py
+++ b/runway/module/staticsite/parameters/models.py
@@ -88,6 +88,7 @@ class RunwayStaticSiteModuleParametersDataModel(ConfigProperty):
             rewrite directory indexes.
         role_boundary_arn: Defines an IAM Managed Policy that will be set as the
             permissions boundary for any IAM Roles created to support the site.
+        service_role: IAM role that CloudFormation will use.
         sign_out_url: The path a user should access to sign themselves out of the
             application.
         supported_identity_providers: A comma delimited list of the User Pool
@@ -158,6 +159,7 @@ class RunwayStaticSiteModuleParametersDataModel(ConfigProperty):
         None, alias="staticsite_rewrite_directory_index"
     )
     role_boundary_arn: Optional[str] = Field(None, alias="staticsite_role_boundary_arn")
+    service_role: Optional[str] = Field(None, alias="cloudformation_service_role")
     sign_out_url: str = Field("/signout", alias="staticsite_sign_out_url")
     supported_identity_providers: List[str] = Field(
         ["COGNITO"], alias="staticsite_supported_identity_providers"

--- a/tests/unit/module/staticsite/conftest.py
+++ b/tests/unit/module/staticsite/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest fixtures and plugins."""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def expected_yaml(local_fixtures: Path) -> Path:
+    """Path to local fixtures expected yaml."""
+    return local_fixtures / "expected_yaml"
+
+
+@pytest.fixture(scope="function")
+def local_fixtures() -> Path:
+    """Local fixtures directory."""
+    return Path(__file__).parent / "fixtures"

--- a/tests/unit/module/staticsite/fixtures/expected_yaml/cleanup.yaml
+++ b/tests/unit/module/staticsite/fixtures/expected_yaml/cleanup.yaml
@@ -1,0 +1,6 @@
+cfngin_bucket: ''
+namespace: ${namespace}
+service_role: null
+stacks:
+  test-cleanup:
+    template_path: ./temp/thisfileisnotused.yaml

--- a/tests/unit/module/staticsite/fixtures/expected_yaml/dependencies.01.yaml
+++ b/tests/unit/module/staticsite/fixtures/expected_yaml/dependencies.01.yaml
@@ -1,0 +1,23 @@
+cfngin_bucket: ''
+namespace: ${namespace}
+pre_deploy: []
+pre_destroy:
+- args:
+    bucket_name: ${rxref test-dependencies::AWSLogBucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+- args:
+    bucket_name: ${rxref test-dependencies::ArtifactsBucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+service_role: null
+stacks:
+  test-dependencies:
+    class_path: runway.blueprints.staticsite.dependencies.Dependencies
+    variables:
+      OAuthScopes:
+      - phone
+      - email
+      - profile
+      - openid
+      - aws.cognito.signin.user.admin

--- a/tests/unit/module/staticsite/fixtures/expected_yaml/dependencies.02.yaml
+++ b/tests/unit/module/staticsite/fixtures/expected_yaml/dependencies.02.yaml
@@ -1,0 +1,40 @@
+cfngin_bucket: ''
+namespace: ${namespace}
+pre_deploy:
+- args:
+    aliases: []
+    stack_name: ${namespace}-test-dependencies
+    user_pool_arn: arn:aws:cognito-idp:<region>:<account-id>:userpool/<pool>
+  data_key: aae_callback_url_retriever
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.callback_url_retriever.get
+  required: true
+- args:
+    user_pool_arn: arn:aws:cognito-idp:<region>:<account-id>:userpool/<pool>
+  data_key: aae_user_pool_id_retriever
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.user_pool_id_retriever.get
+  required: true
+pre_destroy:
+- args:
+    bucket_name: ${rxref test-dependencies::AWSLogBucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+- args:
+    bucket_name: ${rxref test-dependencies::ArtifactsBucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+service_role: aws:arn:iam:123456789012:role/name
+stacks:
+  test-dependencies:
+    class_path: runway.blueprints.staticsite.dependencies.Dependencies
+    variables:
+      AuthAtEdge: true
+      OAuthScopes:
+      - phone
+      - email
+      - profile
+      - openid
+      - aws.cognito.signin.user.admin
+      RedirectPathSignIn: ${default staticsite_redirect_path_sign_in::/parseauth}
+      RedirectPathSignOut: ${default staticsite_redirect_path_sign_out::/}
+      SupportedIdentityProviders:
+      - COGNITO

--- a/tests/unit/module/staticsite/fixtures/expected_yaml/dependencies.03.yaml
+++ b/tests/unit/module/staticsite/fixtures/expected_yaml/dependencies.03.yaml
@@ -1,0 +1,48 @@
+cfngin_bucket: ''
+namespace: ${namespace}
+pre_deploy:
+- args:
+    aliases: []
+    stack_name: ${namespace}-test-dependencies
+    user_pool_arn: null
+  data_key: aae_callback_url_retriever
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.callback_url_retriever.get
+  required: true
+pre_destroy:
+- args:
+    bucket_name: ${rxref test-dependencies::AWSLogBucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+- args:
+    bucket_name: ${rxref test-dependencies::ArtifactsBucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+- args:
+    created_user_pool_id: ${rxref test-dependencies::AuthAtEdgeUserPoolId}
+    user_pool_arn: null
+  data_key: aae_user_pool_id_retriever
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.user_pool_id_retriever.get
+  required: true
+- args:
+    client_id: ${rxref test-dependencies::AuthAtEdgeClient}
+    client_id_output_lookup: test-dependencies::AuthAtEdgeClient
+  data_key: aae_domain_updater
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.domain_updater.delete
+  required: true
+service_role: null
+stacks:
+  test-dependencies:
+    class_path: runway.blueprints.staticsite.dependencies.Dependencies
+    variables:
+      AuthAtEdge: true
+      CreateUserPool: true
+      OAuthScopes:
+      - phone
+      - email
+      - profile
+      - openid
+      - aws.cognito.signin.user.admin
+      RedirectPathSignIn: ${default staticsite_redirect_path_sign_in::/parseauth}
+      RedirectPathSignOut: ${default staticsite_redirect_path_sign_out::/}
+      SupportedIdentityProviders:
+      - COGNITO

--- a/tests/unit/module/staticsite/fixtures/expected_yaml/staticsite.01.yaml
+++ b/tests/unit/module/staticsite/fixtures/expected_yaml/staticsite.01.yaml
@@ -1,0 +1,64 @@
+cfngin_bucket: ''
+namespace: ${namespace}
+post_deploy:
+- args:
+    bucket_name: ${cfn ${namespace}-test.BucketName}
+    cf_disabled: false
+    distribution_domain: ${cfn ${namespace}-test.CFDistributionDomainName::default=undefined}
+    distribution_id: ${cfn ${namespace}-test.CFDistributionId::default=undefined}
+    extra_files: []
+    website_url: ${cfn ${namespace}-test.BucketWebsiteURL::default=undefined}
+  path: runway.cfngin.hooks.staticsite.upload_staticsite.sync
+  required: true
+post_destroy:
+- args:
+    parameter_name: ${namespace}-test-hash
+  path: runway.cfngin.hooks.cleanup_ssm.delete_param
+- args:
+    parameter_name: ${namespace}-test-nonce-secret
+  path: runway.cfngin.hooks.cleanup_ssm.delete_param
+- args:
+    parameter_name: ${namespace}-test-hashextra
+  path: runway.cfngin.hooks.cleanup_ssm.delete_param
+pre_deploy:
+- args:
+    artifact_bucket_rxref_lookup: test-dependencies::ArtifactsBucketName
+    options:
+      build_output: ./
+      build_steps: []
+      extra_files: []
+      name: test
+      namespace: ${namespace}
+      path: !module_dir
+      pre_build_steps: []
+      source_hashing:
+        directories:
+        - exclusions: []
+          path: .
+        enabled: true
+        parameter: ${namespace}-test-hash
+  data_key: staticsite
+  path: runway.cfngin.hooks.staticsite.build_staticsite.build
+  required: true
+pre_destroy:
+- args:
+    bucket_name: ${rxref test::BucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+service_role: null
+stacks:
+  test:
+    class_path: runway.blueprints.staticsite.staticsite.StaticSite
+    variables:
+      Aliases: []
+      Compress: true
+      DisableCloudFront: false
+      LogBucketName: ${rxref test-dependencies::AWSLogBucketName}
+      RedirectPathAuthRefresh: ${default staticsite_redirect_path_auth_refresh::/refreshauth}
+      RedirectPathSignIn: ${default staticsite_redirect_path_sign_in::/parseauth}
+      RedirectPathSignOut: ${default staticsite_redirect_path_sign_out::/}
+      RewriteDirectoryIndex: ''
+      SignOutUrl: ${default staticsite_sign_out_url::/signout}
+      WAFWebACL: ''
+      custom_error_responses: []
+      lambda_function_associations: []

--- a/tests/unit/module/staticsite/fixtures/expected_yaml/staticsite.02.yaml
+++ b/tests/unit/module/staticsite/fixtures/expected_yaml/staticsite.02.yaml
@@ -120,6 +120,7 @@ stacks:
       RedirectPathSignIn: ${default staticsite_redirect_path_sign_in::/parseauth}
       RedirectPathSignOut: ${default staticsite_redirect_path_sign_out::/}
       RewriteDirectoryIndex: ''
+      RoleBoundaryArn: aws:arn:iam:123456789012:policy/name
       SignOutUrl: ${default staticsite_sign_out_url::/signout}
       UserPoolArn: arn:aws:cognito-idp:<region>:<account-id>:userpool/<pool>
       WAFWebACL: ''

--- a/tests/unit/module/staticsite/fixtures/expected_yaml/staticsite.02.yaml
+++ b/tests/unit/module/staticsite/fixtures/expected_yaml/staticsite.02.yaml
@@ -1,0 +1,127 @@
+cfngin_bucket: ''
+namespace: ${namespace}
+post_deploy:
+- args:
+    alternate_domains: []
+    client_id: ${rxref test-dependencies::AuthAtEdgeClient}
+    distribution_domain: ${rxref test::CFDistributionDomainName}
+    oauth_scopes: &id001
+    - phone
+    - email
+    - profile
+    - openid
+    - aws.cognito.signin.user.admin
+    redirect_path_sign_in: ${default staticsite_redirect_path_sign_in::/parseauth}
+    redirect_path_sign_out: ${default staticsite_redirect_path_sign_out::/}
+    supported_identity_providers:
+    - COGNITO
+  data_key: client_updater
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.client_updater.update
+  required: true
+- args:
+    bucket_name: ${cfn ${namespace}-test.BucketName}
+    cf_disabled: false
+    distribution_domain: ${cfn ${namespace}-test.CFDistributionDomainName::default=undefined}
+    distribution_id: ${cfn ${namespace}-test.CFDistributionId::default=undefined}
+    extra_files: []
+    website_url: ${cfn ${namespace}-test.BucketWebsiteURL::default=undefined}
+  path: runway.cfngin.hooks.staticsite.upload_staticsite.sync
+  required: true
+post_destroy:
+- args:
+    parameter_name: ${namespace}-test-hash
+  path: runway.cfngin.hooks.cleanup_ssm.delete_param
+- args:
+    parameter_name: ${namespace}-test-nonce-secret
+  path: runway.cfngin.hooks.cleanup_ssm.delete_param
+- args:
+    parameter_name: ${namespace}-test-hashextra
+  path: runway.cfngin.hooks.cleanup_ssm.delete_param
+pre_deploy:
+- args:
+    artifact_bucket_rxref_lookup: test-dependencies::ArtifactsBucketName
+    options:
+      build_output: ./
+      build_steps: []
+      extra_files: []
+      name: test
+      namespace: ${namespace}
+      path: !module_dir
+      pre_build_steps: []
+      source_hashing:
+        directories:
+        - exclusions: []
+          path: .
+        enabled: true
+        parameter: ${namespace}-test-hash
+  data_key: staticsite
+  path: runway.cfngin.hooks.staticsite.build_staticsite.build
+  required: true
+- args:
+    user_pool_arn: arn:aws:cognito-idp:<region>:<account-id>:userpool/<pool>
+  data_key: aae_user_pool_id_retriever
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.user_pool_id_retriever.get
+  required: true
+- args:
+    client_id: ${rxref test-dependencies::AuthAtEdgeClient}
+    client_id_output_lookup: test-dependencies::AuthAtEdgeClient
+  data_key: aae_domain_updater
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.domain_updater.update
+  required: true
+- args:
+    bucket: ${rxref test-dependencies::ArtifactsBucketName}
+    client_id: ${rxref test-dependencies::AuthAtEdgeClient}
+    cookie_settings: &id002
+      accessToken: Path=/; Secure; SameSite=Lax
+      idToken: Path=/; Secure; SameSite=Lax
+      nonce: Path=/; Secure; HttpOnly; Max-Age=1800; SameSite=Lax
+      refreshToken: Path=/; Secure; SameSite=Lax
+    http_headers: &id003
+      Content-Security-Policy: 'default-src https: ''unsafe-eval'' ''unsafe-inline'';
+        font-src ''self'' ''unsafe-inline'' ''unsafe-eval'' data: https:; object-src
+        ''none''; connect-src ''self'' https://*.amazonaws.com https://*.amazoncognito.com'
+      Referrer-Policy: same-origin
+      Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options: nosniff
+      X-Frame-Options: DENY
+      X-XSS-Protection: 1; mode=block
+    nonce_signing_secret_param_name: ${namespace}-test-nonce-secret
+    oauth_scopes: *id001
+    redirect_path_refresh: ${default staticsite_redirect_path_auth_refresh::/refreshauth}
+    redirect_path_sign_in: ${default staticsite_redirect_path_sign_in::/parseauth}
+    redirect_path_sign_out: ${default staticsite_redirect_path_sign_out::/}
+    required_group: null
+  data_key: aae_lambda_config
+  path: runway.cfngin.hooks.staticsite.auth_at_edge.lambda_config.write
+  required: true
+pre_destroy:
+- args:
+    bucket_name: ${rxref test::BucketName}
+  path: runway.cfngin.hooks.cleanup_s3.purge_bucket
+  required: true
+- args:
+    stack_relative_name: test
+  path: runway.cfngin.hooks.staticsite.cleanup.warn
+  required: false
+service_role: aws:arn:iam:123456789012:role/name
+stacks:
+  test:
+    class_path: runway.blueprints.staticsite.auth_at_edge.AuthAtEdge
+    variables:
+      Aliases: []
+      Compress: true
+      CookieSettings: *id002
+      DisableCloudFront: false
+      HttpHeaders: *id003
+      LogBucketName: ${rxref test-dependencies::AWSLogBucketName}
+      NonSPAMode: false
+      OAuthScopes: *id001
+      RedirectPathAuthRefresh: ${default staticsite_redirect_path_auth_refresh::/refreshauth}
+      RedirectPathSignIn: ${default staticsite_redirect_path_sign_in::/parseauth}
+      RedirectPathSignOut: ${default staticsite_redirect_path_sign_out::/}
+      RewriteDirectoryIndex: ''
+      SignOutUrl: ${default staticsite_sign_out_url::/signout}
+      UserPoolArn: arn:aws:cognito-idp:<region>:<account-id>:userpool/<pool>
+      WAFWebACL: ''
+      custom_error_responses: []
+      lambda_function_associations: []

--- a/tests/unit/module/staticsite/parameters/test_models.py
+++ b/tests/unit/module/staticsite/parameters/test_models.py
@@ -139,6 +139,7 @@ class TestRunwayStaticSiteModuleParametersDataModel:
         assert not obj.required_group
         assert not obj.rewrite_directory_index
         assert not obj.role_boundary_arn
+        assert not obj.service_role
         assert obj.sign_out_url == "/signout"
         assert obj.supported_identity_providers == ["COGNITO"]
         assert not obj.user_pool_arn
@@ -157,6 +158,7 @@ class TestRunwayStaticSiteModuleParametersDataModel:
     def test_init(self) -> None:
         """Test init."""
         data = {
+            "cloudformation_service_role": "aws:arn:iam:123456789012:role/name",
             "staticsite_acmcert_arn": "aws:arn:acm:us-east-1:cert:test",
             "staticsite_additional_redirect_domains": ["github.com"],
             "staticsite_aliases": ["test-alias"],
@@ -226,6 +228,7 @@ class TestRunwayStaticSiteModuleParametersDataModel:
         assert obj.required_group == data["staticsite_required_group"]
         assert obj.rewrite_directory_index == data["staticsite_rewrite_directory_index"]
         assert obj.role_boundary_arn == data["staticsite_role_boundary_arn"]
+        assert obj.service_role == data["cloudformation_service_role"]
         assert obj.sign_out_url == data["staticsite_sign_out_url"]
         assert (
             obj.supported_identity_providers

--- a/tests/unit/module/staticsite/test_handler.py
+++ b/tests/unit/module/staticsite/test_handler.py
@@ -54,19 +54,6 @@ class TestStaticSite:
         )
         assert obj.path == tmp_path
 
-    def test_init(
-        self, caplog: LogCaptureFixture, runway_context: RunwayContext, tmp_path: Path
-    ) -> None:
-        """Test init."""
-        caplog.set_level(logging.WARNING, logger=MODULE)
-        obj = StaticSite(
-            runway_context, module_root=tmp_path, parameters={"namespace": "test"}
-        )
-        assert not obj.init()
-        assert (
-            f"init not currently supported for {StaticSite.__name__}" in caplog.messages
-        )
-
     def test_create_cleanup_yaml(
         self,
         expected_yaml: Path,
@@ -94,11 +81,15 @@ class TestStaticSite:
             (
                 {
                     "cloudformation_service_role": "aws:arn:iam:123456789012:role/name",
-                    "staticsite_auth_at_edge": "true",
+                    "staticsite_auth_at_edge": True,
                     "staticsite_user_pool_arn": "arn:aws:cognito-idp:<region>:<account-id>"
                     ":userpool/<pool>",
                 },
                 "02",
+            ),
+            (
+                {"staticsite_auth_at_edge": True, "staticsite_create_user_pool": True},
+                "03",
             ),
         ],
     )
@@ -131,7 +122,8 @@ class TestStaticSite:
             (
                 {
                     "cloudformation_service_role": "aws:arn:iam:123456789012:role/name",
-                    "staticsite_auth_at_edge": "true",
+                    "staticsite_auth_at_edge": True,
+                    "staticsite_role_boundary_arn": "aws:arn:iam:123456789012:policy/name",
                     "staticsite_user_pool_arn": "arn:aws:cognito-idp:<region>:<account-id>"
                     ":userpool/<pool>",
                 },
@@ -159,3 +151,146 @@ class TestStaticSite:
         assert obj._create_staticsite_yaml(tmp_path).read_text() == SafeStringTemplate(
             (expected_yaml / f"staticsite.{test_file_number}.yaml").read_text()
         ).safe_substitute(module_dir=tmp_path)
+
+    def test_deploy(
+        self, mocker: MockerFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test deploy."""
+        mock_setup_website_module = mocker.patch.object(
+            StaticSite, "_setup_website_module", return_value=None
+        )
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            parameters={"namespace": "test", "staticsite_auth_at_edge": True},
+        )
+        assert not obj.deploy()
+        mock_setup_website_module.assert_called_once_with(command="deploy")
+
+    def test_destroy(
+        self, mocker: MockerFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test destroy."""
+        mock_setup_website_module = mocker.patch.object(
+            StaticSite, "_setup_website_module", return_value=None
+        )
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            parameters={"namespace": "test", "staticsite_auth_at_edge": True},
+        )
+        assert not obj.destroy()
+        mock_setup_website_module.assert_called_once_with(command="destroy")
+
+    def test_ensure_auth_at_edge_requirements_exit(
+        self, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test _ensure_auth_at_edge_requirements."""
+        with pytest.raises(SystemExit):
+            StaticSite(
+                runway_context,
+                module_root=tmp_path,
+                parameters={"namespace": "test", "staticsite_auth_at_edge": True},
+            )._ensure_auth_at_edge_requirements()
+
+    def test_ensure_cloudfront_with_auth_at_edge_exit(
+        self, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test _ensure_cloudfront_with_auth_at_edge."""
+        with pytest.raises(SystemExit):
+            StaticSite(
+                runway_context,
+                module_root=tmp_path,
+                parameters={
+                    "namespace": "test",
+                    "staticsite_auth_at_edge": True,
+                    "staticsite_cf_disable": True,
+                },
+            )
+
+    def test_ensure_correct_region_with_auth_at_edge_exit(
+        self, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test _ensure_correct_region_with_auth_at_edge."""
+        runway_context.env.aws_region = "us-west-2"
+        with pytest.raises(SystemExit):
+            StaticSite(
+                runway_context,
+                module_root=tmp_path,
+                parameters={"namespace": "test", "staticsite_auth_at_edge": True},
+            )
+
+    def test_ensure_valid_environment_config_exit(
+        self, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test _ensure_valid_environment_config."""
+        with pytest.raises(SystemExit):
+            StaticSite(
+                runway_context, module_root=tmp_path, parameters={"namespace": ""}
+            )
+
+    def test_get_client_updater_variables(
+        self, mocker: MockerFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test _get_client_updater_variables."""
+        mock_add_url_scheme = mocker.patch(
+            f"{MODULE}.add_url_scheme", return_value="success"
+        )
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            name="test",
+            parameters={"namespace": "test", "staticsite_auth_at_edge": True},
+        )
+        site_stack_variables = {
+            "Aliases": ["example.com"],
+            "OAuthScopes": "scopes",
+            "RedirectPathSignIn": "signin",
+            "RedirectPathSignOut": "signout",
+        }
+        result = obj._get_client_updater_variables("test", site_stack_variables)
+        mock_add_url_scheme.assert_called_once_with(site_stack_variables["Aliases"][0])
+        assert result["alternate_domains"] == [mock_add_url_scheme.return_value]
+        assert "rxref test-" in result["client_id"]
+        assert "rxref test::" in result["distribution_domain"]
+        assert result["oauth_scopes"] == site_stack_variables["OAuthScopes"]
+        assert (
+            result["redirect_path_sign_in"]
+            == site_stack_variables["RedirectPathSignIn"]
+        )
+        assert (
+            result["redirect_path_sign_out"]
+            == site_stack_variables["RedirectPathSignOut"]
+        )
+        assert (
+            result["supported_identity_providers"]
+            == obj.parameters.supported_identity_providers
+        )
+
+    def test_init(
+        self, caplog: LogCaptureFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test init."""
+        caplog.set_level(logging.WARNING, logger=MODULE)
+        obj = StaticSite(
+            runway_context, module_root=tmp_path, parameters={"namespace": "test"}
+        )
+        assert not obj.init()
+        assert (
+            f"init not currently supported for {StaticSite.__name__}" in caplog.messages
+        )
+
+    def test_plan(
+        self, mocker: MockerFixture, runway_context: RunwayContext, tmp_path: Path
+    ) -> None:
+        """Test plan."""
+        mock_setup_website_module = mocker.patch.object(
+            StaticSite, "_setup_website_module", return_value=None
+        )
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            parameters={"namespace": "test", "staticsite_auth_at_edge": True},
+        )
+        assert not obj.plan()
+        mock_setup_website_module.assert_called_once_with(command="plan")

--- a/tests/unit/module/staticsite/test_handler.py
+++ b/tests/unit/module/staticsite/test_handler.py
@@ -1,10 +1,14 @@
 """Test runway.module.staticsite.handler."""
-# pylint: disable=no-self-use
+# pylint: disable=no-self-use,protected-access
 # pyright: basic
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import string
+from typing import TYPE_CHECKING, Any, ClassVar, Dict
+
+import pytest
+from mock import Mock
 
 from runway.module.staticsite.handler import StaticSite
 from runway.module.staticsite.options.components import StaticSiteOptions
@@ -16,11 +20,18 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
 
     from runway.context import RunwayContext
 
 
 MODULE = "runway.module.staticsite.handler"
+
+
+class SafeStringTemplate(string.Template):
+    """Custom string.Template subclass that changes the ID pattern."""
+
+    delimiter: ClassVar[str] = "!"
 
 
 class TestStaticSite:
@@ -55,3 +66,96 @@ class TestStaticSite:
         assert (
             f"init not currently supported for {StaticSite.__name__}" in caplog.messages
         )
+
+    def test_create_cleanup_yaml(
+        self,
+        expected_yaml: Path,
+        mocker: MockerFixture,
+        runway_context: RunwayContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test _create_cleanup_yaml."""
+        mocker.patch(f"{MODULE}.tempfile", gettempdir=Mock(return_value="./temp"))
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            name="test",
+            parameters={"namespace": "test"},
+        )
+        assert (
+            obj._create_cleanup_yaml(tmp_path).read_text()
+            == (expected_yaml / "cleanup.yaml").read_text()
+        )
+
+    @pytest.mark.parametrize(
+        "parameters, test_file_number",
+        [
+            ({}, "01"),
+            (
+                {
+                    "cloudformation_service_role": "aws:arn:iam:123456789012:role/name",
+                    "staticsite_auth_at_edge": "true",
+                    "staticsite_user_pool_arn": "arn:aws:cognito-idp:<region>:<account-id>"
+                    ":userpool/<pool>",
+                },
+                "02",
+            ),
+        ],
+    )
+    def test_create_dependencies_yaml(
+        self,
+        expected_yaml: Path,
+        parameters: Dict[str, Any],
+        runway_context: RunwayContext,
+        test_file_number: str,
+        tmp_path: Path,
+    ) -> None:
+        """Test _create_dependencies_yaml."""
+        params = {"namespace": "test"}
+        params.update(parameters)
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            name="test",
+            parameters=params,
+        )
+        assert (
+            obj._create_dependencies_yaml(tmp_path).read_text()
+            == (expected_yaml / f"dependencies.{test_file_number}.yaml").read_text()
+        )
+
+    @pytest.mark.parametrize(
+        "parameters, test_file_number",
+        [
+            ({}, "01"),
+            (
+                {
+                    "cloudformation_service_role": "aws:arn:iam:123456789012:role/name",
+                    "staticsite_auth_at_edge": "true",
+                    "staticsite_user_pool_arn": "arn:aws:cognito-idp:<region>:<account-id>"
+                    ":userpool/<pool>",
+                },
+                "02",
+            ),
+        ],
+    )
+    def test_create_staticsite_yaml(
+        self,
+        expected_yaml: Path,
+        parameters: Dict[str, Any],
+        runway_context: RunwayContext,
+        test_file_number: str,
+        tmp_path: Path,
+    ) -> None:
+        """Test _create_staticsite_yaml."""
+        params = {"namespace": "test"}
+        params.update(parameters)
+        obj = StaticSite(
+            runway_context,
+            module_root=tmp_path,
+            name="test",
+            parameters=params,
+        )
+        assert obj._create_staticsite_yaml(tmp_path).read_text() == SafeStringTemplate(
+            (expected_yaml / f"staticsite.{test_file_number}.yaml").read_text()
+        ).safe_substitute(module_dir=tmp_path)


### PR DESCRIPTION
# Summary

CFNgin has the ability to use a [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html?icmpid=docs_cfn_console) when using CloudFormation. This PR added a parameter to static site modules to enable the use of this feature.

# Why This Is Needed

resolves #820

# What Changed

## Added

- added `cloudformation_service_role` parameter for static site modules
- added unit tests for static site

## Changed

- CFNgin configs produced by the static site module are now sorted to allow for consistent results

## Fixed

- fixed spelling for static site `Compress` variable
- fixed some lookups used in static site
