### PR TITLE
changed how some pydantic model field aliases are set to better align expectations with type checker behavior

### DIFF
--- a/runway/cfngin/hooks/awslambda/base_classes.py
+++ b/runway/cfngin/hooks/awslambda/base_classes.py
@@ -147,7 +147,7 @@ class Project(Generic[_AwsLambdaHookArgsTypeVar]):
 
     @cached_property
     def runtime(self) -> str:
-        """Runtime of the build system.
+        """runtime of the build system.
 
         Value should be a valid Lambda Function runtime
         (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
@@ -162,7 +162,7 @@ class Project(Generic[_AwsLambdaHookArgsTypeVar]):
 
     @cached_property
     def _runtime_from_docker(self) -> Optional[str]:
-        """Runtime from Docker if class can use Docker."""
+        """runtime from Docker if class can use Docker."""
         docker: Optional[DockerDependencyInstaller] = getattr(self, "docker", None)
         if not docker:
             return None
@@ -379,14 +379,14 @@ class AwsLambdaHook(CfnginHookProtocol, Generic[_ProjectTypeVar]):
     def _build_response_deploy(self) -> AwsLambdaHookDeployResponse:
         """Build response for deploy stage."""
         return AwsLambdaHookDeployResponse(
-            CodeSha256=self.deployment_package.code_sha256,
-            CompatibleArchitectures=self.deployment_package.compatible_architectures,
-            CompatibleRuntimes=self.deployment_package.compatible_runtimes,
-            License=self.deployment_package.license,
-            Runtime=self.deployment_package.runtime,
-            S3Bucket=self.deployment_package.bucket.name,
-            S3Key=self.deployment_package.object_key,
-            S3ObjectVersion=self.deployment_package.object_version_id,
+            bucket_name=self.deployment_package.bucket.name,
+            code_sha256=self.deployment_package.code_sha256,
+            compatible_architectures=self.deployment_package.compatible_architectures,
+            compatible_runtimes=self.deployment_package.compatible_runtimes,
+            license=self.deployment_package.license,
+            object_key=self.deployment_package.object_key,
+            object_version_id=self.deployment_package.object_version_id,
+            runtime=self.deployment_package.runtime,
         )
 
     def _build_response_destroy(self) -> Optional[BaseModel]:
@@ -397,25 +397,25 @@ class AwsLambdaHook(CfnginHookProtocol, Generic[_ProjectTypeVar]):
         """Build response for plan stage."""
         try:
             return AwsLambdaHookDeployResponse(
-                CodeSha256=self.deployment_package.code_sha256,
-                CompatibleArchitectures=self.deployment_package.compatible_architectures,
-                CompatibleRuntimes=self.deployment_package.compatible_runtimes,
-                License=self.deployment_package.license,
-                Runtime=self.deployment_package.runtime,
-                S3Bucket=self.deployment_package.bucket.name,
-                S3Key=self.deployment_package.object_key,
-                S3ObjectVersion=self.deployment_package.object_version_id,
+                bucket_name=self.deployment_package.bucket.name,
+                code_sha256=self.deployment_package.code_sha256,
+                compatible_architectures=self.deployment_package.compatible_architectures,
+                compatible_runtimes=self.deployment_package.compatible_runtimes,
+                license=self.deployment_package.license,
+                object_key=self.deployment_package.object_key,
+                object_version_id=self.deployment_package.object_version_id,
+                runtime=self.deployment_package.runtime,
             )
         except FileNotFoundError:
             return AwsLambdaHookDeployResponse(
-                CodeSha256="WILL CALCULATE WHEN BUILT",
-                CompatibleArchitectures=self.deployment_package.compatible_architectures,
-                CompatibleRuntimes=self.deployment_package.compatible_runtimes,
-                License=self.deployment_package.license,
-                Runtime=self.deployment_package.runtime,
-                S3Bucket=self.deployment_package.bucket.name,
-                S3Key=self.deployment_package.object_key,
-                S3ObjectVersion=self.deployment_package.object_version_id,
+                bucket_name=self.deployment_package.bucket.name,
+                code_sha256="WILL CALCULATE WHEN BUILT",
+                compatible_architectures=self.deployment_package.compatible_architectures,
+                compatible_runtimes=self.deployment_package.compatible_runtimes,
+                license=self.deployment_package.license,
+                object_key=self.deployment_package.object_key,
+                object_version_id=self.deployment_package.object_version_id,
+                runtime=self.deployment_package.runtime,
             )
 
     def cleanup(self) -> None:

--- a/runway/cfngin/hooks/awslambda/models/responses.py
+++ b/runway/cfngin/hooks/awslambda/models/responses.py
@@ -1,7 +1,7 @@
 """Response data models."""
 from typing import List, Optional
 
-from pydantic import Extra, Field
+from pydantic import Extra
 
 from runway.utils import BaseModel
 
@@ -17,35 +17,31 @@ class AwsLambdaHookDeployResponse(BaseModel):
 
     """
 
-    bucket_name: str = Field(..., alias="S3Bucket")
+    bucket_name: str
     """Name of the S3 Bucket where the deployment package is located. (alias ``S3Bucket``)"""
 
-    code_sha256: str = Field(..., alias="CodeSha256")
+    code_sha256: str
     """SHA256 of the deployment package.
     This can be used by CloudFormation as the value of ``AWS::Lambda::Version.CodeSha256``.
     (alias ``CodeSha256``)
 
     """
 
-    compatible_architectures: Optional[List[str]] = Field(
-        default=None, alias="CompatibleArchitectures"
-    )
+    compatible_architectures: Optional[List[str]] = None
     """A list of compatible instruction set architectures.
     (https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html)
     (alias ``CompatibleArchitectures``)
 
     """
 
-    compatible_runtimes: Optional[List[str]] = Field(
-        default=None, alias="CompatibleRuntimes"
-    )
+    compatible_runtimes: Optional[List[str]] = None
     """A list of compatible function runtimes.
     Used for filtering with ``ListLayers`` and ``ListLayerVersions``.
     (alias ``CompatibleRuntimes``)
 
     """
 
-    license: Optional[str] = Field(default=None, alias="License")
+    license: Optional[str] = None
     """The layer's software license (alias ``License``). Can be any of the following:
 
     - A SPDX license identifier (e.g. ``MIT``).
@@ -55,17 +51,17 @@ class AwsLambdaHookDeployResponse(BaseModel):
 
     """
 
-    object_key: str = Field(..., alias="S3Key")
+    object_key: str
     """Key (file path) of the deployment package S3 Object. (alias ``S3Key``)"""
 
-    object_version_id: Optional[str] = Field(default=None, alias="S3ObjectVersion")
+    object_version_id: Optional[str] = None
     """The version ID of the deployment package S3 Object.
     This will only have a value if the S3 Bucket has versioning enabled.
     (alias ``S3ObjectVersion``)
 
     """
 
-    runtime: str = Field(..., alias="Runtime")
+    runtime: str
     """Runtime of the Lambda Function. (alias ``Runtime``)"""
 
     class Config:
@@ -73,3 +69,13 @@ class AwsLambdaHookDeployResponse(BaseModel):
 
         allow_population_by_field_name = True
         extra = Extra.forbid
+        fields = {
+            "bucket_name": {"alias": "S3Bucket"},
+            "code_sha256": {"alias": "CodeSha256"},
+            "compatible_architectures": {"alias": "CompatibleArchitectures"},
+            "compatible_runtimes": {"alias": "CompatibleRuntimes"},
+            "license": {"alias": "License"},
+            "object_key": {"alias": "S3Key"},
+            "object_version_id": {"alias": "S3ObjectVersion"},
+            "runtime": {"alias": "Runtime"},
+        }

--- a/runway/cfngin/hooks/ssm/parameter.py
+++ b/runway/cfngin/hooks/ssm/parameter.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
-from pydantic import Extra, Field, validator
+from pydantic import Extra, validator
 from typing_extensions import Literal, TypedDict
 
 from ....compat import cached_property
@@ -60,26 +60,37 @@ class ArgsDataModel(BaseModel):
 
     """
 
-    allowed_pattern: Optional[str] = Field(default=None, alias="AllowedPattern")
-    data_type: Optional[Literal["aws:ec2:image", "text"]] = Field(
-        default=None, alias="DataType"
-    )
-    description: Optional[str] = Field(default=None, alias="Description")
+    allowed_pattern: Optional[str] = None
+    data_type: Optional[Literal["aws:ec2:image", "text"]] = None
+    description: Optional[str] = None
     force: bool = False
-    key_id: Optional[str] = Field(default=None, alias="KeyId")
-    name: str = Field(..., alias="Name")
-    overwrite: bool = Field(default=True, alias="Overwrite")
-    policies: Optional[str] = Field(default=None, alias="Policies")
-    tags: Optional[List[TagDataModel]] = Field(default=None, alias="Tags")
-    tier: ParameterTierType = Field(default="Standard", alias="Tier")
-    type: Literal["String", "StringList", "SecureString"] = Field(..., alias="Type")
-    value: Optional[str] = Field(default=None, alias="Value")
+    key_id: Optional[str] = None
+    name: str
+    overwrite: bool = True
+    policies: Optional[str] = None
+    tags: Optional[List[TagDataModel]] = None
+    tier: ParameterTierType = "Standard"
+    type: Literal["String", "StringList", "SecureString"]
+    value: Optional[str] = None
 
     class Config:
         """Model configuration."""
 
         allow_population_by_field_name = True
         extra = Extra.ignore
+        fields = {
+            "allowed_pattern": {"alias": "AllowedPattern"},
+            "data_type": {"alias": "DataType"},
+            "description": {"alias": "Description"},
+            "key_id": {"alias": "KeyId"},
+            "name": {"alias": "Name"},
+            "overwrite": {"alias": "Overwrite"},
+            "policies": {"alias": "Policies"},
+            "tags": {"alias": "Tags"},
+            "tier": {"alias": "Tier"},
+            "type": {"alias": "Type"},
+            "value": {"alias": "Value"},
+        }
 
     @validator("policies", allow_reuse=True, pre=True)
     def _convert_policies(cls, v: Union[List[Dict[str, Any]], str, Any]) -> str:

--- a/runway/cfngin/hooks/utils.py
+++ b/runway/cfngin/hooks/utils.py
@@ -33,14 +33,18 @@ class BlankBlueprint(Blueprint):
 class TagDataModel(BaseModel):
     """AWS Resource Tag data model."""
 
-    key: str = pydantic.Field(..., alias="Key")
-    value: str = pydantic.Field(..., alias="Value")
+    key: str
+    value: str
 
     class Config:
         """Model configuration."""
 
         allow_population_by_field_name = True
         extra = pydantic.Extra.forbid
+        fields = {
+            "key": {"alias": "Key"},
+            "value": {"alias": "Value"},
+        }
 
 
 def full_path(path: str) -> str:

--- a/tests/unit/cfngin/hooks/awslambda/models/test_responses.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_responses.py
@@ -15,11 +15,11 @@ class TestAwsLambdaHookDeployResponse:
         """Test extra fields."""
         with pytest.raises(ValidationError) as excinfo:
             AwsLambdaHookDeployResponse(
-                CodeSha256="sha256",
-                Runtime="test",
-                S3Bucket="test-bucket",
-                S3Key="key",
+                bucket_name="test-bucket",
+                code_sha256="sha256",
                 invalid=True,  # type: ignore
+                object_key="key",
+                runtime="test",
             )
         errors = excinfo.value.errors()
         assert len(errors) == 1

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -60,12 +60,12 @@ class TestAwsLambdaHook:
         assert AwsLambdaHook(Mock()).build_response(
             "deploy"
         ) == AwsLambdaHookDeployResponse(
-            CodeSha256=deployment_package.code_sha256,
-            License="license",
-            Runtime=deployment_package.runtime,
-            S3Bucket=deployment_package.bucket.name,
-            S3Key=deployment_package.object_key,
-            S3ObjectVersion=deployment_package.object_version_id,
+            bucket_name=deployment_package.bucket.name,
+            code_sha256=deployment_package.code_sha256,
+            license="license",
+            object_key=deployment_package.object_key,
+            object_version_id=deployment_package.object_version_id,
+            runtime=deployment_package.runtime,
         )
 
     def test_build_response_destroy(self) -> None:
@@ -96,11 +96,11 @@ class TestAwsLambdaHook:
         assert AwsLambdaHook(Mock()).build_response(
             "plan"
         ) == AwsLambdaHookDeployResponse(
-            S3Bucket=deployment_package.bucket.name,
-            CodeSha256=deployment_package.code_sha256,
-            S3Key=deployment_package.object_key,
-            S3ObjectVersion=deployment_package.object_version_id,
-            Runtime=deployment_package.runtime,
+            bucket_name=deployment_package.bucket.name,
+            code_sha256=deployment_package.code_sha256,
+            object_key=deployment_package.object_key,
+            object_version_id=deployment_package.object_version_id,
+            runtime=deployment_package.runtime,
         )
 
     def test_build_response_plan_handle_file_not_found_error(

--- a/tests/unit/cfngin/hooks/ssm/test_parameter.py
+++ b/tests/unit/cfngin/hooks/ssm/test_parameter.py
@@ -30,7 +30,7 @@ class TestArgsDataModel:
 
     def test_field_defaults(self) -> None:
         """Test field values."""
-        obj = ArgsDataModel(Name="test", Type="String")
+        obj = ArgsDataModel(name="test", type="String")
         assert not obj.allowed_pattern
         assert not obj.data_type
         assert not obj.description
@@ -53,9 +53,9 @@ class TestArgsDataModel:
         """Test policies."""
         with pytest.raises(ValidationError, match="Policies"):
             assert not ArgsDataModel(
-                Name="test",
+                name="test",
                 Policies=True,  # type: ignore
-                Type="String",
+                type="String",
             )
 
     def test_policies_json(self) -> None:
@@ -69,9 +69,9 @@ class TestArgsDataModel:
         ]
         assert (
             ArgsDataModel(
-                Name="test",
+                name="test",
                 Policies=data,  # type: ignore
-                Type="String",
+                type="String",
             ).policies
             == json.dumps(data)
         )
@@ -87,17 +87,17 @@ class TestArgsDataModel:
                 }
             ]
         )
