### PR TITLE
consolidate `.runway/` as much as possible - based on config location

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,10 +26,10 @@
         "**/.mypy_cache": true,
         "**/.pytest_cache": true,
         "**/.runway": true,
-        "**/.runway_cache": true,
         "**/.serverless": true,
         "**/.svn": true,
         "**/CVS": true,
+        "**/Thumbs.db": true,
         "**/__pycache__": true
     },
     "files.insertFinalNewline": true,

--- a/docs/source/cfngin/configuration.rst
+++ b/docs/source/cfngin/configuration.rst
@@ -176,14 +176,18 @@ Top-Level Fields
 
   .. attribute:: cfngin_cache_dir
     :type: Optional[str]
-    :value: ./.runway/cache
+    :value: ./.runway/
 
     Path to a local directory that CFNgin will use for local caching.
+
+    If provided, the cache location is relative to the CFNgin configuration file.
+
+    If NOT provided, the cache location is relative to the ``runway.yaml``/``runway.yml`` file and is shared between all Runway modules.
 
     .. rubric:: Example
     .. code-block:: yaml
 
-        cfngin_cache_dir: ./.runway/cache
+        cfngin_cache_dir: ./.runway
 
   .. attribute:: log_formats
     :type: Optional[Dict[str, str]]

--- a/runway/_cli/utils.py
+++ b/runway/_cli/utils.py
@@ -72,7 +72,6 @@ class CliContext:
         """Runway config."""
         config = RunwayConfig.parse_file(file_path=self.runway_config_path)
         self.env.ignore_git_branch = config.ignore_git_branch
-        # self.env.root_dir = self.runway_config_path.parent
         return config
 
     @cached_property
@@ -99,6 +98,8 @@ class CliContext:
     ) -> RunwayContext:
         """Get a Runway context object.
 
+        Uses the location of the config file to set the working directory for Runway.
+
         Args:
             deploy_environment: Object representing the current deploy environment.
 
@@ -106,7 +107,10 @@ class CliContext:
             RunwayContext
 
         """
-        return RunwayContext(deploy_environment=deploy_environment or self.env)
+        return RunwayContext(
+            deploy_environment=deploy_environment or self.env,
+            work_dir=self.runway_config_path.parent / ".runway",
+        )
 
     def __getitem__(self, key: str) -> Any:
         """Implement evaluation of self[key].

--- a/runway/cfngin/cfngin.py
+++ b/runway/cfngin/cfngin.py
@@ -265,7 +265,11 @@ class CFNgin:
             validate: Validate the loaded config.
 
         """
-        return CfnginConfig.parse_file(file_path=file_path, parameters=self.parameters)
+        return CfnginConfig.parse_file(
+            file_path=file_path,
+            parameters=self.parameters,
+            work_dir=self.__ctx.work_dir,
+        )
 
     def _get_context(self, config: CfnginConfig, config_path: Path) -> CfnginContext:
         """Initialize a CFNgin context object.
@@ -282,6 +286,7 @@ class CFNgin:
             force_stacks=[],  # placeholder
             parameters=self.parameters,
             stack_names=[],  # placeholder
+            work_dir=self.__ctx.work_dir,
         )
 
     def _get_provider_builder(

--- a/runway/cfngin/hooks/awslambda/base_classes.py
+++ b/runway/cfngin/hooks/awslambda/base_classes.py
@@ -21,7 +21,6 @@ from typing_extensions import Literal
 
 from ....compat import cached_property
 from ..protocols import CfnginHookProtocol
-from .constants import BASE_WORK_DIR
 from .exceptions import RuntimeMismatchError
 from .models.args import AwsLambdaHookArgs
 from .models.responses import AwsLambdaHookDeployResponse
@@ -69,7 +68,7 @@ class Project(Generic[_AwsLambdaHookArgsTypeVar]):
     def build_directory(self) -> Path:
         """Directory being used to build deployment package."""
         result = (
-            BASE_WORK_DIR
+            self.ctx.work_dir
             / f"{self.source_code.root_directory.name}.{self.source_code.md5_hash}"
         )
         result.mkdir(exist_ok=True, parents=True)
@@ -90,7 +89,7 @@ class Project(Generic[_AwsLambdaHookArgsTypeVar]):
         cache_dir = (
             self.args.cache_dir
             if self.args.cache_dir
-            else BASE_WORK_DIR / self.DEFAULT_CACHE_DIR_NAME
+            else self.ctx.work_dir / self.DEFAULT_CACHE_DIR_NAME
         )
         cache_dir.mkdir(exist_ok=True, parents=True)
         return cache_dir

--- a/runway/cfngin/hooks/awslambda/constants.py
+++ b/runway/cfngin/hooks/awslambda/constants.py
@@ -1,11 +1,6 @@
 """Constant values."""
-from runway.constants import DOT_RUNWAY_DIR
-
 AWS_SAM_BUILD_IMAGE_PREFIX = "public.ecr.aws/sam/build-"
 """Prefix for build image registries."""
-
-BASE_WORK_DIR = DOT_RUNWAY_DIR / "awslambda"
-"""Base work directory for the awslambda hooks."""
 
 DEFAULT_IMAGE_NAME = "runway.cfngin.hooks.awslambda"
 """Default name to apply to an image when building from a Dockerfile."""

--- a/runway/cfngin/hooks/awslambda/python_requirements/_project.py
+++ b/runway/cfngin/hooks/awslambda/python_requirements/_project.py
@@ -16,7 +16,6 @@ from .....dependency_managers import (
     PoetryNotFoundError,
 )
 from ..base_classes import Project
-from ..constants import BASE_WORK_DIR
 from ..models.args import PythonHookArgs
 from . import PythonDockerDependencyInstaller
 
@@ -164,7 +163,7 @@ class PythonProject(Project[PythonHookArgs]):
         This path is only used when exporting from another format.
 
         """
