### PR TITLE
use `pydantic` for `runway.core.providers.aws._response`

### DIFF
--- a/runway/core/providers/aws/_response.py
+++ b/runway/core/providers/aws/_response.py
@@ -1,75 +1,64 @@
 """Base class for AWS responses."""
 # pylint: disable=invalid-name
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict
+
+from pydantic import Field
+
+from ....utils import BaseModel
 
 
-class ResponseError:
+class ResponseError(BaseModel):
     """Analyse the response from AWS S3 HeadBucket API response.
 
-    Attributes:
-        code: A unique short code representing the error that was emitted.
-        message: A longer human readable error message.
+    Keyword Args:
+        Code: A unique short code representing the error that was emitted.
+        Message: A longer human readable error message.
 
     """
 
-    def __init__(self, *, Code: str = "", Message: str = "") -> None:  # noqa
-        """Instantiate class.
+    code: str = Field(default="", alias="Code")
+    """A unique short code representing the error that was emitted."""
 
-        Args:
-            Code: A unique short code representing the error that was emitted.
-            Message: A longer human readable error message.
-
-        """
-        self.code = Code
-        self.message = Message
+    message: str = Field(default="", alias="Message")
+    """A longer human readable error message."""
 
     def __bool__(self) -> bool:
         """Implement evaluation of instances as a bool."""
         return bool(self.code or self.message)
 
 
-class ResponseMetadata:
+class ResponseMetadata(BaseModel):
     """Analyse the response from AWS S3 HeadBucket API response.
 
-    Attributes:
-        host_id: Host ID data.
-        https_headers: A map of response header keys and
-            their respective values.
-        http_status_code: The HTTP status code of the response (e.g., 200, 404).
-        request_id: The unique request ID associated with the response.
+    Keyword Args:
+        HostId: Host ID data.
+        HTTPHeaders: A map of response header keys and their respective values.
+        HTTPStatusCode: The HTTP status code of the response (e.g., 200, 404).
+        RequestId: The unique request ID associated with the response.
             Log this value when debugging requests for AWS support.
-        retry_attempts: The number of retries that were attempted
-            before the request was completed.
+        RetryAttempts: The number of retries that were attempted before the
+            request was completed.
 
     """
 
-    def __init__(
-        self,
-        *,
-        HostId: Optional[str] = None,  # noqa
-        HTTPHeaders: Optional[Dict[str, Any]] = None,  # noqa
-        HTTPStatusCode: int = 200,  # noqa
-        RequestId: Optional[str] = None,  # noqa
-        RetryAttempts: int = 0,  # noqa
-    ) -> None:
-        """Instantiate class.
+    host_id: str = Field(default="", alias="HostId")
+    """Host ID data."""
 
-        Keyword Args:
-            HostId: Host ID data.
-            HTTPHeaders: A map of response header keys and their respective values.
-            HTTPStatusCode: The HTTP status code of the response (e.g., 200, 404).
-            RequestId: The unique request ID associated with the response.
-                Log this value when debugging requests for AWS support.
-            RetryAttempts: The number of retries that were attempted before the
-                request was completed.
+    https_headers: Dict[str, Any] = Field(default={}, alias="HTTPHeaders")
+    """A map of response header keys and their respective values."""
 
-        """
-        self.host_id = HostId
-        self.https_headers = HTTPHeaders or {}
-        self.http_status_code = HTTPStatusCode
-        self.request_id = RequestId
-        self.retry_attempts = RetryAttempts
+    http_status_code: int = Field(default=200, alias="HTTPStatusCode")
+    """he HTTP status code of the response (e.g., 200, 404)."""
+
+    request_id: str = Field(default="", alias="RequestId")
+    """The unique request ID associated with the response.
+    Log this value when debugging requests for AWS support.
+
+    """
+
+    retry_attempts: int = Field(default=0, alias="RetryAttempts")
+    """The number of retries that were attempted before the request was completed."""
 
     @property
     def forbidden(self) -> bool:
@@ -82,22 +71,19 @@ class ResponseMetadata:
         return self.http_status_code == HTTPStatus.NOT_FOUND
 
 
