### PR TITLE
remove `@cspell/dict-python` as an npm dependency - included in `cspell`

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -55,9 +55,6 @@
         "docs/runway-example.yml",
         "typings/**"
     ],
-    "import": [
-        "@cspell/dict-python/cspell-ext.json"
-    ],
     "language": "en",
     "maxNumberOfProblems": 100,
     "version": "0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "runway",
       "version": "2.0.0-dev",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -17,7 +18,6 @@
         "tar": "^6.1.11"
       },
       "devDependencies": {
-        "@cspell/dict-python": "^2.0.4",
         "cspell": "^5.12.3",
         "pyright": "^1.1.182"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@cspell/dict-python": "^2.0.4",
     "cspell": "^5.12.3",
     "pyright": "^1.1.182"
   }


### PR DESCRIPTION
# Summary

Remove `@cspell/dict-python` as an explicit node devDependencies. It is a dependency of `@cspell/cspell-bundled-dicts` which is a dependency of `cspell`.
There is no need at this time to explicitly pin a version.