-        return BASE_WORK_DIR / f"{self.source_code.md5_hash}.requirements.txt"
+        return self.ctx.work_dir / f"{self.source_code.md5_hash}.requirements.txt"
 
     def cleanup(self) -> None:
         """Cleanup temporary files after the build process has run."""

--- a/runway/cfngin/utils.py
+++ b/runway/cfngin/utils.py
@@ -582,19 +582,15 @@ class SourceProcessor:
     def __init__(
         self,
         sources: CfnginPackageSourcesDefinitionModel,
-        cache_dir: Optional[Path] = None,
+        cache_dir: Path,
     ) -> None:
         """Process a config's defined package sources.
 
         Args:
-            sources: Package sources from CFNgin config
-                dictionary.
-            cache_dir: Path where remote sources will be
-                cached.
+            sources: Package sources from CFNgin config dictionary.
+            cache_dir: Path where remote sources will be cached.
 
         """
-        if not cache_dir:
-            cache_dir = Path.cwd() / ".runway" / "cache"
         self.cache_dir = cache_dir
         self.package_cache_dir = cache_dir / "packages"
         self.sources = sources

--- a/runway/config/__init__.py
+++ b/runway/config/__init__.py
@@ -416,8 +416,10 @@ class CfnginConfig(BaseConfig):
             sources=CfnginPackageSourcesDefinitionModel.parse_obj(
                 config.get("package_sources", {})  # type: ignore
             ),
-            cache_dir=config.get(
-                "cfngin_cache_dir", (work_dir or Path().cwd() / ".runway") / "cache"
+            cache_dir=Path(
+                config.get(
+                    "cfngin_cache_dir", (work_dir or Path().cwd() / ".runway") / "cache"
+                )
             ),
         )
         processor.get_package_sources()

--- a/runway/config/__init__.py
+++ b/runway/config/__init__.py
@@ -141,58 +141,99 @@ class CfnginConfig(BaseConfig):
     """
 
     EXCLUDE_REGEX = r"runway(\..*)?\.(yml|yaml)"
-    EXCLUDE_LIST = ["bitbucket-pipelines.yml", "buildspec.yml", "docker-compose.yml"]
+    """Regex for file names to exclude when looking for config files."""
 
-    #: Bucket to use for CFNgin resources. (e.g. CloudFormation templates).
-    #: May be an empty string.
+    EXCLUDE_LIST = ["bitbucket-pipelines.yml", "buildspec.yml", "docker-compose.yml"]
+    """Explicit files names to ignore when looking for config files."""
+
     cfngin_bucket: Optional[str]
-    #: Explicit region to use for :attr:`CfnginConfig.cfngin_bucket`
+    """Bucket to use for CFNgin resources. (e.g. CloudFormation templates).
+    May be an empty string.
+    """
+
     cfngin_bucket_region: Optional[str]
     """Explicit region to use for :attr:`CfnginConfig.cfngin_bucket`"""
-    cfngin_cache_dir: Path  #: Local directory to use for caching.
-    log_formats: Dict[str, str]  #: Custom formatting for log messages.
-    lookups: Dict[str, str]  #: Register custom lookups.
-    mappings: Dict[  #: Mappings that will be added to all stacks.
-        str, Dict[str, Dict[str, Any]]
-    ]
-    namespace: str  #: Namespace to prepend to everything.
-    # Character used to separate :attr:`CfnginConfig.namespace` and anything it prepends.
+
+    cfngin_cache_dir: Path
+    """Local directory to use for caching."""
+
+    log_formats: Dict[str, str]
+    """Custom formatting for log messages."""
+
+    lookups: Dict[str, str]
+    """Register custom lookups."""
+
+    mappings: Dict[str, Dict[str, Dict[str, Any]]]
+    """Mappings that will be added to all stacks."""
+
+    namespace: str
+    """Namespace to prepend to everything."""
+
     namespace_delimiter: str
-    package_sources: CfnginPackageSourcesDefinitionModel  #: Remote source locations.
-    persistent_graph_key: Optional[  #: S3 object key were the persistent graph is stored.
-        str
-    ] = None
-    post_deploy: List[CfnginHookDefinitionModel]  #: Hooks to run after a deploy action.
-    post_destroy: List[  #: Hooks to run after a destroy action.
-        CfnginHookDefinitionModel
-    ]
-    pre_deploy: List[CfnginHookDefinitionModel]  #: Hooks to run before a deploy action.
-    pre_destroy: List[  #: Hooks to run before a destroy action.
-        CfnginHookDefinitionModel
-    ]
-    service_role: Optional[str]  #: IAM role for CloudFormation to use.
-    stacks: List[CfnginStackDefinitionModel]  #: Stacks to be processed.
-    sys_path: Optional[Path]  #: Relative or absolute path to use as the work directory.
-    tags: Optional[Dict[str, str]]  #: Tags to apply to all resources.
-    template_indent: int  #: Spaces to use per-indent level when outputing a template to json.
+    """Character used to separate :attr:`CfnginConfig.namespace` and anything it prepends."""
+
+    package_sources: CfnginPackageSourcesDefinitionModel
+    """Remote source locations."""
+
+    persistent_graph_key: Optional[str] = None
+    """S3 object key were the persistent graph is stored."""
+
+    post_deploy: List[CfnginHookDefinitionModel]
+    """Hooks to run after a deploy action."""
+
+    post_destroy: List[CfnginHookDefinitionModel]
+    """Hooks to run after a destroy action."""
+
+    pre_deploy: List[CfnginHookDefinitionModel]
+    """Hooks to run before a deploy action."""
+
+    pre_destroy: List[CfnginHookDefinitionModel]
+    """Hooks to run before a destroy action."""
+
+    service_role: Optional[str]
+    """IAM role for CloudFormation to use."""
+
+    stacks: List[CfnginStackDefinitionModel]
+    """Stacks to be processed."""
+
+    sys_path: Optional[Path]
+    """Relative or absolute path to use as the work directory."""
+
+    tags: Optional[Dict[str, str]]
+    """Tags to apply to all resources."""
+
+    template_indent: int
+    """Spaces to use per-indent level when outputing a template to json."""
 
     _data: CfnginConfigDefinitionModel
 
     def __init__(
-        self, data: CfnginConfigDefinitionModel, *, path: Optional[Path] = None
+        self,
+        data: CfnginConfigDefinitionModel,
+        *,
+        path: Optional[Path] = None,
+        work_dir: Optional[Path] = None,
     ) -> None:
         """Instantiate class.
 
         Args:
             data: The data model of the config file.
             path: Path to the config file.
