### PR TITLE
cleanup useless pylint suppressions

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -73,6 +73,7 @@
         "hashextra",
         "hashicorp",
         "igittigitt",
+        "kwoa",
         "libltdl",
         "libmysqlclient",
         "libxmlsec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,7 @@ disable = [
   "missing-module-docstring",  # flake8 (pydocstyle) overlap
   "similarities",  # black overcomplicated this
   "ungrouped-imports", # false positive when using TYPE_CHECKING; isort should cover this
+  "unused-import",  # flake8 overlap (F401)
 ]
 
 [tool.pylint.typecheck]

--- a/runway/__init__.py
+++ b/runway/__init__.py
@@ -1,23 +1,16 @@
 """Set package version."""
-# pylint: disable=wrong-import-position
 import logging
 import sys
 
-from ._logging import LogLevels, RunwayLogger  # noqa
+from ._logging import LogLevels, RunwayLogger  # noqa: F401
 
 logging.setLoggerClass(RunwayLogger)
 
 if sys.version_info < (3, 8):
     # importlib.metadata is standard lib for python>=3.8, use backport
-    from importlib_metadata import (  # type: ignore # pylint: disable=E
-        PackageNotFoundError,
-        version,
-    )
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
 else:
-    from importlib.metadata import (  # type: ignore # pylint: disable=E
-        PackageNotFoundError,
-        version,
-    )
+    from importlib.metadata import PackageNotFoundError, version  # type: ignore
 
 try:
     __version__ = version(__name__)

--- a/runway/_cli/options.py
+++ b/runway/_cli/options.py
@@ -1,5 +1,4 @@
 """Click options."""
