### PR TITLE
fix intermittent pylint error

### DIFF
--- a/tests/unit/module/test_base.py
+++ b/tests/unit/module/test_base.py
@@ -1,5 +1,6 @@
 """Test runway.module.base."""
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=comparison-with-callable,no-self-use,unused-argument
+# comparison-with-callable is intermittent - possibly due to use of runway.compat?
 # pyright: basic
 from __future__ import annotations
 


### PR DESCRIPTION
# Why This Is Needed

Occasionally `comparison-with-callable` is flagged in the file on different lines. 