+            work_dir: Working directory.
 
         """
         super().__init__(data, path=path)
 
         self.cfngin_bucket = self._data.cfngin_bucket
         self.cfngin_bucket_region = self._data.cfngin_bucket_region
-        self.cfngin_cache_dir = self._data.cfngin_cache_dir
+        if self._data.cfngin_cache_dir:
+            self.cfngin_cache_dir = self._data.cfngin_cache_dir
+        elif work_dir:
+            self.cfngin_cache_dir = work_dir / "cache"
+        elif path:
+            self.cfngin_cache_dir = path.parent / ".runway" / "cache"
+        else:
+            self.cfngin_cache_dir = Path().cwd() / ".runway" / "cache"
         self.log_formats = self._data.log_formats
         self.lookups = self._data.lookups
         self.mappings = self._data.mappings
@@ -268,6 +309,7 @@ class CfnginConfig(BaseConfig):
         path: Optional[Path] = None,
         file_path: Optional[Path] = None,
         parameters: Optional[MutableMapping[str, Any]] = None,
+        work_dir: Optional[Path] = None,
         **kwargs: Any,
     ) -> CfnginConfig:
         """Parse a YAML file to create a config object.
@@ -276,6 +318,7 @@ class CfnginConfig(BaseConfig):
             path: The path to search for a config file.
             file_path: Exact path to a file to parse.
             parameters: Values to use when resolving a raw config.
+            work_dir: Explicit working directory.
 
         Raises:
             ConfigNotFound: Provided config file was not found.
@@ -288,6 +331,7 @@ class CfnginConfig(BaseConfig):
                 file_path.read_text(),
                 path=file_path,
                 parameters=parameters or {},
+                work_dir=work_dir,
                 **kwargs,
             )
         if path:
@@ -295,20 +339,28 @@ class CfnginConfig(BaseConfig):
             if len(found) > 1:
                 raise ValueError(f"more than one config files found: {found}")
             return cls.parse_file(
-                file_path=found[0], parameters=parameters or {}, **kwargs
+                file_path=found[0],
+                parameters=parameters or {},
+                work_dir=work_dir,
+                **kwargs,
             )
         raise ValueError("must provide path or file_path")
 
     @classmethod
-    def parse_obj(cls, obj: Any, *, path: Optional[Path] = None) -> CfnginConfig:
+    def parse_obj(
+        cls, obj: Any, *, path: Optional[Path] = None, work_dir: Optional[Path] = None
+    ) -> CfnginConfig:
         """Parse a python object.
 
         Args:
             obj: A python object to parse as a CFNgin config.
             path: The path to the config file that was parsed into the object.
+            work_dir: Working directory.
 
         """
