### PR TITLE
fix issue causing `runway.context.BaseContext.get_session()` to use the wrong region when no region is specified

### DIFF
--- a/runway/context/_base.py
+++ b/runway/context/_base.py
@@ -130,7 +130,7 @@ class BaseContext:
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
             botocore_session=Session(),
-            region_name=region,
+            region_name=region or self.env.aws_region,
             profile_name=profile,
         )
         cred_provider = session._session.get_component("credential_provider")  # type: ignore

--- a/tests/unit/context/test_base.py
+++ b/tests/unit/context/test_base.py
@@ -112,7 +112,7 @@ class TestBaseContext:
             aws_secret_access_key=self.env.vars["AWS_SECRET_ACCESS_KEY"],
             aws_session_token=self.env.vars["AWS_SESSION_TOKEN"],
             botocore_session=mock_sso_botocore_session.return_value,
-            region_name=None,
+            region_name=self.env.aws_region,
             profile_name=None,
         )
         mock_boto3_session.return_value._session.get_component.assert_called_once_with(
@@ -137,7 +137,7 @@ class TestBaseContext:
             aws_secret_access_key=TEST_BOTO3_CREDS["aws_secret_access_key"],
             aws_session_token=TEST_BOTO3_CREDS["aws_session_token"],
             botocore_session=mock_sso_botocore_session.return_value,
-            region_name=None,
+            region_name=self.env.aws_region,
             profile_name=None,
         )
 
@@ -152,7 +152,7 @@ class TestBaseContext:
             aws_secret_access_key=None,
             aws_session_token=None,
             botocore_session=mock_sso_botocore_session.return_value,
-            region_name=None,
+            region_name=self.env.aws_region,
             profile_name="something",
         )
 


### PR DESCRIPTION
# Summary

When using `BaseContext.get_session()`, `region_name=None` is passed when creating a boto3 session. This causes boto3 to try to determine what the region should be. Because runway does not push its environment variable changes to `os.environ`, the wrong regions is usually selected.

The current workaround for this issue is to specific a region when creating a session. This includes using lookups in the CFNgin or Runway config file.

Testing shows that this issue affects`runway > 1.18.3`

# What Changed

## Fixed

- fixed issue causing `runway.context.BaseContext.get_session()` to use the wrong region when no region is specified by using the region from the deployment environment as a default value
