### PR TITLE
makefile: rename some targets & update options used for cspell

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           node-version: '15'
       - run: make npm-ci
-      - run: make lint-cspell
+      - run: make spellcheck

--- a/Makefile
+++ b/Makefile
@@ -61,19 +61,11 @@ fix-black: ## automatically fix all black errors
 fix-isort: ## automatically fix all isort errors
 	@poetry run isort .
 
-install: ## create a python virtual environment in the project for development
-	@poetry install --extras docs --remove-untracked
-
 lint: lint-isort lint-black lint-pyright lint-flake8 lint-pylint ## run all linters
 
 lint-black: ## run black
 	@echo "Running black... If this fails, run 'make fix-black' to resolve."
 	@poetry run black . --check --color --diff
-	@echo ""
-
-lint-cspell: ## run cspell
-	@echo "Running cSpell to checking spelling..."
-	@npx cspell "**/*" --color --config .vscode/cspell.json --must-find-files
 	@echo ""
 
 lint-flake8: ## run flake8
@@ -115,10 +107,27 @@ npm-prep: version ## process that needs to be run before creating an npm package
 run-pre-commit: ## run pre-commit for all files
 	@poetry run pre-commit run -a
 
-setup: npm-ci install setup-pre-commit ## setup development environment
+setup: setup-poetry setup-pre-commit setup-npm ## setup development environment
+
+setup-npm: npm-ci ## install node dependencies with npm
+
+setup-poetry: ## setup python virtual environment
+	@poetry install \
+		--extras docs \
+		--remove-untracked
 
 setup-pre-commit: ## install pre-commit git hooks
 	@poetry run pre-commit install
+
+spellcheck: ## run cspell
+	@echo "Running cSpell to checking spelling..."
+	@npx cspell "**/*" \
+		--color \
+		--config .vscode/cspell.json \
+		--must-find-files \
+		--no-progress \
+		--relative \
+		--show-context
 
 test: ## run integration and unit tests
 	@echo "Running integration & unit tests..."
@@ -164,9 +173,6 @@ test-unit: ## run unit tests only
 		--cov=runway \
 		--cov-config=tests/unit/.coveragerc \
 		--cov-report term-missing:skip-covered
-
-update: ## update project python environment
-	@poetry update
 
 version: ## set project version using distance from last tag
 	@VERSION=$$(poetry run dunamai from git --style semver --no-metadata) && \


### PR DESCRIPTION
# What Changed

## Added

- added `setup-npm` target

## Changed

- `lint-cspell` target is now `spellcheck`
	- some options were added to the cspell command to improve readability
- `install` target is now `setup-poetry`
- `setup` target now forwards to `setup-npm` instead of `npm-ci`

## Removed

- removed `update` target