-        return cls(CfnginConfigDefinitionModel.parse_obj(obj), path=path)
+        return cls(
+            CfnginConfigDefinitionModel.parse_obj(obj), path=path, work_dir=work_dir
+        )
 
     @classmethod
     def parse_raw(
@@ -318,6 +370,7 @@ class CfnginConfig(BaseConfig):
         parameters: Optional[MutableMapping[str, Any]] = None,
         path: Optional[Path] = None,
         skip_package_sources: bool = False,
+        work_dir: Optional[Path] = None,
     ) -> CfnginConfig:
         """Parse raw data.
 
@@ -326,6 +379,7 @@ class CfnginConfig(BaseConfig):
             parameters: Values to use when resolving a raw config.
             path: The path to search for a config file.
             skip_package_sources: Skip processing package sources.
+            work_dir: Explicit working directory.
 
         """
         if not parameters:
@@ -334,19 +388,27 @@ class CfnginConfig(BaseConfig):
         if skip_package_sources:
             return cls.parse_obj(yaml.safe_load(pre_rendered))
         config_dict = yaml.safe_load(
-            cls.process_package_sources(pre_rendered, parameters=parameters)
+            cls.process_package_sources(
+                pre_rendered, parameters=parameters, work_dir=work_dir
+            )
         )
         return cls.parse_obj(config_dict, path=path)
 
     @classmethod
     def process_package_sources(
-        cls, raw_data: str, *, parameters: Optional[MutableMapping[str, Any]] = None
+        cls,
+        raw_data: str,
+        *,
+        parameters: Optional[MutableMapping[str, Any]] = None,
+        work_dir: Optional[Path] = None,
     ) -> str:
         """Process the package sources defined in a rendered config.
 
         Args:
             raw_data: Raw configuration data.
+            cache_dir: Directory to use when caching remote sources.
             parameters: Values to use when resolving a raw config.
+            work_dir: Explicit working directory.
 
         """
         config = yaml.safe_load(raw_data) or {}
@@ -354,7 +416,9 @@ class CfnginConfig(BaseConfig):
             sources=CfnginPackageSourcesDefinitionModel.parse_obj(
                 config.get("package_sources", {})  # type: ignore
             ),
-            cache_dir=config.get("cfngin_cache_dir"),
+            cache_dir=config.get(
+                "cfngin_cache_dir", (work_dir or Path().cwd() / ".runway") / "cache"
+            ),
         )
         processor.get_package_sources()
         if processor.configs_to_merge:

--- a/runway/config/models/cfngin/__init__.py
+++ b/runway/config/models/cfngin/__init__.py
@@ -217,8 +217,8 @@ class CfnginConfigDefinitionModel(ConfigProperty):
         description="AWS Region where the CFNgin Bucket is located. "
         "If not provided, the current region is used.",
     )
-    cfngin_cache_dir: Path = Field(
-        default=Path.cwd() / ".runway" / "cache",
+    cfngin_cache_dir: Optional[Path] = Field(
+        default=None,
         title="CFNgin Cache Directory",
         description="Path to a local directory that CFNgin will use for local caching.",
     )

--- a/runway/constants.py
+++ b/runway/constants.py
@@ -1,12 +1,8 @@
 """Runway constants."""
-from pathlib import Path
 from typing import Any, Dict
 
-# A global credential cache that can be shared among boto3 sessions. This is
-# inherently threadsafe thanks to the GIL:
-# https://docs.python.org/3/glossary.html#term-global-interpreter-lock
 BOTO3_CREDENTIAL_CACHE: Dict[str, Any] = {}
-
-DOT_RUNWAY_DIR = Path.cwd() / ".runway"
-
-DEFAULT_CACHE_DIR = DOT_RUNWAY_DIR / "cache"
+"""A global credential cache that can be shared among boto3 sessions.
+This is inherently threadsafe thanks to the GIL.
+(https://docs.python.org/3/glossary.html#term-global-interpreter-lock)
+"""

--- a/runway/context/_base.py
+++ b/runway/context/_base.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import boto3
@@ -25,14 +26,23 @@ class BaseContext(DelCachedPropMixin):
     """Base class for context objects."""
 
     env: DeployEnvironment
+    """Object containing information about the environment being deployed to."""
+
     logger: Union[PrefixAdaptor, RunwayLogger]
+    """Custom logger."""
+
     sys_info: SystemInfo
+    """Information about the current system being used to run Runway."""
+
+    work_dir: Path
+    """Working directory used by Runway. Should always be a directory named ``.runway``."""
 
     def __init__(
         self,
         *,
         deploy_environment: DeployEnvironment,
         logger: Union[PrefixAdaptor, RunwayLogger] = LOGGER,
+        work_dir: Optional[Path] = None,
         **_: Any,
     ) -> None:
         """Instantiate class.
@@ -40,11 +50,13 @@ class BaseContext(DelCachedPropMixin):
         Args:
             deploy_environment: The current deploy environment.
             logger: Custom logger.
+            work_dir: Working directory used by Runway.
 
         """
         self.env = deploy_environment
         self.logger = logger
         self.sys_info = SystemInfo()
+        self.work_dir = work_dir or Path.cwd() / ".runway"
 
     @property
     def boto3_credentials(self) -> Boto3CredentialsTypeDef:

--- a/runway/context/_cfngin.py
+++ b/runway/context/_cfngin.py
@@ -94,6 +94,7 @@ class CfnginContext(BaseContext):
         logger: Union[PrefixAdaptor, RunwayLogger] = LOGGER,
         parameters: Optional[MutableMapping[str, Any]] = None,
         stack_names: Optional[List[str]] = None,
+        work_dir: Optional[Path] = None,
         **_: Any,
     ) -> None:
         """Instantiate class.
@@ -107,6 +108,7 @@ class CfnginContext(BaseContext):
             parameters: Parameters passed from Runway or read from a file.
             stack_names: A list of stack_names to operate on. If not passed,
                 all stacks defined in the config will be operated on.
+            work_dir: Working directory used by Runway.
 
         """
         self.config_path = config_path or Path.cwd()