-        assert ArgsDataModel(Name="test", Policies=data, Type="String").policies == data
+        assert ArgsDataModel(name="test", policies=data, type="String").policies == data
 
     def test_tags_dict(self) -> None:
         """Test tags."""
         assert (
             ArgsDataModel(
-                Name="test",
-                Tags={"tag-key": "tag-value"},  # type: ignore
-                Type="String",
+                name="test",
+                tags={"tag-key": "tag-value"},  # type: ignore
+                type="String",
             ).tags
-            == [TagDataModel(Key="tag-key", Value="tag-value")]
+            == [TagDataModel(key="tag-key", value="tag-value")]
         )
 
     def test_tags_raise_type_error(self) -> None:

--- a/tests/unit/cfngin/lookups/handlers/test_awslambda.py
+++ b/tests/unit/cfngin/lookups/handlers/test_awslambda.py
@@ -32,14 +32,14 @@ QUERY = "test::foo=bar"
 def hook_data() -> AwsLambdaHookDeployResponse:
     """Fixture for hook response data."""
     return AwsLambdaHookDeployResponse(
-        CodeSha256="code_sha256",
-        CompatibleArchitectures=["compatible_architectures"],
-        CompatibleRuntimes=["compatible_runtimes"],
-        License="license",
-        Runtime="runtime",
-        S3Bucket="bucket_name",
-        S3Key="object_key",
-        S3ObjectVersion="object_version_id",
+        code_sha256="code_sha256",
+        compatible_architectures=["compatible_architectures"],
+        compatible_runtimes=["compatible_runtimes"],
+        license="license",
+        runtime="runtime",
+        bucket_name="bucket_name",
+        object_key="object_key",
+        object_version_id="object_version_id",
     )
 
 


### PR DESCRIPTION
# Why This Is Needed

They pydantic update in #1124 changed the behavior of `Field.alias` when using with pyright. To pass type checking, some changes were required to adapt to this new behavior.

This PR reverts some of those changes for models whose attributes are primarily met to be set by field name but also provide an alias.

# What Changed

## Changed

- changed how some pydantic model field aliases are set to better align expectations with type checker behavior
