### PR TITLE
improve stability of test_rollback_dependant functional test

### DIFF
--- a/tests/functional/cfngin/test_rollback_dependant/test_runner.py
+++ b/tests/functional/cfngin/test_rollback_dependant/test_runner.py
@@ -44,8 +44,8 @@ def test_deploy_log_messages(deploy_result: Result, namespace: str) -> None:
         "dependent-rollback-child:failed (dependency has failed)",
         "The following steps failed: dependent-rollback-parent, dependent-rollback-child",
     ]
-    expected = "\n".join(f"[runway] {msg}" for msg in expected_lines)
-    assert expected in deploy_result.stdout, (
-        "stdout does not match expected\n\nEXPECTED:\n"
-        f"{expected}\n\nSTDOUT:\n{deploy_result.stdout}"
-    )
+    for line in expected_lines:
+        assert f"[runway] {line}" in deploy_result.stdout, (
+            "stdout is missing expected line\n\nEXPECTED:\n"
+            f"{line}\n\nSTDOUT:\n{deploy_result.stdout}"
+        )

--- a/tests/functional/cfngin/test_rollback_dependant/test_runner.py
+++ b/tests/functional/cfngin/test_rollback_dependant/test_runner.py
@@ -36,11 +36,9 @@ def test_deploy_log_messages(deploy_result: Result, namespace: str) -> None:
     expected_lines = [
         "cfngin.yml:deploy (in progress)",
         "dependent-rollback-parent:submitted (creating new stack)",
-        "dependent-rollback-parent:submitted (rolling back new stack)",
         f"{namespace}-dependent-rollback-parent:roll back reason: "
         "The following resource(s) failed to create: [BrokenWaitCondition]. "
         "Rollback requested by user.",
-        "dependent-rollback-parent:failed (rolled back new stack)",
         "dependent-rollback-child:failed (dependency has failed)",
         "The following steps failed: dependent-rollback-parent, dependent-rollback-child",
     ]


### PR DESCRIPTION
# Why This Is Needed

Test can occasionally fail because messages are logged out of order.

# What Changed

## Changed

- stdout is not checked for each individual line instead of a block of lines
- stdout is not checked for lines that can be missing depending on the timing of describe calls