@@ -116,6 +118,7 @@ class CfnginContext(BaseContext):
                 self.config_path.name.split(".")[0],
                 logger if isinstance(logger, RunwayLogger) else LOGGER,
             ),
+            work_dir=work_dir or self.config_path / ".runway",
         )
         self._persistent_graph_lock_code = None
         self._persistent_graph = None
@@ -347,6 +350,7 @@ class CfnginContext(BaseContext):
             logger=self.logger,
             parameters=self.parameters,
             stack_name=self.stack_names,
+            work_dir=self.work_dir,
         )
 
     def get_fqn(self, name: Optional[str] = None) -> str:

--- a/runway/context/_runway.py
+++ b/runway/context/_runway.py
@@ -11,6 +11,8 @@ from ..core.components import DeployEnvironment
 from ._base import BaseContext
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from .._logging import PrefixAdaptor, RunwayLogger
     from ..core.type_defs import RunwayActionTypeDef
 
@@ -21,8 +23,7 @@ class RunwayContext(BaseContext):
     """Runway context object."""
 
     command: Optional[RunwayActionTypeDef]
-    env: DeployEnvironment
-    logger: Union[PrefixAdaptor, RunwayLogger]
+    """Runway command/action being run."""
 
     def __init__(
         self,
@@ -30,6 +31,7 @@ class RunwayContext(BaseContext):
         command: Optional[RunwayActionTypeDef] = None,
         deploy_environment: Optional[DeployEnvironment] = None,
         logger: Union[PrefixAdaptor, RunwayLogger] = LOGGER,
+        work_dir: Optional[Path] = None,
         **_: Any,
     ) -> None:
         """Instantiate class.
@@ -38,10 +40,13 @@ class RunwayContext(BaseContext):
             command: Runway command/action being run.
             deploy_environment: The current deploy environment.
             logger: Custom logger.
+            work_dir: Working directory used by Runway.
 
         """
         super().__init__(
-            deploy_environment=deploy_environment or DeployEnvironment(), logger=logger
+            deploy_environment=deploy_environment or DeployEnvironment(),
+            logger=logger,
+            work_dir=work_dir,
         )
         self.command = command
         self._inject_profile_credentials()
@@ -88,7 +93,10 @@ class RunwayContext(BaseContext):
     def copy(self) -> RunwayContext:
         """Copy the contents of this object into a new instance."""
         return self.__class__(
-            command=self.command, deploy_environment=self.env.copy(), logger=self.logger
+            command=self.command,
+            deploy_environment=self.env.copy(),
+            logger=self.logger,
+            work_dir=self.work_dir,
         )
 
     def echo_detected_environment(self) -> None:

--- a/runway/core/components/_module.py
+++ b/runway/core/components/_module.py
@@ -126,7 +126,11 @@ class Module:
     @cached_property
     def path(self) -> ModulePath:  # lazy load the path
         """Return resolve module path."""
-        return ModulePath.parse_obj(self.definition, deploy_environment=self.ctx.env)
+        return ModulePath.parse_obj(
+            self.definition,
+            cache_dir=self.ctx.work_dir / "cache",
+            deploy_environment=self.ctx.env,
+        )
 
     @cached_property
     def payload(self) -> Dict[str, Any]:  # lazy load the payload

--- a/runway/core/components/_module_path.py
+++ b/runway/core/components/_module_path.py
@@ -12,7 +12,6 @@ from typing_extensions import TypedDict
 from ...compat import cached_property
 from ...config.components.runway import RunwayModuleDefinition
 from ...config.models.runway import RunwayModuleDefinitionModel
-from ...constants import DEFAULT_CACHE_DIR
 from ...sources.git import Git
 from ._deploy_environment import DeployEnvironment
 
@@ -44,7 +43,7 @@ class ModulePath:
         self,
         definition: Optional[Union[Path, str]] = None,
         *,
