### PR TITLE
lookup `TYPE_NAME` is now a ClassVar of `LookupHandler` instead of a constant

### DIFF
--- a/docs/source/cfngin/lookups.rst
+++ b/docs/source/cfngin/lookups.rst
@@ -687,8 +687,8 @@ The lookup must be importable using your current ``sys.path``.
 This takes into account the :attr:`~cfngin.config.sys_path` defined in the config file as well as any ``paths`` of :class:`~cfngin.package_sources`.
 
 The lookup must be a subclass of :class:`~runway.lookups.handlers.base.LookupHandler` with a ``@classmethod`` of ``handle`` with a similar signature to what is provided in the example below.
+The subclass must override the :attr:`~runway.lookups.handlers.base.LookupHandler.TYPE_NAME` class variable with a name that will be used to register the lookup.
 There must be only one lookup per file.
-The file containing the lookup class must have a ``TYPE_NAME`` global variable with a value of the name that will be used to register the lookup.
 
 The lookup must return a string if being used for a CloudFormation parameter.
 
@@ -706,7 +706,7 @@ If using boto3 in a lookup, use :meth:`context.get_session() <runway.context.Cfn
   """Example lookup."""
   from __future__ import annotations
 
-  from typing import TYPE_CHECKING, Any, Optional, Union
+  from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Union
 
   from runway.cfngin.utils import read_value_from_path
   from runway.lookups.handlers.base import LookupHandler
@@ -715,11 +715,12 @@ If using boto3 in a lookup, use :meth:`context.get_session() <runway.context.Cfn
       from runway.cfngin.providers.aws.default import Provider
       from runway.context import CfnginContext, RunwayContext
 
-  TYPE_NAME = "mylookup"
-
 
   class MylookupLookup(LookupHandler):
       """My lookup."""