-class BaseResponse:
+class BaseResponse(BaseModel):
     """Analyse the response from AWS S3 HeadBucket API response.
 
-    Attributes:
-        error: Information about a service or networking error.
-        metadata: Information about the request.
+    Keyword Args:
+        Error: Information about a service or networking error.
+        ResponseMetadata: Information about the request.
 
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        """Instantiate class.
+    error: ResponseError = Field(default=ResponseError(), alias="Error")
+    """Information about a service or networking error."""
 
-        Keyword Args:
-            Error: Information about a service or networking error.
-            ResponseMetadata: Information about the request.
-
-        """
-        self.error = ResponseError(**kwargs.pop("Error", {}))  # type: ignore
-        self.metadata = ResponseMetadata(**kwargs.pop("ResponseMetadata", {}))  # type: ignore
+    metadata: ResponseMetadata = Field(
+        default=ResponseMetadata(), alias="ResponseMetadata"
+    )
+    """Information about the request."""

--- a/runway/core/providers/aws/s3/_bucket.py
+++ b/runway/core/providers/aws/s3/_bucket.py
@@ -83,7 +83,7 @@ class Bucket(DelCachedPropMixin):
                 self.name,
                 exc_info=True,
             )
-            return BaseResponse(**err.response)
+            return BaseResponse.parse_obj(err.response)
 
     @cached_property
     def not_found(self) -> bool:

--- a/tests/unit/core/providers/aws/test_response.py
+++ b/tests/unit/core/providers/aws/test_response.py
@@ -3,12 +3,7 @@
 # pyright: basic
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from runway.core.providers.aws import BaseResponse, ResponseError, ResponseMetadata
-
-if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
 
 MODULE = "runway.core.providers.aws._response"
 
@@ -16,7 +11,7 @@ MODULE = "runway.core.providers.aws._response"
 class TestBaseResponse:
     """Test runway.core.providers.aws._response.BaseResponse."""
 
-    def test_init(self, mocker: MockerFixture) -> None:
+    def test_init(self) -> None:
         """Test init and the attributes it sets."""
         data = {"Error": {"Code": "something"}, "ResponseMetadata": {"HostId": "id"}}
         response = BaseResponse(**data.copy())
@@ -26,7 +21,7 @@ class TestBaseResponse:
         assert isinstance(response.metadata, ResponseMetadata)
         assert response.metadata.host_id == data["ResponseMetadata"]["HostId"]
 
-    def test_init_default(self, mocker: MockerFixture) -> None:
+    def test_init_default(self) -> None:
         """Test init default values and the attributes it sets."""
         response = BaseResponse()
         assert response.error == ResponseError()

--- a/tests/unit/core/providers/aws/test_response.py
+++ b/tests/unit/core/providers/aws/test_response.py
@@ -18,26 +18,19 @@ class TestBaseResponse:
 
     def test_init(self, mocker: MockerFixture) -> None:
         """Test init and the attributes it sets."""
-        mock_error = mocker.patch(f"{MODULE}.ResponseError")
-        mock_metadata = mocker.patch(f"{MODULE}.ResponseMetadata")
         data = {"Error": {"Code": "something"}, "ResponseMetadata": {"HostId": "id"}}
         response = BaseResponse(**data.copy())
 
-        assert response.error == mock_error.return_value
-        assert response.metadata == mock_metadata.return_value
-        mock_error.assert_called_once_with(**data["Error"])
-        mock_metadata.assert_called_once_with(**data["ResponseMetadata"])
+        assert isinstance(response.error, ResponseError)
+        assert response.error.code == data["Error"]["Code"]
+        assert isinstance(response.metadata, ResponseMetadata)
+        assert response.metadata.host_id == data["ResponseMetadata"]["HostId"]
 
     def test_init_default(self, mocker: MockerFixture) -> None:
         """Test init default values and the attributes it sets."""
-        mock_error = mocker.patch(f"{MODULE}.ResponseError")
-        mock_metadata = mocker.patch(f"{MODULE}.ResponseMetadata")
         response = BaseResponse()
-
-        assert response.error == mock_error.return_value
-        assert response.metadata == mock_metadata.return_value
-        mock_error.assert_called_once_with()
-        mock_metadata.assert_called_once_with()
+        assert response.error == ResponseError()
+        assert response.metadata == ResponseMetadata()
 
 
 class TestResponseError:


### PR DESCRIPTION
# Why This Is Needed

resolves #918

# What Changed

## Changed

- objects in `runway.core.providers.aws._response` now use `runway.utils.BaseModel` as their base class to improve functionality