-        cache_dir: Path = DEFAULT_CACHE_DIR,
+        cache_dir: Path,
         deploy_environment: Optional[DeployEnvironment] = None,
     ) -> None:
         """Instantiate class.
@@ -145,12 +144,14 @@ class ModulePath:
             Union[Path, RunwayModuleDefinition, RunwayModuleDefinitionModel, str]
         ],
         *,
+        cache_dir: Path,
         deploy_environment: Optional[DeployEnvironment] = None,
     ) -> ModulePath:
         """Parse object.
 
         Args:
             obj: Object to parse.
+            cache_dir: Directory to use for caching if needed.
             deploy_environment: Current deploy environment object.
 
         Raises:
@@ -158,9 +159,17 @@ class ModulePath:
 
         """
         if isinstance(obj, (RunwayModuleDefinition, RunwayModuleDefinitionModel)):
-            return cls(definition=obj.path, deploy_environment=deploy_environment)
+            return cls(
+                cache_dir=cache_dir,
+                definition=obj.path,
+                deploy_environment=deploy_environment,
+            )
         if isinstance(obj, (type(None), Path, str)):
-            return cls(definition=obj, deploy_environment=deploy_environment)
+            return cls(
+                cache_dir=cache_dir,
+                definition=obj,
+                deploy_environment=deploy_environment,
+            )
         raise TypeError(
             f"object type {type(obj)}; expected pathlib.Path, "
             "RunwayModuleDefinition, RunwayModuleDefinitionModel, or str"

--- a/runway/module/serverless.py
+++ b/runway/module/serverless.py
@@ -20,7 +20,6 @@ from ..compat import cached_property
 from ..config.models.runway.options.serverless import (
     RunwayServerlessModuleOptionsDataModel,
 )
-from ..constants import DOT_RUNWAY_DIR
 from ..s3_utils import does_s3_object_exist, download, upload
 from ..utils import YamlDumper, merge_dicts
 from .base import ModuleOptions, RunwayModuleNpm
@@ -308,7 +307,7 @@ class Serverless(RunwayModuleNpm):
     def _deploy_package(self) -> None:
         """Deploy Serverless package."""
         if self.options.promotezip.bucketname:
-            with tempfile.TemporaryDirectory(dir=DOT_RUNWAY_DIR) as tmp_dir:
+            with tempfile.TemporaryDirectory(dir=self.ctx.work_dir) as tmp_dir:
                 artifact = ServerlessArtifact(
                     self.ctx,
                     self.sls_print(),

--- a/runway/sources/source.py
+++ b/runway/sources/source.py
@@ -8,8 +8,6 @@ import logging
 from pathlib import Path
 from typing import Any, Union
 
-from ..constants import DEFAULT_CACHE_DIR
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -30,7 +28,7 @@ class Source:
 
     cache_dir: Path
 
-    def __init__(self, *, cache_dir: Union[Path, str] = DEFAULT_CACHE_DIR, **_: Any):
+    def __init__(self, *, cache_dir: Union[Path, str], **_: Any):
         """Source.
 
         Args:

--- a/tests/functional/cfngin/hooks/test_awslambda/test_runner.py
+++ b/tests/functional/cfngin/hooks/test_awslambda/test_runner.py
@@ -14,7 +14,6 @@ import pytest
 from pydantic import root_validator
 
 from runway._cli import cli
-from runway.cfngin.hooks.awslambda.constants import BASE_WORK_DIR
 from runway.compat import cached_property
 from runway.utils import BaseModel
 
@@ -156,18 +155,6 @@ def deploy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
     (DOCKER_XMLSEC_DIR / "poetry.lock").unlink(missing_ok=True)
     for subdir in [DOCKER_MYSQL_DIR, DOCKER_XMLSEC_DIR]:
         shutil.rmtree(subdir / ".venv", ignore_errors=True)
-    # TODO fix how this dir is determined
-    for pattern in [
-        "docker.*",
-        "docker_mysql.*",
-        "docker_xmlsec.*",
-        "local.*",
-        "local_xmlsec_layer.*",
-    ]:
-        for match in BASE_WORK_DIR.rglob(pattern):
-            shutil.rmtree(match, ignore_errors=True)
-    for match in BASE_WORK_DIR.rglob("*.txt"):
-        match.unlink()
 
 
 @pytest.mark.order("first")

--- a/tests/functional/cfngin/test_parallel/test_runner.py
+++ b/tests/functional/cfngin/test_parallel/test_runner.py
@@ -27,6 +27,7 @@ def deploy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
 def destroy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
     """Execute `runway destroy`."""
     yield cli_runner.invoke(cli, ["destroy"], env={"CI": "1"})
+    shutil.rmtree(CURRENT_DIR / ".runway", ignore_errors=True)
     shutil.rmtree(CURRENT_DIR / "child-01.cfn" / ".runway", ignore_errors=True)
     shutil.rmtree(CURRENT_DIR / "child-02.cfn" / ".runway", ignore_errors=True)
 