+
+      TYPE_NAME: Final[Literal["mylookup"]] = "mylookup"
+      """Name that the Lookup is registered as."""
 
       @classmethod
       def handle(

--- a/runway/cfngin/lookups/handlers/ami.py
+++ b/runway/cfngin/lookups/handlers/ami.py
@@ -6,13 +6,13 @@ import operator
 import re
 from typing import TYPE_CHECKING, Any, Dict
 
+from typing_extensions import Final, Literal
+
 from ....lookups.handlers.base import LookupHandler
 from ...utils import read_value_from_path
 
 if TYPE_CHECKING:
     from ....context import CfnginContext
-
-TYPE_NAME = "ami"
 
 
 class ImageNotFound(Exception):
@@ -31,6 +31,9 @@ class ImageNotFound(Exception):
 
 class AmiLookup(LookupHandler):
     """AMI lookup."""
+
+    TYPE_NAME: Final[Literal["ami"]] = "ami"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/default.py
+++ b/runway/cfngin/lookups/handlers/default.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional
 
+from typing_extensions import Final, Literal
+
 from ....lookups.handlers.base import LookupHandler
 
 if TYPE_CHECKING:
     from ....context import CfnginContext
 
-TYPE_NAME = "default"
-
 
 class DefaultLookup(LookupHandler):
     """Lookup to provide a default value."""
+
+    TYPE_NAME: Final[Literal["default"]] = "default"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/dynamodb.py
+++ b/runway/cfngin/lookups/handlers/dynamodb.py
@@ -6,7 +6,7 @@ import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from botocore.exceptions import ClientError
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Final, Literal, TypedDict
 
 from ....lookups.handlers.base import LookupHandler
 from ...utils import read_value_from_path
@@ -14,11 +14,12 @@ from ...utils import read_value_from_path
 if TYPE_CHECKING:
     from ....context import CfnginContext
 
-TYPE_NAME = "dynamodb"
-
 
 class DynamodbLookup(LookupHandler):
     """DynamoDB lookup."""
+
+    TYPE_NAME: Final[Literal["dynamodb"]] = "dynamodb"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/envvar.py
+++ b/runway/cfngin/lookups/handlers/envvar.py
@@ -3,14 +3,17 @@
 import os
 from typing import Any
 
+from typing_extensions import Final, Literal
+
 from ....lookups.handlers.base import LookupHandler
 from ...utils import read_value_from_path
-
-TYPE_NAME = "envvar"
 
 
 class EnvvarLookup(LookupHandler):
     """Environment variable lookup."""
+
+    TYPE_NAME: Final[Literal["envvar"]] = "envvar"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(cls, value: str, **_: Any) -> str:  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/file.py
+++ b/runway/cfngin/lookups/handlers/file.py
@@ -7,11 +7,11 @@ import base64
 import collections.abc
 import json
 import re
-from typing import Any, Callable, Dict, Final, List, Mapping, Sequence, Union, overload
+from typing import Any, Callable, Dict, List, Mapping, Sequence, Union, overload
 
 import yaml
 from troposphere import Base64, GenericHelperFn
-from typing_extensions import Literal
+from typing_extensions import Final, Literal
 
 from ....lookups.handlers.base import LookupHandler
 from ...utils import read_value_from_path

--- a/runway/cfngin/lookups/handlers/file.py
+++ b/runway/cfngin/lookups/handlers/file.py
@@ -7,7 +7,7 @@ import base64
 import collections.abc
 import json
 import re
-from typing import Any, Callable, Dict, List, Mapping, Sequence, Union, overload
+from typing import Any, Callable, Dict, Final, List, Mapping, Sequence, Union, overload
 
 import yaml
 from troposphere import Base64, GenericHelperFn
@@ -15,8 +15,6 @@ from typing_extensions import Literal
 
 from ....lookups.handlers.base import LookupHandler
 from ...utils import read_value_from_path
-
-TYPE_NAME = "file"
 
 _PARAMETER_PATTERN = re.compile(r"{{([::|\w]+)}}")
 
@@ -30,6 +28,9 @@ ParameterizedObjectReturnTypeDef = Union[
 
 class FileLookup(LookupHandler):
     """File lookup."""
+
+    TYPE_NAME: Final[Literal["file"]] = "file"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(cls, value: str, **_: Any) -> Any:

--- a/runway/cfngin/lookups/handlers/hook_data.py
+++ b/runway/cfngin/lookups/handlers/hook_data.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from troposphere import BaseAWSObject
+from typing_extensions import Final, Literal
 
 from ....lookups.handlers.base import LookupHandler
 from ....utils import MutableMap
@@ -14,11 +15,13 @@ if TYPE_CHECKING:
     from ....context import CfnginContext
 
 LOGGER = logging.getLogger(__name__)
-TYPE_NAME = "hook_data"
 
 
 class HookDataLookup(LookupHandler):
     """Hook data lookup."""
+
+    TYPE_NAME: Final[Literal["hook_data"]] = "hook_data"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/kms.py
+++ b/runway/cfngin/lookups/handlers/kms.py
@@ -5,17 +5,20 @@ from __future__ import annotations
 import codecs
 from typing import TYPE_CHECKING, Any, BinaryIO, Union, cast
 
+from typing_extensions import Final, Literal
+
 from ....lookups.handlers.base import LookupHandler
 from ...utils import read_value_from_path
 
 if TYPE_CHECKING:
     from ....context import CfnginContext
 
-TYPE_NAME = "kms"
-
 
 class KmsLookup(LookupHandler):
     """AWS KMS lookup."""
+
+    TYPE_NAME: Final[Literal["kms"]] = "kms"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/output.py
+++ b/runway/cfngin/lookups/handlers/output.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, NamedTuple, Set
 
+from typing_extensions import Final, Literal
+
 from ....lookups.handlers.base import LookupHandler
 from ...exceptions import StackDoesNotExist
 
 if TYPE_CHECKING:
     from ....context import CfnginContext
     from ....variables import VariableValue
-
-TYPE_NAME = "output"
 
 
 class OutputQuery(NamedTuple):
@@ -24,6 +24,9 @@ class OutputQuery(NamedTuple):
 
 class OutputLookup(LookupHandler):
     """AWS CloudFormation Output lookup."""
+
+    TYPE_NAME: Final[Literal["output"]] = "output"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/rxref.py
+++ b/runway/cfngin/lookups/handlers/rxref.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import Final, Literal
+
 from ....lookups.handlers.base import LookupHandler
 from .output import deconstruct
 
@@ -11,11 +13,12 @@ if TYPE_CHECKING:
     from ....context import CfnginContext
     from ...providers.aws.default import Provider
 
-TYPE_NAME = "rxref"
-
 
 class RxrefLookup(LookupHandler):
     """Rxref lookup."""
+
+    TYPE_NAME: Final[Literal["rxref"]] = "rxref"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/split.py
+++ b/runway/cfngin/lookups/handlers/split.py
@@ -2,13 +2,16 @@
 # pyright: reportIncompatibleMethodOverride=none
 from typing import Any, List
 
-from ....lookups.handlers.base import LookupHandler
+from typing_extensions import Final, Literal
 
-TYPE_NAME = "split"
+from ....lookups.handlers.base import LookupHandler
 
 
 class SplitLookup(LookupHandler):
     """Split lookup."""
+
+    TYPE_NAME: Final[Literal["split"]] = "split"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/cfngin/lookups/handlers/xref.py
+++ b/runway/cfngin/lookups/handlers/xref.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import Final, Literal
+
 from ....lookups.handlers.base import LookupHandler
 from .output import deconstruct
 
@@ -12,7 +14,6 @@ if TYPE_CHECKING:
     from ...providers.aws.default import Provider
 
 LOGGER = logging.getLogger(__name__)
-TYPE_NAME = "xref"
 
 XREF_PRESISTENT_STATE = {"has_warned": False}
 
@@ -21,6 +22,8 @@ class XrefLookup(LookupHandler):
     """Xref lookup."""
 
     DEPRECATION_MSG = "xref Lookup has been deprecated; use the cfn lookup instead"
+    TYPE_NAME: Final[Literal["xref"]] = "xref"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ,arguments-renamed

--- a/runway/cfngin/lookups/registry.py
+++ b/runway/cfngin/lookups/registry.py
@@ -4,12 +4,23 @@ from __future__ import annotations
 import logging
 from typing import Dict, Type, Union, cast
 
-from ...lookups.handlers import cfn, ecr, random_string, ssm
 from ...lookups.handlers.base import LookupHandler
+from ...lookups.handlers.cfn import CfnLookup
+from ...lookups.handlers.ecr import EcrLookup
+from ...lookups.handlers.random_string import RandomStringLookup
+from ...lookups.handlers.ssm import SsmLookup
 from ...utils import DOC_SITE, load_object_from_string
-from .handlers import ami, default, dynamodb, envvar
-from .handlers import file as file_handler
-from .handlers import hook_data, kms, output, rxref, split, xref
+from .handlers.ami import AmiLookup
+from .handlers.default import DefaultLookup
+from .handlers.dynamodb import DynamodbLookup
+from .handlers.envvar import EnvvarLookup
+from .handlers.file import FileLookup
+from .handlers.hook_data import HookDataLookup
+from .handlers.kms import KmsLookup
+from .handlers.output import OutputLookup
+from .handlers.rxref import RxrefLookup
+from .handlers.split import SplitLookup
+from .handlers.xref import XrefLookup
 
 CFNGIN_LOOKUP_HANDLERS: Dict[str, Type[LookupHandler]] = {}
 LOGGER = logging.getLogger(__name__)
@@ -65,18 +76,18 @@ def unregister_lookup_handler(lookup_type: str) -> None:
     CFNGIN_LOOKUP_HANDLERS.pop(lookup_type, None)
 
 
-register_lookup_handler(ami.TYPE_NAME, ami.AmiLookup)
-register_lookup_handler(cfn.TYPE_NAME, cfn.CfnLookup)
-register_lookup_handler(default.TYPE_NAME, default.DefaultLookup)
-register_lookup_handler(dynamodb.TYPE_NAME, dynamodb.DynamodbLookup)
-register_lookup_handler(ecr.TYPE_NAME, ecr.EcrLookup)
-register_lookup_handler(envvar.TYPE_NAME, envvar.EnvvarLookup)
-register_lookup_handler(file_handler.TYPE_NAME, file_handler.FileLookup)
-register_lookup_handler(hook_data.TYPE_NAME, hook_data.HookDataLookup)
-register_lookup_handler(kms.TYPE_NAME, kms.KmsLookup)
-register_lookup_handler(output.TYPE_NAME, output.OutputLookup)
-register_lookup_handler(random_string.TYPE_NAME, random_string.RandomStringLookup)
-register_lookup_handler(rxref.TYPE_NAME, rxref.RxrefLookup)
-register_lookup_handler(split.TYPE_NAME, split.SplitLookup)
-register_lookup_handler(ssm.TYPE_NAME, ssm.SsmLookup)
-register_lookup_handler(xref.TYPE_NAME, xref.XrefLookup)
+register_lookup_handler(AmiLookup.TYPE_NAME, AmiLookup)
+register_lookup_handler(CfnLookup.TYPE_NAME, CfnLookup)
+register_lookup_handler(DefaultLookup.TYPE_NAME, DefaultLookup)
+register_lookup_handler(DynamodbLookup.TYPE_NAME, DynamodbLookup)
+register_lookup_handler(EcrLookup.TYPE_NAME, EcrLookup)
+register_lookup_handler(EnvvarLookup.TYPE_NAME, EnvvarLookup)
+register_lookup_handler(FileLookup.TYPE_NAME, FileLookup)
+register_lookup_handler(HookDataLookup.TYPE_NAME, HookDataLookup)
+register_lookup_handler(KmsLookup.TYPE_NAME, KmsLookup)
+register_lookup_handler(OutputLookup.TYPE_NAME, OutputLookup)
+register_lookup_handler(RandomStringLookup.TYPE_NAME, RandomStringLookup)
+register_lookup_handler(RxrefLookup.TYPE_NAME, RxrefLookup)
+register_lookup_handler(SplitLookup.TYPE_NAME, SplitLookup)
+register_lookup_handler(SsmLookup.TYPE_NAME, SsmLookup)
+register_lookup_handler(XrefLookup.TYPE_NAME, XrefLookup)

--- a/runway/lookups/handlers/__init__.py
+++ b/runway/lookups/handlers/__init__.py
@@ -1,4 +1,4 @@
-"""Import classes."""
+"""Runway lookup handlers."""
 from . import cfn, ecr, env, random_string, ssm, var
 
 __all__ = ["cfn", "ecr", "env", "random_string", "ssm", "var"]

--- a/runway/lookups/handlers/base.py
+++ b/runway/lookups/handlers/base.py
@@ -4,7 +4,18 @@ from __future__ import annotations
 import json
 import logging
 from distutils.util import strtobool
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Set, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 import yaml
 from troposphere import BaseAWSObject
@@ -25,6 +36,9 @@ TransformToTypeLiteral = Literal["bool", "str"]
 
 class LookupHandler:
     """Base class for lookup handlers."""
+
+    TYPE_NAME: ClassVar[str]
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def dependencies(cls, __lookup_query: VariableValue) -> Set[str]:

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -12,6 +12,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, NamedTuple, Optional, Union, cast
 
 from botocore.exceptions import ClientError
+from typing_extensions import Final, Literal
 
 from ...cfngin.exceptions import StackDoesNotExist
 from ...exceptions import OutputDoesNotExist
@@ -24,7 +25,6 @@ if TYPE_CHECKING:
     from ...context import CfnginContext, RunwayContext
 
 LOGGER = logging.getLogger(__name__)
-TYPE_NAME = "cfn"
 
 
 class OutputQuery(NamedTuple):
@@ -36,6 +36,9 @@ class OutputQuery(NamedTuple):
 
 class CfnLookup(LookupHandler):
     """CloudFormation Stack Output lookup."""
+
+    TYPE_NAME: Final[Literal["cfn"]] = "cfn"
+    """Name that the Lookup is registered as."""
 
     @staticmethod
     def should_use_provider(args: Dict[str, str], provider: Optional[Provider]) -> bool:

--- a/runway/lookups/handlers/ecr.py
+++ b/runway/lookups/handlers/ecr.py
@@ -5,6 +5,8 @@ import base64
 import logging
 from typing import TYPE_CHECKING, Any, Union  # pylint: disable=W
 
+from typing_extensions import Final, Literal
+
 from ...lookups.handlers.base import LookupHandler
 
 if TYPE_CHECKING:
@@ -14,11 +16,12 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-TYPE_NAME = "ecr"
-
 
 class EcrLookup(LookupHandler):
     """ECR Lookup."""
+
+    TYPE_NAME: Final[Literal["ecr"]] = "ecr"
+    """Name that the Lookup is registered as."""
 
     @staticmethod
     def get_login_password(client: ECRClient) -> str:

--- a/runway/lookups/handlers/env.py
+++ b/runway/lookups/handlers/env.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import Final, Literal
+
 from .base import LookupHandler
 
 if TYPE_CHECKING:
     from ...context import RunwayContext
 
-TYPE_NAME = "env"
-
 
 class EnvLookup(LookupHandler):
     """Environment variable Lookup."""
+
+    TYPE_NAME: Final[Literal["env"]] = "env"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/lookups/handlers/random_string.py
+++ b/runway/lookups/handlers/random_string.py
@@ -7,13 +7,13 @@ import secrets
 import string
 from typing import TYPE_CHECKING, Any, Callable, List, Sequence, Union
 
+from typing_extensions import Final, Literal
+
 from ...utils import BaseModel
 from .base import LookupHandler
 
 if TYPE_CHECKING:
     from ...context import CfnginContext, RunwayContext
-
-TYPE_NAME = "random.string"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +29,9 @@ class ArgsDataModel(BaseModel):
 
 class RandomStringLookup(LookupHandler):
     """Random string lookup."""
+
+    TYPE_NAME: Final[Literal["random.string"]] = "random.string"
+    """Name that the Lookup is registered as."""
 
     @staticmethod
     def calculate_char_set(args: ArgsDataModel) -> str:

--- a/runway/lookups/handlers/ssm.py
+++ b/runway/lookups/handlers/ssm.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Union
 
+from typing_extensions import Final, Literal
+
 from ...lookups.handlers.base import LookupHandler
 
 if TYPE_CHECKING:
     from ...context import CfnginContext, RunwayContext
 
 LOGGER = logging.getLogger(__name__)
-TYPE_NAME = "ssm"
 
 
 class SsmLookup(LookupHandler):
     """SSM Parameter Store Lookup."""
+
+    TYPE_NAME: Final[Literal["ssm"]] = "ssm"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/lookups/handlers/var.py
+++ b/runway/lookups/handlers/var.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import Final, Literal
+
 from .base import LookupHandler
 
 if TYPE_CHECKING:
@@ -17,6 +19,9 @@ TYPE_NAME = "var"
 
 class VarLookup(LookupHandler):
     """Variable definition Lookup."""
+
+    TYPE_NAME: Final[Literal["var"]] = "var"
+    """Name that the Lookup is registered as."""
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ

--- a/runway/lookups/registry.py
+++ b/runway/lookups/registry.py
@@ -5,8 +5,13 @@ import logging
 from typing import Dict, Type, Union, cast
 
 from ..utils import load_object_from_string
-from .handlers import cfn, ecr, env, random_string, ssm, var
 from .handlers.base import LookupHandler
+from .handlers.cfn import CfnLookup
+from .handlers.ecr import EcrLookup
+from .handlers.env import EnvLookup
+from .handlers.random_string import RandomStringLookup
+from .handlers.ssm import SsmLookup
+from .handlers.var import VarLookup
 
 RUNWAY_LOOKUP_HANDLERS: Dict[str, Type[LookupHandler]] = {}
 LOGGER = logging.getLogger(__name__)
@@ -54,9 +59,9 @@ def unregister_lookup_handler(lookup_type: str) -> None:
     RUNWAY_LOOKUP_HANDLERS.pop(lookup_type, None)
 
 
-register_lookup_handler(cfn.TYPE_NAME, cfn.CfnLookup)
-register_lookup_handler(ecr.TYPE_NAME, ecr.EcrLookup)
-register_lookup_handler(env.TYPE_NAME, env.EnvLookup)
-register_lookup_handler(random_string.TYPE_NAME, random_string.RandomStringLookup)
-register_lookup_handler(ssm.TYPE_NAME, ssm.SsmLookup)
-register_lookup_handler(var.TYPE_NAME, var.VarLookup)
+register_lookup_handler(CfnLookup.TYPE_NAME, CfnLookup)
+register_lookup_handler(EcrLookup.TYPE_NAME, EcrLookup)
+register_lookup_handler(EnvLookup.TYPE_NAME, EnvLookup)
+register_lookup_handler(RandomStringLookup.TYPE_NAME, RandomStringLookup)
+register_lookup_handler(SsmLookup.TYPE_NAME, SsmLookup)
+register_lookup_handler(VarLookup.TYPE_NAME, VarLookup)

--- a/tests/unit/lookups/handlers/test_cfn.py
+++ b/tests/unit/lookups/handlers/test_cfn.py
@@ -17,7 +17,7 @@ from mock import MagicMock
 from runway.cfngin.exceptions import StackDoesNotExist
 from runway.cfngin.providers.aws.default import Provider
 from runway.exceptions import OutputDoesNotExist
-from runway.lookups.handlers.cfn import TYPE_NAME, CfnLookup, OutputQuery
+from runway.lookups.handlers.cfn import CfnLookup, OutputQuery
 
 if TYPE_CHECKING:
     from mypy_boto3_cloudformation.client import CloudFormationClient
@@ -352,8 +352,3 @@ def test_outputquery() -> None:
     result = OutputQuery("stack_name", "output_name")
     assert result.stack_name == "stack_name"
     assert result.output_name == "output_name"
-
-
-def test_type_name() -> None:
-    """Test runway.lookups.handlers.cfn.TYPE_NAME."""
-    assert TYPE_NAME == "cfn"


### PR DESCRIPTION
# Summary

Lookup type names are now set using a class variable set on the lookup class instead of using a constant defined in the same module as the handler class.

# What Changed

## Added

- added `runway.lookups.handlers.base.LookupHandler.TYPE_NAME` class variable

## Changed

- all lookup handlers now override the `LookupHandler.TYPE_NAME` class variable with the value that was used in the removed `TYPE_NAME` constant

## Removed

- removed `TYPE_NAME` constant from all lookup handlers
