### PR TITLE
pass `encoding` when opening a file in text mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,6 @@ disable = [
   "missing-module-docstring",  # flake8 (pydocstyle) overlap
   "similarities",  # black overcomplicated this
   "ungrouped-imports", # false positive when using TYPE_CHECKING; isort should cover this
-  "unspecified-encoding",  # TODO remove
 ]
 
 [tool.pylint.typecheck]

--- a/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
+++ b/runway/_cli/commands/_gen_sample/_k8s_cfn_repo.py
@@ -1,4 +1,5 @@
 """``runway gen-sample k8s-cfn`` command."""
+import locale
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -37,18 +38,22 @@ def k8s_cfn_repo(ctx: click.Context, **_: Any) -> None:
     env = {"namespace": "test"}
 
     LOGGER.verbose("rendering master templates...")
+    encoding = locale.getpreferredencoding(do_setlocale=False)
     master_templates.mkdir()
     (master_templates / "k8s_iam.yaml").write_text(
-        to_yaml(Iam("test", CfnginContext(environment=env.copy())).to_json())
+        to_yaml(Iam("test", CfnginContext(environment=env.copy())).to_json()),
+        encoding=encoding,
     )
     (master_templates / "k8s_master.yaml").write_text(
-        to_yaml(Cluster("test", CfnginContext(environment=env.copy())).to_json())
+        to_yaml(Cluster("test", CfnginContext(environment=env.copy())).to_json()),
+        encoding=encoding,
     )
 
     LOGGER.verbose("rendering worker templates...")
     worker_templates.mkdir()
     (worker_templates / "k8s_workers.yaml").write_text(
-        to_yaml(NodeGroup("test", CfnginContext(environment=env.copy())).to_json())
+        to_yaml(NodeGroup("test", CfnginContext(environment=env.copy())).to_json()),
+        encoding=encoding,
     )
 
     LOGGER.success("Sample k8s infrastructure repo created at %s", dest)

--- a/runway/_cli/commands/_gen_sample/_tf.py
+++ b/runway/_cli/commands/_gen_sample/_tf.py
@@ -1,4 +1,5 @@
 """``runway gen-sample tf`` command."""
+import locale
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -28,6 +29,9 @@ def tf(ctx: click.Context, **_: Any) -> None:  # pylint: disable=invalid-name
     copy_sample(ctx, src, dest)
 
     if not (src / ".terraform-version").is_file():
-        (dest / ".terraform-version").write_text(get_latest_tf_version())
+        (dest / ".terraform-version").write_text(
+            get_latest_tf_version(),
+            encoding=locale.getpreferredencoding(do_setlocale=False),
+        )
 
     LOGGER.success("Sample Terraform app created at %s", dest)

--- a/runway/_cli/commands/_new.py
+++ b/runway/_cli/commands/_new.py
@@ -1,5 +1,6 @@
 """``runway new`` command."""
 # docs: file://./../../../docs/source/commands.rst
+import locale
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -40,7 +41,9 @@ def new(ctx: click.Context, **_: Any) -> None:
         )
         ctx.exit(1)
 
-    runway_yml.write_text(RUNWAY_YML)
+    runway_yml.write_text(
+        RUNWAY_YML, encoding=locale.getpreferredencoding(do_setlocale=False)
+    )
     LOGGER.success("runway.yml generated")
     LOGGER.notice(
         "See addition getting started information at "

--- a/runway/_cli/commands/_run_python.py
+++ b/runway/_cli/commands/_run_python.py
@@ -1,5 +1,6 @@
 """``runway run-python`` command."""
 # docs: file://./../../../docs/source/commands.rst
+import locale
 from pathlib import Path
 from typing import Any
 
@@ -32,5 +33,9 @@ def run_python(filename: str, **_: Any) -> None:
     # override name & file so script operates as if it were invoked directly
     execglobals.update({"__name__": "__main__", "__file__": filename})
     exec(  # pylint: disable=exec-used
-        Path(filename).read_text(), execglobals, execglobals
+        Path(filename).read_text(
+            encoding=locale.getpreferredencoding(do_setlocale=False)
+        ),
+        execglobals,
+        execglobals,
     )

--- a/runway/_cli/commands/_schema/_cfngin.py
+++ b/runway/_cli/commands/_schema/_cfngin.py
@@ -1,6 +1,7 @@
 """Output CFNgin configuration file schema."""
 from __future__ import annotations
 
+import locale
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
@@ -46,7 +47,9 @@ def cfngin(indent: int, output: Optional[str], **_: Any) -> None:
     content = CfnginConfigDefinitionModel.schema_json(indent=indent)
     if output:
         file_path = Path(output).absolute()
-        file_path.write_text(content + "\n")  # append empty line to end of file
+        file_path.write_text(  # append empty line to end of file
+            content + "\n", encoding=locale.getpreferredencoding(do_setlocale=False)
+        )
         LOGGER.success("output JSON schema to %s", file_path)
     else:
         click.echo(content)

--- a/runway/_cli/commands/_schema/_runway.py
+++ b/runway/_cli/commands/_schema/_runway.py
@@ -1,6 +1,7 @@
 """Output Runway configuration file schema."""
 from __future__ import annotations
 
+import locale
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
@@ -46,7 +47,9 @@ def runway(indent: int, output: Optional[str], **_: Any) -> None:
     content = RunwayConfigDefinitionModel.schema_json(indent=indent)
     if output:
         file_path = Path(output).absolute()
-        file_path.write_text(content + "\n")  # append empty line to end of file
+        file_path.write_text(  # append empty line to end of file
+            content + "\n", encoding=locale.getpreferredencoding(do_setlocale=False)
+        )
         LOGGER.success("output JSON schema to %s", file_path)
     else:
         click.echo(content)

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import locale
 import logging
 import os
 import shutil
@@ -623,7 +624,10 @@ def _zip_package(  # pylint: disable=too-many-locals,too-many-statements
                     '   runpy.run_module("pip", run_name="__main__")\n',
                 ]
             )
