### PR TITLE
`runway.cfngin.hooks.base.Hook.ARGS_PARSER` is now a `ClassVar`

### DIFF
--- a/docs/source/cfngin/hooks/index.rst
+++ b/docs/source/cfngin/hooks/index.rst
@@ -194,10 +194,13 @@ These can then be used to parse the values provided in the :attr:`~cfngin.hook.a
 
   """My hook."""
   import logging
-  from typing import Any, Dict, Optional
+  from typing import TYPE_CHECKING, Any, Dict, Optional
 
   from runway.utils import BaseModel
   from runway.cfngin.hooks.protocols import CfnginHookProtocol
+
+  if TYPE_CHECKING:
+      from ...context import CfnginContext
 
   LOGGER = logging.getLogger(__name__)
 
@@ -238,9 +241,19 @@ These can then be used to parse the values provided in the :attr:`~cfngin.hook.a
 
       args: MyClassArgs
 
-      def __init__(self, **kwargs: Any) -> None:
-          """Instantiate class."""
-          self.args = MyClassArgs.parse_obj(kwargs)
+      def __init__(self, context: CfnginContext, **kwargs: Any) -> None:
+          """Instantiate class.
+
+          Args:
+              context: Context instance. (passed in by CFNgin)
+              provider: Provider instance. (passed in by CFNgin)
+
+          """
+          kwargs.setdefault("tags", {})
+
+          self.args = self.ARGS_PARSER.parse_obj(kwargs)
+          self.args.tags.update(context.tags)
+          self.context = context
 
       def post_deploy(self) -> Optional[Dict[str, str]]:
           """Run during the **post_deploy** stage."""

--- a/runway/cfngin/hooks/acm.py
+++ b/runway/cfngin/hooks/acm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Type
 
 from botocore.exceptions import ClientError
 from troposphere import Ref
@@ -79,7 +79,7 @@ class Certificate(Hook):
 
     """
 
-    ARGS_PARSER = HookArgs
+    ARGS_PARSER: ClassVar[Type[HookArgs]] = HookArgs
 
     acm_client: ACMClient
     args: HookArgs

--- a/runway/cfngin/hooks/base.py
+++ b/runway/cfngin/hooks/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union, cast
 
 from troposphere import Tags
 
@@ -45,7 +45,8 @@ class Hook(CfnginHookProtocol):
 
     """
 
-    ARGS_PARSER: Type[HookArgsBaseModel] = HookArgsBaseModel
+    ARGS_PARSER: ClassVar[Type[HookArgsBaseModel]] = HookArgsBaseModel
+    """Class used to parse arguments passed to the hook."""
 
     args: HookArgsBaseModel
     blueprint: Optional[Blueprint] = None

--- a/runway/cfngin/hooks/protocols.py
+++ b/runway/cfngin/hooks/protocols.py
@@ -77,6 +77,7 @@ class CfnginHookProtocol(Protocol):
     """
 
     args: CfnginHookArgsProtocol
+    """Arguments passed to the hook and parsed into an object."""
 
     @abstractmethod
     def __init__(  # pylint: disable=super-init-not-called


### PR DESCRIPTION
# Why This Is Needed

resolves #920

# What Changed

## Changed

- `runway.cfngin.hooks.base.Hook.ARGS_PARSER` is now a `ClassVar` to better reflect it's purpose
