### PR TITLE
fix issue causing `.kubectl-version` in overlay directories to be ignore

### DIFF
--- a/runway/module/k8s.py
+++ b/runway/module/k8s.py
@@ -99,7 +99,7 @@ class K8s(RunwayModule):
     @cached_property
     def kbenv(self) -> KBEnvManager:
         """Kubectl environmet manager."""
-        return KBEnvManager(self.path)
+        return KBEnvManager(self.path, overlay_path=self.options.overlay_path)
 
     @cached_property
     def kubectl_bin(self) -> str:

--- a/tests/unit/module/test_k8s.py
+++ b/tests/unit/module/test_k8s.py
@@ -122,10 +122,13 @@ class TestK8s:
     ) -> None:
         """Test kbenv."""
         mock_env_mgr = mocker.patch(f"{MODULE}.KBEnvManager", return_value="success")
+        overlay_path = mocker.patch(
+            f"{MODULE}.K8sOptions.overlay_path", tmp_path / "overlay"
+        )
         assert (
             K8s(runway_context, module_root=tmp_path).kbenv == mock_env_mgr.return_value
         )
-        mock_env_mgr.assert_called_once_with(tmp_path)
+        mock_env_mgr.assert_called_once_with(tmp_path, overlay_path=overlay_path)
 
     def test_kubectl_apply(
         self,


### PR DESCRIPTION
# Why This Is Needed

Kustomize overlay directory was not being searched for a `.kubectl-version` file. This was due to the path not being passed to `KBEnvManager`.

# What Changed

## Fixed

- fixed an issue causing `.kubectl-version` files in kustomize overlay directories to be ignore
