### PR TITLE
change protocol used in git source test

### DIFF
--- a/tests/unit/sources/test_git.py
+++ b/tests/unit/sources/test_git.py
@@ -23,12 +23,12 @@ class TestGit:
             cache_dir=cd_tmp_path,
             location="/",
             options={},
-            uri="git://github.com/onicagroup/runway.git",
+            uri="https://github.com/onicagroup/runway.git",
         ).fetch()
         assert result.parent == cd_tmp_path
         assert "onicagroup_runway" in result.name
 
     def test_sanitize_git_path(self) -> None:
         """Ensure git path is property sanitized."""
-        path = Git.sanitize_git_path("git://github.com/onicagroup/runway.git")
+        path = Git.sanitize_git_path("https://github.com/onicagroup/runway.git")
         assert path == "github.com_onicagroup_runway"


### PR DESCRIPTION
# Why This Is Needed

https://github.blog/2021-09-01-improving-git-protocol-security-github/

> January 11, 2022
>
> Final brownout. This is the full brownout period where we’ll temporarily stop accepting the deprecated key and signature types, ciphers, and MACs, and the unencrypted Git protocol. This will help clients discover any lingering use of older keys or old URLs.

The final brownout caused the `git://` protocol used in the test to fail with the following error:

```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
