### PR TITLE
add `runway.mixins.DelCachedPropMixin`

### DIFF
--- a/runway/cfngin/actions/init.py
+++ b/runway/cfngin/actions/init.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from ...compat import cached_property
@@ -124,10 +123,9 @@ class Action(BaseAction):
             LOGGER.notice("using default blueprint to create cfngin_bucket...")
             self.context.config.stacks = [self.default_cfngin_bucket_stack]
             # clear cached values that were populated by checking the previous condition
-            with suppress(AttributeError):
-                del self.context.stacks_dict
-            with suppress(AttributeError):
-                del self.context.stacks
+            self.context._del_cached_property(  # pylint: disable=protected-access
+                "stacks", "stacks_dict"
+            )
         if self.provider_builder:
             self.provider_builder.region = self.context.bucket_region
         deploy.Action(

--- a/runway/cfngin/blueprints/base.py
+++ b/runway/cfngin/blueprints/base.py
@@ -21,6 +21,7 @@ from typing import (
 from troposphere import Output, Parameter, Ref, Template
 
 from ...compat import cached_property
+from ...mixins import DelCachedPropMixin
 from ...variables import Variable
 from ..exceptions import (
     InvalidUserdataPlaceholder,
@@ -291,7 +292,7 @@ def parse_user_data(
     return res
 
 
-class Blueprint:
+class Blueprint(DelCachedPropMixin):
     """Base implementation for rendering a troposphere template.
 
     Attributes:
@@ -510,14 +511,7 @@ class Blueprint:
         """
         self._resolved_variables = value
         # clear cached properties that rely on this property
-        try:
-            del self.cfn_parameters
-        except Exception:  # pylint: disable=broad-except
-            pass
-        try:
-            del self.parameter_values
-        except Exception:  # pylint: disable=broad-except
-            pass
+        self._del_cached_property("cfn_parameters", "parameter_values")
 
     @property
     def version(self) -> str:

--- a/runway/cfngin/blueprints/raw.py
+++ b/runway/cfngin/blueprints/raw.py
@@ -182,10 +182,7 @@ class RawTemplateBlueprint(Blueprint):  # pylint: disable=abstract-method
             else:
                 raise InvalidConfig(f"Could not find template {self.raw_template_path}")
             # clear cached properties that rely on this property
-            try:
-                del self.parameter_definitions
-            except Exception:  # pylint: disable=broad-except
-                pass
+            self._del_cached_property("parameter_definitions")
 
         return self._rendered
 
@@ -254,9 +251,5 @@ class RawTemplateBlueprint(Blueprint):  # pylint: disable=abstract-method
             value = resolve_variable(variable_dict.get(var_name), self.name)
             if value is not None:
                 self._resolved_variables[var_name] = value
-
         # clear cached properties that rely on the property set by this
-        try:
-            del self.parameter_values
-        except Exception:  # pylint: disable=broad-except
-            pass
+        self._del_cached_property("parameter_values")

--- a/runway/context/_base.py
+++ b/runway/context/_base.py
@@ -9,6 +9,7 @@ import boto3
 from ..aws_sso_botocore.session import Session
 from ..cfngin.ui import ui
 from ..constants import BOTO3_CREDENTIAL_CACHE
+from ..mixins import DelCachedPropMixin
 from ..type_defs import Boto3CredentialsTypeDef
 from .sys_info import SystemInfo
 
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 
 
-class BaseContext:
+class BaseContext(DelCachedPropMixin):
     """Base class for context objects."""
 
     env: DeployEnvironment

--- a/runway/core/components/_deploy_environment.py
+++ b/runway/core/components/_deploy_environment.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 import click
 
 from ...compat import cached_property
+from ...mixins import DelCachedPropMixin
 from ...type_defs import EnvVarsAwsCredentialsTypeDef
 from ...utils import AWS_ENV_VARS
 
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
 
 
-class DeployEnvironment:
+class DeployEnvironment(DelCachedPropMixin):
     """Runway deploy environment."""
 
     __name: Optional[str]
@@ -167,14 +168,11 @@ class DeployEnvironment:
         """
         if self._ignore_git_branch != value:
             self._ignore_git_branch = value
-            try:
-                del self.name
-                LOGGER.debug(
-                    "value of ignore_git_branch has changed; "
-                    "cleared cached name so it can be determined again"
-                )
-            except AttributeError:
-                pass  # it's fine if it does not exist yes
+            self._del_cached_property("name")
+            LOGGER.debug(
+                "value of ignore_git_branch has changed; "
+                "cleared cached name so it can be determined again"
+            )
 
     @property
     def max_concurrent_cfngin_stacks(self) -> int:

--- a/runway/core/providers/aws/s3/_bucket.py
+++ b/runway/core/providers/aws/s3/_bucket.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 from botocore.exceptions import ClientError
 
 from .....compat import cached_property
+from .....mixins import DelCachedPropMixin
 from .._response import BaseResponse
 from ._sync_handler import S3SyncHandler
 
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__.replace("._", "."))
 
 
-class Bucket:
+class Bucket(DelCachedPropMixin):
     """AWS S3 bucket."""
 
     def __init__(
@@ -119,9 +120,7 @@ class Bucket:
                 {"LocationConstraint": self.client.meta.region_name}
             )
         LOGGER.debug("creating bucket: %s", json.dumps(kwargs))
-        del self.not_found  # clear cached value
-        del self.forbidden  # clear cached value
-        del self.head  # clear cached value
+        self._del_cached_property("forbidden", "not_found", "head")
         return self.client.create_bucket(**kwargs)
 
     def enable_versioning(self) -> None:

--- a/runway/env_mgr/__init__.py
+++ b/runway/env_mgr/__init__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Generator, Optional, Union, cast
 
 from ..compat import cached_property
+from ..mixins import DelCachedPropMixin
 
 if TYPE_CHECKING:
     from urllib.error import URLError
@@ -51,7 +52,7 @@ def handle_bin_download_error(exc: URLError, name: str) -> None:
     sys.exit(1)
 
 
-class EnvManager:
+class EnvManager(DelCachedPropMixin):
     """Base environment manager class.
 
     Attributes:

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -268,10 +268,7 @@ class KBEnvManager(EnvManager):
         if self.current_version == version:
             return
         self.current_version = version
-        try:
-            del self.version
-        except Exception:  # pylint: disable=broad-except
-            pass
+        self._del_cached_property("version")
 
     @classmethod
     def parse_version_string(cls, version: str) -> Version:

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -384,10 +384,7 @@ class TFEnvManager(EnvManager):
         if self.current_version == version:
             return
         self.current_version = version
-        try:
-            del self.version
-        except Exception:  # pylint: disable=broad-except
-            pass
+        self._del_cached_property("version")
 
     @classmethod
     def get_version_from_executable(

--- a/runway/mixins.py
+++ b/runway/mixins.py
@@ -1,0 +1,26 @@
+"""Class mixins."""
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from runway._logging import RunwayLogger
+
+LOGGER = cast("RunwayLogger", logging.getLogger(f"runway.{__name__}"))
+
+
+class DelCachedPropMixin:
+    """Mixin to handle safely clearing the value of :func:`functools.cached_property`."""
+
+    def _del_cached_property(self, *names: str) -> None:
+        """Delete the cached value of a :func:`functools.cached_property`.
+
+        Args:
+            names: Names of the attribute that is cached. Can provide one or multiple.
+
+        """
+        for name in names:
+            with suppress(AttributeError):
+                delattr(self, name)

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -20,6 +20,7 @@ from ..config.models.runway.options.terraform import (
     RunwayTerraformModuleOptionsDataModel,
 )
 from ..env_mgr.tfenv import TFEnvManager
+from ..mixins import DelCachedPropMixin
 from ..utils import DOC_SITE, Version, which
 from .base import ModuleOptions, RunwayModule
 from .utils import run_module_command
@@ -75,7 +76,7 @@ TerraformActionTypeDef = Literal[
 ]
 
 
-class Terraform(RunwayModule):
+class Terraform(RunwayModule, DelCachedPropMixin):
     """Terraform Runway Module."""
 
     options: TerraformOptions
@@ -518,7 +519,7 @@ class Terraform(RunwayModule):
             env_vars=self.ctx.env.vars,
             logger=self.logger,
         )
-        del self.current_workspace
+        self._del_cached_property("current_workspace")
 
     def terraform_workspace_show(self) -> str:
         """Execute ``terraform workspace show`` command.

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -1,0 +1,39 @@
+"""Test runway.mixins."""
+# pylint: disable=no-self-use,protected-access
+from __future__ import annotations
+
+from runway.compat import cached_property
+from runway.mixins import DelCachedPropMixin
+
+MODULE = "runway.mixins"
+
+
+class TestDelCachedPropMixin:
+    """Test DelCachedPropMixin."""
+
+    class Kls(DelCachedPropMixin):
+        """Used in tests."""
+
+        counter = 0
+
+        @cached_property
+        def test_prop(self) -> str:
+            """Test property."""
+            self.counter += 1
+            return "foobar"
+
+    def test__del_cached_property(self) -> None:
+        """Test _del_cached_property."""
+        obj = self.Kls()
+        # ensure suppression is working as expected
+        assert obj.counter == 0
+        assert not obj._del_cached_property("test_prop")
+        assert obj.test_prop == "foobar"
+        assert obj.counter == 1
+        # ensure value is cached and not being evaluated each call
+        assert obj.test_prop == "foobar"
+        assert obj.counter == 1
+        # this would fail if the suppresion was outside the loop
+        assert not obj._del_cached_property("invalid", "test_prop")
+        assert obj.test_prop == "foobar"
+        assert obj.counter == 2


### PR DESCRIPTION
# Summary

Add a mixin for easily deleting cached properties that accounts for the property not being resulted yet.

# What Changed

## Added

- added `runway.mixins.DelCachedPropMixin`

## Changed

- updated uses of `contextlib.suppress` and try blocks for deleting cached properties to use the newly added mixin which adds a method for handling safe deletion of cached properties