-            tmp_script.write_text(script_contents)
+            tmp_script.write_text(
+                script_contents,
+                encoding=locale.getpreferredencoding(do_setlocale=False),
+            )
             cmd = [sys.executable, "run-python", str(tmp_script)]
         else:
             if not _pip_has_no_color_option(pip_cmd[0]):

--- a/runway/cfngin/utils.py
+++ b/runway/cfngin/utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import locale
 import logging
 import os
 import re
@@ -379,7 +380,9 @@ def read_value_from_path(value: str, *, root_path: Optional[Path] = None) -> str
             else:
                 read_path = root_path.parent / path
         if read_path.is_file():
-            return read_path.read_text()
+            return read_path.read_text(
+                encoding=locale.getpreferredencoding(do_setlocale=False)
+            )
         if read_path.is_dir():
             raise ValueError(
                 f"path must lead to a file not directory: {read_path.absolute()}"

--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import locale
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -357,7 +358,9 @@ class CfnginConfigDefinitionModel(ConfigProperty):
         return cast(
             "Model",
             cls.parse_raw(
-                path.read_text() if isinstance(path, Path) else Path(path).read_text(),
+                Path(path).read_text(
+                    encoding=locale.getpreferredencoding(do_setlocale=False)
+                ),
                 content_type=content_type,  # type: ignore
                 encoding=encoding,
                 proto=proto,  # type: ignore

--- a/runway/config/models/runway/__init__.py
+++ b/runway/config/models/runway/__init__.py
@@ -2,6 +2,7 @@
 # pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
+import locale
 import logging
 from pathlib import Path
 from typing import (
@@ -643,7 +644,9 @@ class RunwayConfigDefinitionModel(ConfigProperty):
         return cast(
             "Model",
             cls.parse_raw(
-                path.read_text() if isinstance(path, Path) else Path(path).read_text(),
+                Path(path).read_text(
+                    encoding=locale.getpreferredencoding(do_setlocale=False)
+                ),
                 content_type=content_type,  # type: ignore
                 encoding=encoding,
                 proto=proto,  # type: ignore

--- a/runway/dependency_managers/_pipenv.py
+++ b/runway/dependency_managers/_pipenv.py
@@ -1,6 +1,7 @@
 """Pipenv interface."""
 from __future__ import annotations
 
+import locale
 import logging
 import re
 import subprocess
@@ -110,5 +111,7 @@ class Pipenv(DependencyManager):
             raise PipenvExportFailedError from exc
         output.parent.mkdir(exist_ok=True, parents=True)  # ensure directory exists
         # python3.7 w/ pylint 2.12.[12] crashes if result is not wrapped in str()
-        output.write_text(str(result))
+        output.write_text(
+            str(result), encoding=locale.getpreferredencoding(do_setlocale=False)
+        )
         return output

--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import locale
 import logging
 import os
 import platform
@@ -211,7 +212,9 @@ class KBEnvManager(EnvManager):
         """
         file_path = file_path or self.version_file
         if file_path and file_path.is_file():
-            return file_path.read_text().strip()
+            return file_path.read_text(
+                encoding=locale.getpreferredencoding(do_setlocale=False)
+            ).strip()
         LOGGER.debug("file path not provided and version file could not be found")
         return None
 

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import locale
 import logging
 import os
 import platform
@@ -334,7 +335,9 @@ class TFEnvManager(EnvManager):
         """
         file_path = file_path or self.version_file
         if file_path and file_path.is_file():
-            return file_path.read_text().strip()
+            return file_path.read_text(
+                encoding=locale.getpreferredencoding(do_setlocale=False)
+            ).strip()
         LOGGER.debug("file path not provided and version file could not be found")
         return None
 

--- a/runway/tests/handlers/cfn_lint.py
+++ b/runway/tests/handlers/cfn_lint.py
@@ -1,6 +1,7 @@
 """cfn-list test runner."""
 from __future__ import annotations
 
+import locale
 import logging
 import runpy
 import sys
@@ -44,7 +45,14 @@ class CfnLintHandler(TestHandler):
                 runpy.run_module("cfnlint", run_name="__main__")
         except SystemExit as err:  # this call will always result in SystemExit
             if err.code != 0:  # ignore zero exit codes but re-raise for non-zero
-                if not (yaml.safe_load(cfnlintrc.read_text()) or {}).get("templates"):
+                if not (
+                    yaml.safe_load(
+                        cfnlintrc.read_text(
+                            encoding=locale.getpreferredencoding(do_setlocale=False)
+                        )
+                    )
+                    or {}
+                ).get("templates"):
                     logger.warning(
                         'cfnlintrc is missing a "templates" '
                         "section which is required by cfn-lint"

--- a/tests/functional/terraform/test_backend_local_2_s3/test_runner.py
+++ b/tests/functional/terraform/test_backend_local_2_s3/test_runner.py
@@ -2,6 +2,7 @@
 # pylint: disable=redefined-outer-name,unused-argument
 from __future__ import annotations
 
+import locale
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, cast
@@ -37,7 +38,10 @@ def tf_state_bucket(cli_runner: CliRunner) -> Iterator[None]:
 def tf_version(request: SubRequest) -> Iterator[str]:
     """Set Terraform version."""
     file_path = CURRENT_DIR / TF_VERSION_FILENAME
-    file_path.write_text(cast(str, request.param) + "\n")
+    file_path.write_text(
+        cast(str, request.param) + "\n",
+        encoding=locale.getpreferredencoding(do_setlocale=False),
+    )
     yield cast(str, request.param)
     file_path.unlink(missing_ok=True)  # pylint: disable=unexpected-keyword-arg
 

--- a/tests/functional/terraform/test_backend_no_2_local/test_runner.py
+++ b/tests/functional/terraform/test_backend_no_2_local/test_runner.py
@@ -2,6 +2,7 @@
 # pylint: disable=redefined-outer-name,unused-argument
 from __future__ import annotations
 
+import locale
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Generator, cast
@@ -26,7 +27,10 @@ CURRENT_DIR = Path(__file__).parent
 def tf_version(request: SubRequest) -> Generator[str, None, None]:
     """Set Terraform version."""
     file_path = CURRENT_DIR / TF_VERSION_FILENAME
-    file_path.write_text(cast(str, request.param) + "\n")
+    file_path.write_text(
+        cast(str, request.param) + "\n",
+        encoding=locale.getpreferredencoding(do_setlocale=False),
+    )
     yield cast(str, request.param)
     file_path.unlink(missing_ok=True)  # pylint: disable=unexpected-keyword-arg
 

--- a/tests/functional/terraform/test_base/test_runner.py
+++ b/tests/functional/terraform/test_base/test_runner.py
@@ -7,6 +7,7 @@ Other tests should exist to test low-level interactions with Terraform.
 # pylint: disable=redefined-outer-name
 from __future__ import annotations
 
+import locale
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Generator, cast
@@ -31,7 +32,10 @@ CURRENT_DIR = Path(__file__).parent
 def tf_version(request: SubRequest) -> Generator[str, None, None]:
     """Set Terraform version."""
     file_path = CURRENT_DIR / TF_VERSION_FILENAME
-    file_path.write_text(cast(str, request.param) + "\n")
+    file_path.write_text(
+        cast(str, request.param) + "\n",
+        encoding=locale.getpreferredencoding(do_setlocale=False),
+    )
     yield cast(str, request.param)
     file_path.unlink(missing_ok=True)  # pylint: disable=unexpected-keyword-arg
 

--- a/tests/unit/cfngin/providers/aws/test_default.py
+++ b/tests/unit/cfngin/providers/aws/test_default.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import locale
 import os.path
 import random
 import string
@@ -637,7 +638,11 @@ class TestProviderDefaultMode(unittest.TestCase):
         """Test create_stack, force changeset, termination protection."""
         stack_name = "fake_stack"
         template_path = Path("./tests/unit/cfngin/fixtures/cfn_template.yaml")
-        template = Template(body=template_path.read_text())
+        template = Template(
+            body=template_path.read_text(
+                encoding=locale.getpreferredencoding(do_setlocale=False)
+            )
+        )
         parameters: List[Any] = []
         tags: List[Any] = []
 


### PR DESCRIPTION
# Why This Is Needed

resolves #904 

https://www.python.org/dev/peps/pep-0597

# What Changed

## Changed

- pass `encoding` when opening a file in text mode