-# pylint: disable=invalid-name
 import click
 
 ci = click.option(

--- a/runway/blueprints/k8s/k8s_master.py
+++ b/runway/blueprints/k8s/k8s_master.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 """Module with k8s cluster resources."""
 import awacs.iam
-from awacs.aws import StringLike  # pylint: disable=no-name-in-module
-from awacs.aws import Allow, Condition, PolicyDocument, Statement
+from awacs.aws import Allow, Condition, PolicyDocument, Statement, StringLike
 from awacs.helpers.trust import make_simple_assume_policy
 from troposphere import Export, Join, Output, Sub, ec2, eks, iam
 

--- a/runway/blueprints/staticsite/staticsite.py
+++ b/runway/blueprints/staticsite/staticsite.py
@@ -34,7 +34,7 @@ from ...cfngin.blueprints.base import Blueprint
 from ...context import CfnginContext
 
 if TYPE_CHECKING:
-    from troposphere import Ref  # pylint: disable=ungrouped-imports
+    from troposphere import Ref
 
     from ...cfngin.blueprints.type_defs import BlueprintVariableTypeDef
 

--- a/runway/cfngin/actions/deploy.py
+++ b/runway/cfngin/actions/deploy.py
@@ -292,7 +292,7 @@ class Action(BaseAction):
 
         return param_list
 
-    def _destroy_stack(  # pylint: disable=too-many-return-statements
+    def _destroy_stack(
         self, stack: Stack, *, status: Optional[Status] = None, **_: Any
     ) -> Status:
         """Delete a CloudFormation stack.
@@ -344,9 +344,8 @@ class Action(BaseAction):
             return SkippedStatus(reason="canceled execution")
 
     # TODO refactor long if, elif, else block
-    def _launch_stack(  # pylint: disable=R
-        self, stack: Stack, *, status: Status, **_: Any
-    ) -> Status:
+    # pylint: disable=too-many-return-statements,too-many-branches,too-many-statements
+    def _launch_stack(self, stack: Stack, *, status: Status, **_: Any) -> Status:
         """Handle the creating or updating of a stack in CloudFormation.
 
         Also makes sure that we don't try to create or update a stack while
@@ -556,7 +555,7 @@ class Action(BaseAction):
 
         return Plan(context=self.context, description=self.DESCRIPTION, graph=graph)
 
-    def pre_run(  # pylint: disable=arguments-differ
+    def pre_run(
         self, *, dump: Union[bool, str] = False, outline: bool = False, **_: Any
     ) -> None:
         """Any steps that need to be taken prior to running the action."""
@@ -616,7 +615,7 @@ class Action(BaseAction):
         if isinstance(dump, str):
             plan.dump(directory=dump, context=self.context, provider=self.provider)
 
-    def post_run(  # pylint: disable=arguments-differ
+    def post_run(
         self, *, dump: Union[bool, str] = False, outline: bool = False, **_: Any
     ) -> None:
         """Any steps that need to be taken after running the action."""

--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -194,9 +194,7 @@ class Action(deploy.Action):
         """Run against a step."""
         return self._diff_stack
 
-    def _diff_stack(  # pylint: disable=too-many-return-statements
-        self, stack: Stack, **_: Any
-    ) -> Status:
+    def _diff_stack(self, stack: Stack, **_: Any) -> Status:
         """Handle diffing a stack in CloudFormation vs our config."""
         if self.cancel.wait(0):
             return INTERRUPTED
@@ -300,10 +298,6 @@ class Action(deploy.Action):
             self.bucket_name = None
 
     def post_run(
-        self,
-        *,
-        dump: Union[bool, str] = False,  # pylint: disable=unused-argument
-        outline: bool = False,  # pylint: disable=unused-argument
-        **__kwargs: Any,
+        self, *, dump: Union[bool, str] = False, outline: bool = False, **__kwargs: Any
     ) -> None:
         """Do nothing."""

--- a/runway/cfngin/actions/init.py
+++ b/runway/cfngin/actions/init.py
@@ -142,8 +142,8 @@ class Action(BaseAction):
     def pre_run(
         self,
         *,
-        dump: Union[bool, str] = False,  # pylint: disable=unused-argument
-        outline: bool = False,  # pylint: disable=unused-argument
+        dump: Union[bool, str] = False,
+        outline: bool = False,
         **__kwargs: Any,
     ) -> None:
         """Do nothing."""
@@ -151,8 +151,8 @@ class Action(BaseAction):
     def post_run(
         self,
         *,
-        dump: Union[bool, str] = False,  # pylint: disable=unused-argument
-        outline: bool = False,  # pylint: disable=unused-argument
+        dump: Union[bool, str] = False,
+        outline: bool = False,
         **__kwargs: Any,
     ) -> None:
         """Do nothing."""

--- a/runway/cfngin/blueprints/testutil.py
+++ b/runway/cfngin/blueprints/testutil.py
@@ -174,7 +174,7 @@ class YamlDirTestGenerator:
                 blueprint.create_template()
                 self.assertRenderedBlueprint(blueprint)
 
-            def assertEqual(  # noqa pylint: disable=invalid-name
+            def assertEqual(  # noqa: N802
                 self, first: Any, second: Any, msg: Optional[str] = None
             ) -> None:
                 """Test that first and second are equal.

--- a/runway/cfngin/blueprints/variables/types.py
+++ b/runway/cfngin/blueprints/variables/types.py
@@ -1,5 +1,4 @@
 """CFNgin blueprint variable types."""
-# pylint: disable=invalid-name,len-as-condition
 from __future__ import annotations
 
 from typing import (

--- a/runway/cfngin/dag/__init__.py
+++ b/runway/cfngin/dag/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import collections
+import collections.abc
 import logging
 from copy import copy, deepcopy
 from threading import Thread
@@ -315,7 +316,7 @@ class DAG:
         for new_node in graph_dict:
             self.add_node(new_node)
         for ind_node, dep_nodes in graph_dict.items():
-            if not isinstance(dep_nodes, collections.Iterable):
+            if not isinstance(dep_nodes, collections.abc.Iterable):
                 raise TypeError(f"{ind_node}: dict values must be lists")
             for dep_node in dep_nodes:
                 self.add_edge(ind_node, dep_node)

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -217,7 +217,8 @@ def _calculate_hash(files: Iterable[str], root: str) -> str:
         file_path = os.path.join(root, file_name)
         file_hash.update((file_name + "\0").encode())
         with open(file_path, "rb") as file_:
-            for chunk in iter(lambda: file_.read(4096), ""):  # pylint: disable=W
+            # pylint: disable=cell-var-from-loop
+            for chunk in iter(lambda: file_.read(4096), ""):
                 if not chunk:
                     break
                 file_hash.update(chunk)
@@ -663,7 +664,7 @@ def _zip_package(  # pylint: disable=too-many-locals,too-many-statements
     if sys.version_info.major < 3:
         remove_error = OSError
     else:
-        remove_error = PermissionError  # noqa pylint: disable=E
+        remove_error = PermissionError
     try:
         tmpdir.cleanup()
     except remove_error:

--- a/runway/cfngin/hooks/docker/image/_build.py
+++ b/runway/cfngin/hooks/docker/image/_build.py
@@ -73,7 +73,7 @@ class DockerImageBuildApiOptions(BaseModel):
     timout: Optional[int]
     use_config_proxy: bool
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         *,
         buildargs: Optional[Dict[str, Any]] = None,

--- a/runway/cfngin/hooks/staticsite/auth_at_edge/client_updater.py
+++ b/runway/cfngin/hooks/staticsite/auth_at_edge/client_updater.py
@@ -4,7 +4,6 @@ Responsible for updating the User Pool Client with the generated
 distribution url + callback url paths.
 
 """
-# pylint: disable=unused-argument
 from __future__ import annotations
 
 import logging

--- a/runway/cfngin/hooks/staticsite/auth_at_edge/templates/shared_jose.py
+++ b/runway/cfngin/hooks/staticsite/auth_at_edge/templates/shared_jose.py
@@ -101,7 +101,7 @@ class JwksClient:
         LOGGER.info("Fetching keys from %s", self.options.get("jwks_uri"))
 
         try:
-            # pylint: disable=consider-using-with,no-member
+            # pylint: disable=consider-using-with
             request_res = request.urlopen(self.options.get("jwks_uri"))
             data = json.loads(
                 request_res.read().decode(

--- a/runway/cfngin/ui.py
+++ b/runway/cfngin/ui.py
@@ -85,7 +85,7 @@ class UI(ContextManager["UI"]):
 
     def __enter__(self) -> UI:
         """Enter the context manager."""
-        self._lock.__enter__()  # pylint: disable=consider-using-with
+        self._lock.__enter__()
         return self
 
     def __exit__(

--- a/runway/cfngin/utils.py
+++ b/runway/cfngin/utils.py
@@ -832,8 +832,7 @@ class SourceProcessor:
         """
         LOGGER.debug("getting commit ID from repo: %s", " ".join(uri))
         ls_remote_output = subprocess.check_output(["git", "ls-remote", uri, ref])
-        # incorrectly detected - https://github.com/PyCQA/pylint/issues/3045
-        if b"\t" in ls_remote_output:  # pylint: disable=unsupported-membership-test
+        if b"\t" in ls_remote_output:
             commit_id = ls_remote_output.split(b"\t", maxsplit=1)[0]
             LOGGER.debug("matching commit id found: %s", commit_id)
             return commit_id.decode()

--- a/runway/compat.py
+++ b/runway/compat.py
@@ -1,5 +1,4 @@
 """Python dependency compatability handling."""
-# pylint: disable=E
 import sys
 from typing import Iterable
 

--- a/runway/config/__init__.py
+++ b/runway/config/__init__.py
@@ -1,5 +1,4 @@
 """CFNgin config."""
-# pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
 import logging
@@ -263,7 +262,7 @@ class CfnginConfig(BaseConfig):
         return result
 
     @classmethod
-    def parse_file(  # pylint: disable=arguments-differ
+    def parse_file(
         cls,
         *,
         path: Optional[Path] = None,

--- a/runway/config/models/runway/_builtin_tests.py
+++ b/runway/config/models/runway/_builtin_tests.py
@@ -1,5 +1,4 @@
 """Runway test definition models."""
-# pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Union, cast

--- a/runway/core/providers/aws/_response.py
+++ b/runway/core/providers/aws/_response.py
@@ -1,5 +1,4 @@
 """Base class for AWS responses."""
-# pylint: disable=invalid-name
 from http import HTTPStatus
 from typing import Any, Dict
 

--- a/runway/core/providers/aws/s3/_helpers/results.py
+++ b/runway/core/providers/aws/s3/_helpers/results.py
@@ -265,7 +265,6 @@ class UploadResultSubscriber(BaseResultSubscriber):
 class UploadStreamResultSubscriber(UploadResultSubscriber):
     """Upload stream result subscriber."""
 
-    # pylint: disable=no-self-use,unused-argument
     def _get_src(self, fileobj: AnyPath) -> str:
         return "-"
 

--- a/runway/core/providers/aws/s3/_helpers/s3handler.py
+++ b/runway/core/providers/aws/s3/_helpers/s3handler.py
@@ -701,7 +701,6 @@ class UploadStreamRequestSubmitter(UploadRequestSubmitter):
             raise StdinMissingError()
         return NonSeekableStream(sys.stdin.buffer)
 
-    # pylint: disable=unused-argument
     def _format_local_path(self, path: Optional[AnyPath]) -> str:
         """Format local path."""
         return "-"
@@ -730,7 +729,6 @@ class DownloadStreamRequestSubmitter(DownloadRequestSubmitter):
             fileinfo.operation_name == "download" and self._config_params.is_stream
         )
 
-    # pylint: disable=unused-argument
     def _add_additional_subscribers(
         self, subscribers: List[BaseSubscriber], fileinfo: FileInfo
     ) -> None:
@@ -741,7 +739,6 @@ class DownloadStreamRequestSubmitter(DownloadRequestSubmitter):
         """Get file out."""
         return StdoutBytesWriter()
 
-    # pylint: disable=unused-argument
     def _format_local_path(self, path: Optional[AnyPath]) -> str:
         """Format local path."""
         return "-"
@@ -812,7 +809,6 @@ class LocalDeleteRequestSubmitter(BaseTransferRequestSubmitter):
         """
         return fileinfo.operation_name == "delete" and fileinfo.src_type == "local"
 
-    # pylint: disable=unused-argument
     def _submit_transfer_request(  # type: ignore
         self,
         fileinfo: FileInfo,

--- a/runway/core/providers/aws/s3/_helpers/utils.py
+++ b/runway/core/providers/aws/s3/_helpers/utils.py
@@ -170,7 +170,6 @@ class OnDoneFilteredSubscriber(BaseSubscriber):
     def _on_success(self, future: TransferFuture) -> None:
         """On success."""
 
-    # pylint: disable=invalid-name
     def _on_failure(self, future: TransferFuture, exception: Exception) -> None:
         """On failure."""
 
@@ -184,7 +183,6 @@ class DeleteSourceSubscriber(OnDoneFilteredSubscriber):
         except Exception as exc:  # pylint: disable=broad-except
             future.set_exception(exc)
 
-    # pylint: disable=no-self-use
     def _delete_source(self, future: TransferFuture) -> None:
         raise NotImplementedError("_delete_source()")
 
@@ -250,7 +248,7 @@ class DirectoryCreatorSubscriber(BaseSubscriber):
         try:
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
-        except OSError as exc:  # pylint: disable=broad-except
+        except OSError as exc:
             if exc.errno != errno.EEXIST:
                 raise CreateDirectoryError(
                     f"Could not create directory {dirname}: {exc}"
@@ -308,7 +306,6 @@ class PrintTask(NamedTuple):
 class ProvideCopyContentTypeSubscriber(BaseProvideContentTypeSubscriber):
     """Provide copy content type subscriber."""
 
-    # pylint: disable=no-self-use
     def _get_filename(self, future: TransferFuture) -> str:
         return future.meta.call_args.copy_source["Key"]
 
@@ -352,7 +349,6 @@ class ProvideSizeSubscriber(BaseSubscriber):
 class ProvideUploadContentTypeSubscriber(BaseProvideContentTypeSubscriber):
     """Provider upload content type subscriber."""
 
-    # pylint: disable=no-self-use
     def _get_filename(self, future: TransferFuture) -> str:
         return str(future.meta.call_args.fileobj)
 

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -48,8 +48,7 @@ LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 TF_VERSION_FILENAME = ".terraform-version"
 
 
-# Branch and local variable count will go down when py2 support is dropped
-def download_tf_release(  # noqa pylint: disable=too-many-locals,too-many-branches
+def download_tf_release(
     version: str,
     versions_dir: Path,
     command_suffix: str,

--- a/runway/lookups/handlers/ecr.py
+++ b/runway/lookups/handlers/ecr.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import base64
 import logging
-from typing import TYPE_CHECKING, Any, Union  # pylint: disable=W
+from typing import TYPE_CHECKING, Any, Union
 
 from typing_extensions import Final, Literal
 

--- a/runway/utils/__init__.py
+++ b/runway/utils/__init__.py
@@ -43,12 +43,12 @@ from pydantic import BaseModel as _BaseModel
 from typing_extensions import Literal
 
 # make this importable for util as it was before
-from ..compat import cached_property  # noqa pylint: disable=unused-import
+from ..compat import cached_property  # noqa: F401
 
 # make this importable without defining __all__ yet.
 # more things need to be moved of this file before starting an explicit __all__.
-from ._file_hash import FileHash  # noqa pylint: disable=unused-import
-from ._version import Version  # noqa pylint: disable=unused-import
+from ._file_hash import FileHash  # noqa: F401
+from ._version import Version  # noqa: F401
 
 if TYPE_CHECKING:
     from mypy_boto3_cloudformation.type_defs import OutputTypeDef

--- a/runway/variables.py
+++ b/runway/variables.py
@@ -374,7 +374,7 @@ class VariableValueDict(VariableValue, MutableMapping[str, VariableValue]):
     def dependencies(self) -> Set[str]:
         """Stack names that this variable depends on."""
         deps: Set[str] = set()
-        for item in self.values():  # pylint: disable=no-member
+        for item in self.values():
             deps.update(item.dependencies)
         return deps
 
@@ -382,7 +382,7 @@ class VariableValueDict(VariableValue, MutableMapping[str, VariableValue]):
     def resolved(self) -> bool:
         """Use to check if the variable value has been resolved."""
         accumulator: bool = True
-        for item in self.values():  # pylint: disable=no-member
+        for item in self.values():
             accumulator = accumulator and item.resolved
         return accumulator
 
@@ -394,12 +394,12 @@ class VariableValueDict(VariableValue, MutableMapping[str, VariableValue]):
         flatten nested concatenations.
 
         """
-        return {k: v.simplified for k, v in self.items()}  # pylint: disable=no-member
+        return {k: v.simplified for k, v in self.items()}
 
     @property
     def value(self) -> Dict[str, Any]:
         """Value of the variable. Can be resolved or unresolved."""
-        return {k: v.value for k, v in self.items()}  # pylint: disable=no-member
+        return {k: v.value for k, v in self.items()}
 
     def resolve(
         self,
@@ -416,7 +416,7 @@ class VariableValueDict(VariableValue, MutableMapping[str, VariableValue]):
             variables: Object containing variables passed to Runway.
 
         """
-        for item in self.values():  # pylint: disable=no-member
+        for item in self.values():
             item.resolve(context, provider=provider, variables=variables, **kwargs)
 
     def __delitem__(self, __key: str) -> None:
@@ -437,7 +437,6 @@ class VariableValueDict(VariableValue, MutableMapping[str, VariableValue]):
 
     def __repr__(self) -> str:
         """Return object representation."""
-        # pylint: disable=no-member
         return f"Dict[{', '.join(f'{k}={v}' for k, v in self.items())}]"
 
     def __setitem__(self, __key: str, __value: VariableValue) -> None:
@@ -989,7 +988,6 @@ class VariableValuePydanticModel(Generic[_PydanticModelTypeVar], VariableValue):
 
     def __repr__(self) -> str:
         """Return object representation."""
-        # pylint: disable=no-member
         return (
             self._model_class.__name__
             + f"[{', '.join(f'{k}={v}' for k, v in self._data.items())}]"

--- a/tests/functional/cdk/test_multistack/test_runner.py
+++ b/tests/functional/cdk/test_multistack/test_runner.py
@@ -36,8 +36,6 @@ def deploy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
 def destroy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
     """Execute `runway destroy`."""
     yield cli_runner.invoke(cli, ["destroy"], env={"CI": "1"})
-    # pylint: disable=unexpected-keyword-arg
-    # (CURRENT_DIR / "cdk.out").unlink(missing_ok=True)
     shutil.rmtree(CURRENT_DIR / "cdk.out", ignore_errors=True)
     shutil.rmtree(CURRENT_DIR / "node_modules", ignore_errors=True)
     shutil.rmtree(CURRENT_DIR / ".runway", ignore_errors=True)

--- a/tests/functional/cfngin/hooks/test_awslambda/sample_app/src/type_defs.py
+++ b/tests/functional/cfngin/hooks/test_awslambda/sample_app/src/type_defs.py
@@ -5,9 +5,9 @@ import sys
 from typing import Any, Dict, Optional
 
 if sys.version_info < (3, 8):
-    from typing_extensions import Literal, TypedDict  # type: ignore # pylint: disable=E
+    from typing_extensions import Literal, TypedDict  # type: ignore
 else:
-    from typing import Literal, TypedDict  # type: ignore # pylint: disable=E
+    from typing import Literal, TypedDict  # type: ignore
 
 
 class _LambdaResponeOptional(TypedDict, total=False):

--- a/tests/functional/cfngin/test_assume_role/test_runner.py
+++ b/tests/functional/cfngin/test_assume_role/test_runner.py
@@ -1,5 +1,5 @@
 """Test Runway assume role."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/functional/cfngin/test_aws_lambda_hook/test_runner.py
+++ b/tests/functional/cfngin/test_aws_lambda_hook/test_runner.py
@@ -1,5 +1,5 @@
 """Test AWS Lambda hook."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/functional/cfngin/test_destroy_removed/test_runner.py
+++ b/tests/functional/cfngin/test_destroy_removed/test_runner.py
@@ -1,5 +1,5 @@
 """Test destroy stack removed from persistent graph."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/functional/cfngin/test_duplicate_stack/test_runner.py
+++ b/tests/functional/cfngin/test_duplicate_stack/test_runner.py
@@ -1,5 +1,5 @@
 """Test duplicate stack names."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/functional/cfngin/test_locked_stack/test_runner.py
+++ b/tests/functional/cfngin/test_locked_stack/test_runner.py
@@ -1,5 +1,5 @@
 """Test locked stack."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/functional/cfngin/test_raw_cfn/test_runner.py
+++ b/tests/functional/cfngin/test_raw_cfn/test_runner.py
@@ -1,5 +1,5 @@
 """Test using raw CloudFormation template."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/functional/cfngin/test_recreate_failed/test_runner.py
+++ b/tests/functional/cfngin/test_recreate_failed/test_runner.py
@@ -1,5 +1,5 @@
 """Test recreation of a failed deployment."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/functional/cfngin/test_rollback_dependant/test_runner.py
+++ b/tests/functional/cfngin/test_rollback_dependant/test_runner.py
@@ -1,5 +1,5 @@
 """Test failed stack with dependency."""
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/integration/cli/commands/kbenv/test_list.py
+++ b/tests/integration/cli/commands/kbenv/test_list.py
@@ -1,5 +1,4 @@
 """Test ``runway kbenv list`` command."""
-# pylint: disable=unused-argument
 from __future__ import annotations
 
 import logging

--- a/tests/integration/cli/commands/test_gen_sample.py
+++ b/tests/integration/cli/commands/test_gen_sample.py
@@ -1,5 +1,4 @@
 """Test ``runway gen-sample`` command."""
-# pylint: disable=unused-argument
 from __future__ import annotations
 
 import logging

--- a/tests/integration/cli/commands/tfenv/test_list.py
+++ b/tests/integration/cli/commands/tfenv/test_list.py
@@ -1,5 +1,4 @@
 """Test ``runway tfenv list`` command."""
-# pylint: disable=unused-argument
 from __future__ import annotations
 
 import logging

--- a/tests/unit/cfngin/actions/test_base.py
+++ b/tests/unit/cfngin/actions/test_base.py
@@ -1,5 +1,5 @@
 """Tests for runway.cfngin.actions.base."""
-# pylint: disable=no-self-use,protected-access,unused-argument
+# pylint: disable=no-self-use,protected-access
 # pyright: basic
 import unittest
 

--- a/tests/unit/cfngin/fixtures/mock_hooks.py
+++ b/tests/unit/cfngin/fixtures/mock_hooks.py
@@ -1,5 +1,4 @@
 """Mock hook."""
-# pylint: disable=unused-argument
 from typing import Any, Dict
 
 

--- a/tests/unit/cfngin/hooks/awslambda/models/test_args.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_args.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.models.args."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/cfngin/hooks/awslambda/models/test_responses.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_responses.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.models.responses."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/test__deployment_package.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/test__deployment_package.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.python_requirements._deployment_package."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/test__docker.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/test__docker.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.python_requirements._docker."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 import logging

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/test__project.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/test__project.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.python_requirements._project."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 import logging

--- a/tests/unit/cfngin/hooks/awslambda/test__python_hooks.py
+++ b/tests/unit/cfngin/hooks/awslambda/test__python_hooks.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda._python_hooks."""
-# pylint: disable=no-self-use,protected-access,redefined-outer-name
+# pylint: disable=no-self-use,redefined-outer-name
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.base_classes."""
-# pylint: disable=no-self-use,protected-access,unused-argument
+# pylint: disable=no-self-use,unused-argument
 from __future__ import annotations
 
 import logging

--- a/tests/unit/cfngin/hooks/awslambda/test_docker.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_docker.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.docker."""
-# pylint: disable=no-self-use,protected-access,redefined-outer-name
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 import logging

--- a/tests/unit/cfngin/hooks/awslambda/test_source_code.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_source_code.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.awslambda.source_code."""
-# pylint: disable=no-self-use,protected-access,redefined-outer-name
+# pylint: disable=no-self-use,protected-access
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/cfngin/hooks/docker/image/test_push.py
+++ b/tests/unit/cfngin/hooks/docker/image/test_push.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.docker.image._push."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 # pyright: basic, reportFunctionMemberAccess=none
 from __future__ import annotations
 
@@ -43,7 +43,7 @@ def test_push(
     cfngin_context.hook_data["docker"] = docker_hook_data
     assert push(context=cfngin_context, **args.dict()) == docker_hook_data
     mock_from_cfngin_context.assert_called_once_with(cfngin_context)
-    docker_hook_data.client.api.push.assert_has_calls(  # pylint: disable=no-member
+    docker_hook_data.client.api.push.assert_has_calls(
         [call(args.repo, tag=args.tags[0]), call(args.repo, tag=args.tags[1])]
     )
     mock_update_context.assert_called_once_with(cfngin_context)

--- a/tests/unit/cfngin/hooks/docker/image/test_remove.py
+++ b/tests/unit/cfngin/hooks/docker/image/test_remove.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.docker.image._remove."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 # pyright: basic, reportFunctionMemberAccess=none
 from __future__ import annotations
 
@@ -55,7 +55,6 @@ def test_remove(
         == docker_hook_data
     )
     mock_from_cfngin_context.assert_called_once_with(cfngin_context)
-    # pylint: disable=no-member
     docker_hook_data.client.api.remove_image.assert_has_calls(  # type: ignore
         [
             call(force=True, image=f"{args.repo}:{tag}", noprune=False)
@@ -83,7 +82,6 @@ def test_remove_image_not_found(
         DockerHookData, "update_context", return_value=docker_hook_data
     )
     cfngin_context.hook_data["docker"] = docker_hook_data
-    # pylint: disable=no-member
     docker_hook_data.client.api.remove_image.side_effect = ImageNotFound(  # type: ignore
         f"{args.repo}:latest"
     )

--- a/tests/unit/cfngin/hooks/staticsite/test_upload_staticsite.py
+++ b/tests/unit/cfngin/hooks/staticsite/test_upload_staticsite.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.hooks.staticsite.upload_staticsite."""
-# pylint: disable=no-self-use,too-few-public-methods
+# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/cfngin/hooks/test_aws_lambda.py
+++ b/tests/unit/cfngin/hooks/test_aws_lambda.py
@@ -1,5 +1,5 @@
 """Tests for runway.cfngin.hooks.aws_lambda."""
-# pylint: disable=invalid-name,no-self-use
+# pylint: disable=no-self-use
 # pyright: basic, reportUnknownArgumentType=none, reportUnknownVariableType=none
 # pyright: reportFunctionMemberAccess=none, reportOptionalMemberAccess=none
 # pyright: reportOptionalOperand=none
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import os.path
-import random  # pylint: disable=syntax-error
+import random
 import sys
 import unittest
 from io import BytesIO as StringIO
@@ -618,8 +618,6 @@ class TestDockerizePip:
             docker_file = tmp_dir.write("Dockerfile", b"")
             dockerized_pip(os.getcwd(), client=client, docker_file=docker_file)
 
-            # for some reason, the current version of pylint does not see these methods
-            # pylint: disable=no-member
             client.api.build.assert_called_with(
                 path=tmp_dir.path, dockerfile="Dockerfile", forcerm=True
             )
@@ -641,8 +639,6 @@ class TestDockerizePip:
         image = "alpine"
         dockerized_pip(os.getcwd(), client=client, docker_image=image)
 
-        # for some reason, the current version of pylint does not see these methods
-        # pylint: disable=no-member
         client.api.create_container.assert_called_with(
             detach=True, image=image, command=self.command, host_config=self.host_config
         )
@@ -658,8 +654,6 @@ class TestDockerizePip:
         runtime = "python3.8"
         dockerized_pip(os.getcwd(), client=client, runtime=runtime)
 
-        # for some reason, the current version of pylint does not see these methods
-        # pylint: disable=no-member
         client.api.create_container.assert_called_with(
             detach=True,
             image="lambci/lambda:build-" + runtime,

--- a/tests/unit/cfngin/hooks/test_base.py
+++ b/tests/unit/cfngin/hooks/test_base.py
@@ -1,5 +1,5 @@
 """Tests for runway.cfngin.hooks.base."""
-# pylint: disable=no-self-use,too-few-public-methods
+# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/cfngin/hooks/test_ecs.py
+++ b/tests/unit/cfngin/hooks/test_ecs.py
@@ -74,4 +74,5 @@ class TestECSHooks(unittest.TestCase):
 
             self.assertEqual(len(response.get("clusterArns", [""])), 0)
             with self.assertRaises(TypeError):
-                create_clusters(context=self.context)  # type: ignore pylint: disable=E
+                # pylint: disable=missing-kwoa
+                create_clusters(context=self.context)  # type: ignore

--- a/tests/unit/cfngin/hooks/test_utils.py
+++ b/tests/unit/cfngin/hooks/test_utils.py
@@ -1,5 +1,5 @@
 """Tests for runway.cfngin.hooks.utils."""
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 # pyright: basic, reportUnknownArgumentType=none, reportUnknownVariableType=none
 from __future__ import annotations
 

--- a/tests/unit/cfngin/lookups/handlers/test_awslambda.py
+++ b/tests/unit/cfngin/lookups/handlers/test_awslambda.py
@@ -1,5 +1,5 @@
 """Test runway.cfngin.lookups.handlers.awslambda."""
-# pylint: disable=no-self-use,protected-access,redefined-outer-name
+# pylint: disable=no-self-use,redefined-outer-name
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/unit/cfngin/lookups/test_registry.py
+++ b/tests/unit/cfngin/lookups/test_registry.py
@@ -1,5 +1,4 @@
 """Tests for runway.cfngin.lookups.registry."""
-# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/cfngin/test_cfngin.py
+++ b/tests/unit/cfngin/test_cfngin.py
@@ -1,5 +1,5 @@
 """Tests for runway.cfngin entry point."""
-# pylint: disable=no-self-use,protected-access.redefined-outer-name
+# pylint: disable=no-self-use,redefined-outer-name
 from __future__ import annotations
 
 import shutil

--- a/tests/unit/config/models/runway/test_builtin_tests.py
+++ b/tests/unit/config/models/runway/test_builtin_tests.py
@@ -1,5 +1,5 @@
 """Test runway.config.models.runway._builtin_tests."""
-# pylint: disable=no-self-use,too-few-public-methods
+# pylint: disable=no-self-use
 # pyright: basic
 from typing import Optional
 

--- a/tests/unit/config/models/runway/test_runway.py
+++ b/tests/unit/config/models/runway/test_runway.py
@@ -1,5 +1,5 @@
 """Test runway.config.models.runway.__init__."""
-# pylint: disable=no-self-use,too-few-public-methods
+# pylint: disable=no-self-use
 # pyright: basic
 from pathlib import Path
 from typing import Any, Dict

--- a/tests/unit/config/models/test_utils.py
+++ b/tests/unit/config/models/test_utils.py
@@ -1,5 +1,4 @@
 """Test runway.config.models.utils."""
-# pylint: disable=no-self-use
 # pyright: basic
 from pathlib import Path
 from typing import Any, Optional

--- a/tests/unit/context/test_base.py
+++ b/tests/unit/context/test_base.py
@@ -1,5 +1,5 @@
 """Test runway.context._base."""
-# pylint: disable=no-self-use,redefined-outer-name
+# pylint: disable=redefined-outer-name
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/context/test_cfngin.py
+++ b/tests/unit/context/test_cfngin.py
@@ -1,5 +1,5 @@
 """Test runway.context._cfngin."""
-# pylint: disable=no-self-use,redefined-outer-name
+# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/context/test_runway.py
+++ b/tests/unit/context/test_runway.py
@@ -1,5 +1,5 @@
 """Test runway.context._runway."""
-# pylint: disable=no-self-use,redefined-outer-name
+# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/context/test_sys_info.py
+++ b/tests/unit/context/test_sys_info.py
@@ -1,5 +1,5 @@
 """Test runway.context.sys_info."""
-# pylint: disable=invalid-name,no-self-use,redefined-outer-name,unused-argument
+# pylint: disable=invalid-name,no-self-use,unused-argument
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/core/providers/aws/s3/_helpers/sync_strategy/test_register.py
+++ b/tests/unit/core/providers/aws/s3/_helpers/sync_strategy/test_register.py
@@ -1,5 +1,4 @@
 """Test runway.core.providers.aws.s3._helpers.sync_strategy.register."""
-# pylint: disable=no-self-use
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/unit/core/providers/aws/s3/_helpers/test_action_architecture.py
+++ b/tests/unit/core/providers/aws/s3/_helpers/test_action_architecture.py
@@ -1,5 +1,4 @@
 """Test runway.core.providers.aws.s3._helpers.action_architecture."""
-# pylint: disable=no-self-use
 from __future__ import annotations
 
 import os

--- a/tests/unit/core/providers/aws/s3/_helpers/test_results.py
+++ b/tests/unit/core/providers/aws/s3/_helpers/test_results.py
@@ -498,7 +498,7 @@ class TestNoProgressResultPrinter(BaseResultPrinterTest):
         transfer_type = "upload"
         src = "file"
         dest = "s3://mybucket/test-key"
-        mb = 1024 * 1024  # pylint: disable=invalid-name
+        mb = 1024 * 1024
         self.result_recorder.expected_files_transferred = 1
         self.result_recorder.files_transferred = 1
         self.result_recorder.expected_bytes_transferred = mb
@@ -600,7 +600,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
         transfer_type = "upload"
         src = "file"
         dest = "s3://mybucket/test-key"
-        mb = 1024 * 1024  # pylint: disable=invalid-name
+        mb = 1024 * 1024
         self.result_recorder.expected_files_transferred = 1
         self.result_recorder.files_transferred = 1
         self.result_recorder.expected_bytes_transferred = mb

--- a/tests/unit/core/providers/aws/test_assume_role.py
+++ b/tests/unit/core/providers/aws/test_assume_role.py
@@ -1,5 +1,4 @@
 """Test runway.core.providers.aws._assume_role."""
-# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/dependency_managers/test__pipenv.py
+++ b/tests/unit/dependency_managers/test__pipenv.py
@@ -1,5 +1,5 @@
 """Test runway.dependency_manager._pipenv."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 import logging

--- a/tests/unit/dependency_managers/test__poetry.py
+++ b/tests/unit/dependency_managers/test__poetry.py
@@ -1,5 +1,5 @@
 """Test runway.dependency_managers._poetry."""
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 import subprocess

--- a/tests/unit/lookups/handlers/test_ecr.py
+++ b/tests/unit/lookups/handlers/test_ecr.py
@@ -1,5 +1,5 @@
 """Test runway.lookups.handlers.ecr."""
-# pylint: disable=no-self-use,too-few-public-methods,redefined-outer-name
+# pylint: disable=no-self-use,redefined-outer-name
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/lookups/handlers/test_var.py
+++ b/tests/unit/lookups/handlers/test_var.py
@@ -1,5 +1,5 @@
 """Tests for lookup handler for var."""
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/mock_docker/fake_api.py
+++ b/tests/unit/mock_docker/fake_api.py
@@ -1,7 +1,7 @@
 """Fake Docker API."""
 # cspell:disable
 # flake8: noqa=D103
-# pylint: disable=consider-using-f-string,invalid-name,missing-docstring
+# pylint: disable=consider-using-f-string,invalid-name
 from typing import Any, Callable, Dict, Tuple, Union
 
 from docker import constants

--- a/tests/unit/module/test_base.py
+++ b/tests/unit/module/test_base.py
@@ -1,6 +1,5 @@
 """Test runway.module.base."""
-# pylint: disable=comparison-with-callable,no-self-use,unused-argument
-# comparison-with-callable is intermittent - possibly due to use of runway.compat?
+# pylint: disable=no-self-use
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/module/test_base.py
+++ b/tests/unit/module/test_base.py
@@ -1,5 +1,6 @@
 """Test runway.module.base."""
-# pylint: disable=no-self-use
+# pylint: disable=comparison-with-callable,no-self-use
+# comparison-with-callable is intermittent - possibly due to use of runway.compat?
 # pyright: basic
 from __future__ import annotations
 

--- a/tests/unit/module/test_serverless.py
+++ b/tests/unit/module/test_serverless.py
@@ -1,5 +1,5 @@
 """Test runway.module.serverless."""
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=no-self-use
 # pyright: basic, reportFunctionMemberAccess=none
 from __future__ import annotations
 
@@ -334,7 +334,6 @@ class TestServerless:
         tmp_path: Path,
     ) -> None:
         """Test gen_cmd."""
-        # pylint: disable=no-member
         mock_cmd = mocker.patch(
             "runway.module.serverless.generate_node_command", return_value=["success"]
         )

--- a/tests/unit/module/test_terraform.py
+++ b/tests/unit/module/test_terraform.py
@@ -1,5 +1,5 @@
 """Test runway.module.terraform."""
-# pylint: disable=no-self-use,protected-access,too-many-statements,unused-argument,too-many-lines
+# pylint: disable=no-self-use,too-many-statements,too-many-lines
 # pyright: basic, reportFunctionMemberAccess=none
 from __future__ import annotations
 

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -1,5 +1,5 @@
 """Test runway.mixins."""
-# pylint: disable=no-self-use,protected-access,unused-argument
+# pylint: disable=protected-access,unused-argument
 from __future__ import annotations
 
 import subprocess

--- a/tests/unit/utils/test__version.py
+++ b/tests/unit/utils/test__version.py
@@ -1,5 +1,5 @@
 """Test runway.core.utils."""
-# pylint: disable=no-self-use,protected-access,redefined-outer-name
+# pylint: disable=no-self-use
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -251,7 +251,8 @@ class TestSafeHaven:
         expected_logs = ["entering a safe haven...", "resetting sys.modules..."]
 
         with SafeHaven() as obj:
-            from ..fixtures import mock_hooks  # noqa pylint: disable=E,W,C
+            # pylint: disable=import-outside-toplevel
+            from ..fixtures import mock_hooks  # noqa: F401
 
             assert sys.modules != orig_val
             obj.reset_sys_modules()
@@ -267,7 +268,8 @@ class TestSafeHaven:
 
         assert module not in sys.modules
         with SafeHaven(sys_modules_exclude=[module]) as obj:
-            from ..fixtures import mock_hooks  # noqa pylint: disable=E,W,C
+            # pylint: disable=import-outside-toplevel
+            from ..fixtures import mock_hooks  # noqa: F401
 
             assert module in sys.modules
             obj.reset_sys_modules()


### PR DESCRIPTION
# Summary

Cleanup useless pylint suppressions as identified by using `--enable=useless-suppressions` when running pylint with python 3.7.
