### PR TITLE
cfngin: fix issue causing stack with `stack_name` to not be found

### DIFF
--- a/runway/context/_cfngin.py
+++ b/runway/context/_cfngin.py
@@ -367,7 +367,14 @@ class CfnginContext(BaseContext):
             name: Name of a Stack as defined in the config.
 
         """
-        return self.stacks_dict.get(self.get_fqn(name))
+        stack_fqn = self.get_fqn(name)
+        if stack_fqn in self.stacks_dict:  # quickly get stack from fqn
+            return self.stacks_dict[stack_fqn]
+        # account for stack def using stack_name and stack.name was provided
+        for stack in self.stacks:
+            if stack.name == name:
+                return stack
+        return None
 
     def lock_persistent_graph(self, lock_code: str) -> None:
         """Locks the persistent graph in s3.

--- a/tests/unit/context/test_cfngin.py
+++ b/tests/unit/context/test_cfngin.py
@@ -82,6 +82,7 @@ class TestCFNginContext:  # pylint: disable=too-many-public-methods
             "stacks": [
                 {"name": "stack1", "template_path": "."},
                 {"name": "stack2", "template_path": "."},
+                {"name": "stack3", "stack_name": "foobar-stack", "template_path": "."},
             ],
         }
     )
@@ -160,6 +161,13 @@ class TestCFNginContext:  # pylint: disable=too-many-public-methods
         assert obj.get_stack("stack1") == obj.stacks[0]
         assert not obj.get_stack("dev-stack1")
         assert not obj.get_stack("stack12")
+
+    def test_get_stack_def_stack_name(self) -> None:
+        """Test get_stack stack def has stack_name."""
+        obj = CfnginContext(config=self.config)
+        assert obj.get_stack("stack3") == obj.stacks[2]
+        assert obj.get_stack("foobar-stack") == obj.stacks[2]
+        assert obj.get_stack("test-foobar-stack") == obj.stacks[2]
 
     def test_init(self, tmp_path: Path) -> None:
         """Test init."""
@@ -588,6 +596,7 @@ class TestCFNginContext:  # pylint: disable=too-many-public-methods
         assert obj.stacks_dict == {
             "test-stack1": obj.stacks[0],
             "test-stack2": obj.stacks[1],
+            "test-foobar-stack": obj.stacks[2],
         }
 
     def test_stacks(self) -> None:


### PR DESCRIPTION
# Why This Is Needed

resolves #989 

# What Changed

## Fixed

- fixed issue causing stacks that use the `stack_name` field to not be returned by `CfnginContext.get_stack()` when passing the `stack.name`
	- This was caused by a change in v2 that made `.get_stack()` only look for a stack by FQN (for improved performance). The FQN will not always match the input if `stack.name` is passed into the method and `stack_name` is set in the stack's definition. To resolve this, the FQN is tried then it will fall back to checking against `stack.name`.