--- a/tests/unit/cfngin/hooks/awslambda/python_requirements/test__project.py
+++ b/tests/unit/cfngin/hooks/awslambda/python_requirements/test__project.py
@@ -493,11 +493,10 @@ class TestPythonProject:
 
     def test_tmp_requirements_txt(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test tmp_requirements_txt."""
-        mocker.patch(f"{MODULE}.BASE_WORK_DIR", tmp_path)
         source_code = mocker.patch.object(
             PythonProject, "source_code", Mock(md5_hash="hash")
         )
         assert (
-            PythonProject(Mock(), Mock()).tmp_requirements_txt
+            PythonProject(Mock(), Mock(work_dir=tmp_path)).tmp_requirements_txt
             == tmp_path / f"{source_code.md5_hash}.requirements.txt"
         )

--- a/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
+++ b/tests/unit/cfngin/hooks/awslambda/test_base_classes.py
@@ -198,10 +198,9 @@ class TestProject:
         mocker.patch.object(
             Project, "source_code", Mock(md5_hash="hash", root_directory=tmp_path)
         )
-        mocker.patch(f"{MODULE}.BASE_WORK_DIR", tmp_path)
         expected = tmp_path / f"{tmp_path.name}.hash"
 
-        obj = Project(Mock(), Mock())
+        obj = Project(Mock(), Mock(work_dir=tmp_path))
         assert obj.build_directory == expected
         assert expected.is_dir()
 
@@ -220,7 +219,6 @@ class TestProject:
 
     def test_cache_dir_default(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Test cache_dir default."""
-        mocker.patch(f"{MODULE}.BASE_WORK_DIR", tmp_path)
         cache_dir = tmp_path / Project.DEFAULT_CACHE_DIR_NAME
         cache_dir.mkdir()
         args = AwsLambdaHookArgs(
@@ -229,7 +227,7 @@ class TestProject:
             source_code=tmp_path,
             use_cache=True,
         )
-        assert Project(args, Mock()).cache_dir == cache_dir
+        assert Project(args, Mock(work_dir=tmp_path)).cache_dir == cache_dir
 
     def test_cache_dir_disabled(self, tmp_path: Path) -> None:
         """Test cache_dir disabled."""

--- a/tests/unit/cfngin/test_utils.py
+++ b/tests/unit/cfngin/test_utils.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import logging
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, cast
@@ -259,6 +261,16 @@ def test_read_value_from_path_root_path_file(tmp_path: Path) -> None:
 class TestUtil(unittest.TestCase):
     """Tests for runway.cfngin.utils."""
 
+    tmp_path: Path
+
+    def setUp(self) -> None:
+        """Set up test case."""
+        self.tmp_path = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        """Tear down test case."""
+        shutil.rmtree(self.tmp_path, ignore_errors=True)
+
     def test_cf_safe_name(self) -> None:
         """Test cf safe name."""
         tests = (("abc-def", "AbcDef"), ("GhI", "GhI"), ("jKlm.noP", "JKlmNoP"))
@@ -363,7 +375,7 @@ Outputs:
             "create_cache_directories",
             new=mock_create_cache_directories,
         ):
-            sp = SourceProcessor(sources={})  # type: ignore
+            sp = SourceProcessor(cache_dir=self.tmp_path, sources={})  # type: ignore
 
             self.assertEqual(
                 sp.sanitize_git_path("git@github.com:foo/bar.git"),

--- a/tests/unit/config/models/cfngin/test_cfngin.py
+++ b/tests/unit/config/models/cfngin/test_cfngin.py
@@ -73,7 +73,7 @@ class TestCfnginConfigDefinitionModel:
         obj = CfnginConfigDefinitionModel(namespace="test")
         assert not obj.cfngin_bucket
         assert not obj.cfngin_bucket_region
-        assert obj.cfngin_cache_dir == Path.cwd() / ".runway" / "cache"
+        assert not obj.cfngin_cache_dir
         assert obj.log_formats == {}
         assert obj.lookups == {}
         assert obj.mappings == {}
@@ -110,8 +110,8 @@ class TestCfnginConfigDefinitionModel:
             cfngin_cache_dir="./cache",  # type: ignore
             sys_path="./something",  # type: ignore
         )
-        assert obj.cfngin_cache_dir.is_absolute()
-        assert obj.sys_path.is_absolute()  # type: ignore
+        assert obj.cfngin_cache_dir and obj.cfngin_cache_dir.is_absolute()
+        assert obj.sys_path and obj.sys_path.is_absolute()
 
     def test_required_fields(self) -> None:
         """Test required fields."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -183,7 +183,7 @@ def runway_config() -> MockRunwayConfig:
 
 
 @pytest.fixture(scope="function")
-def runway_context(request: FixtureRequest) -> MockRunwayContext:
+def runway_context(request: FixtureRequest, tmp_path: Path) -> MockRunwayContext:
     """Create a mock Runway context object."""
     env_vars = {
         "AWS_REGION": getattr(
@@ -206,4 +206,5 @@ def runway_context(request: FixtureRequest) -> MockRunwayContext:
     return MockRunwayContext(
         command="test",
         deploy_environment=DeployEnvironment(environ=env_vars, explicit_name="test"),
+        work_dir=tmp_path / ".runway",
     )

--- a/tests/unit/core/components/test_module.py
+++ b/tests/unit/core/components/test_module.py
@@ -173,7 +173,9 @@ class TestModule:
 
         assert mod.path == "module-path"
         mock_path.parse_obj.assert_called_once_with(
-            mod.definition, deploy_environment=mod.ctx.env
+            mod.definition,
+            cache_dir=runway_context.work_dir / "cache",
+            deploy_environment=mod.ctx.env,
         )
 
     def test_payload_with_deployment(

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -119,6 +119,7 @@ class MockCFNginContext(CfnginContext):
         force_stacks: Optional[List[str]] = None,
         region: Optional[str] = "us-east-1",
         stack_names: Optional[List[str]] = None,
+        work_dir: Optional[Path] = None,
         **_: Any,
     ) -> None:
         """Instantiate class."""
@@ -135,6 +136,7 @@ class MockCFNginContext(CfnginContext):
             force_stacks=force_stacks,
             parameters=parameters,
             stack_names=stack_names,
+            work_dir=work_dir,
         )
 
     def add_stubber(self, service_name: str, region: Optional[str] = None) -> Stubber:
@@ -210,12 +212,15 @@ class MockRunwayContext(RunwayContext):
         *,
         command: Optional[RunwayActionTypeDef] = None,
         deploy_environment: Any = None,
+        work_dir: Optional[Path] = None,
         **_: Any,
     ) -> None:
         """Instantiate class."""
         if not deploy_environment:
             deploy_environment = DeployEnvironment(environ={}, explicit_name="test")
-        super().__init__(command=command, deploy_environment=deploy_environment)
+        super().__init__(
+            command=command, deploy_environment=deploy_environment, work_dir=work_dir
+        )
         self._boto3_test_client = MutableMap()
         self._boto3_test_stubber = MutableMap()
         self._use_concurrent = True

--- a/tests/unit/module/test_serverless.py
+++ b/tests/unit/module/test_serverless.py
@@ -15,7 +15,6 @@ from pydantic import ValidationError
 from runway.config.models.runway.options.serverless import (
     RunwayServerlessModuleOptionsDataModel,
 )
-from runway.constants import DOT_RUNWAY_DIR
 from runway.module.serverless import (
     Serverless,
     ServerlessArtifact,
@@ -101,7 +100,9 @@ class TestServerless:
             options={"promotezip": {"bucketname": "test-bucket"}},
         )
         assert not obj._deploy_package()  # pylint: disable=protected-access
-        tempfile_temporary_directory.assert_called_once_with(dir=DOT_RUNWAY_DIR)
+        tempfile_temporary_directory.assert_called_once_with(
+            dir=runway_context.work_dir
+        )
         sls_print.assert_called_once()
         artifact_class.assert_called_once_with(
             runway_context,

--- a/tests/unit/sources/test_source.py
+++ b/tests/unit/sources/test_source.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from runway.constants import DEFAULT_CACHE_DIR
 from runway.sources.source import Source
 
 if TYPE_CHECKING:
@@ -20,16 +19,16 @@ LOGGER = logging.getLogger("runway")
 class TestSource:
     """Tests for the Source type object."""
 
-    def test_fetch_not_implemented(self) -> None:
+    def test_fetch_not_implemented(self, tmp_path: Path) -> None:
         """#fetch: By default a not implemented error should be thrown."""
-        source = Source()
+        source = Source(cache_dir=tmp_path)
         with pytest.raises(NotImplementedError):
             source.fetch()
 
-    def test_when_no_cache_dir_parameter_in_config(self) -> None:
+    def test_when_no_cache_dir_parameter_in_config(self, tmp_path: Path) -> None:
         """The default when no cache_dir is passed in the config."""
-        source = Source()
-        assert source.cache_dir == DEFAULT_CACHE_DIR
+        source = Source(cache_dir=tmp_path)
+        assert source.cache_dir == tmp_path
 
     def test_a_cache_directory_is_created(self, cd_tmp_path: Path) -> None:
         """Ensure a cache directory is created."""


### PR DESCRIPTION
# Summary

Runway will now do it best to only use one `.runway` working directory by default. This directory will be located in the same directory as the Runway config file.

CFNgin will also use this same working directory unless configured otherwise. If explicitly provided, it will be relative to the CFNgin config file it is defined in.

# Why This Is Needed

resolves #1150 

# What Changed

## Added

- added `work_dir` attribute and kwarg to `runway.config.CfnginConfig`
- added `work_dir` attribute and kwarg to `runway.context._base.BaseContext`

## Changed

- `runway.cfngin.utils.SourceProcessor` no longer has a default value for `cache_dir` - it must be explicitly provided to ensure it is in the correct location

## Removed

- removed `runway.constants.DOT_RUNWAY_DIR` as the location is now determined based on the location of the Runway config file
- removed `runway.constants.DEFAULT_CACHE_DIR` as the location is now determined based on the location of the Runway config file
