### PR TITLE
use pydantic data model to parse `cfngin.hooks.docker` hook arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build  clean help install lint list release test version
+.PHONY: build clean docs help install lint list release test version
 
 SHELL := /bin/bash
 

--- a/runway/cfngin/hooks/docker/_login.py
+++ b/runway/cfngin/hooks/docker/_login.py
@@ -1,67 +1,14 @@
-"""Docker login hook.
-
-Replicates the functionality of the ``docker login`` CLI command.
-
-This hook does not modify the Docker config file.
-The credentials/authenticated session is stored in memory and is deleted after
-processing a given CFNgin config file.
-
-This hook can be executed as a pre or post hook.
-The authenticated session carries over from pre to post and to each subsequent
-built-in Docker hook.
-
-.. rubric:: Hook Path
-
-``runway.cfngin.hooks.docker.login``
-
-.. rubric:: Args
-
-dockercfg_path (Optional[str])
-    Use a custom path for the Docker config file (``$HOME/.docker/config.json``
-    if present, otherwise ``$HOME/.dockercfg``).
-ecr (Optional[Union[bool, Dict[str, Optional[str]]]])
-    Information describing an ECR registry. This is used to construct the registry URL.
-    If providing a value for this field, do not provide a value for ``registry``.
-
-    If using a private registry, the value can simply be ``true``.
-    If using a public registry, more information is required.
-
-    account_id (Optional[str])
-        AWS account ID that owns the registry being logged into. If not provided,
-        it will be acquired automatically if needed.
-    alias (Optional[str])
-        If it is a public repository, provide the alias.
-    aws_region (Optional[str])
-        AWS region where the registry is located. If not provided, it will be acquired
-        automatically if needed.
-
-email (Optional[str])
-    The email for the registry account.
-password (str)
-    The plaintext password.
-registry (Optional[str])
-    URL to the registry (e.g. ``https://index.docker.io/v1/``).
-
-    If providing a value for this field, do not provide a value for ``ecr``.
-username (str)
-    The registry username. Defaults to ``AWS`` if supplying ``ecr``.
-
-.. rubric:: Example
-.. code-block:: yaml
-
-    pre_deploy:
-      - path: runway.cfngin.hooks.docker.login
-        args:
-          ecr: true
-          password: ${ecr login-password}
-
-"""
+"""Docker login hook."""
+# pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from .data_models import BaseModel, ElasticContainerRegistry
+from pydantic import Field, validator
+
+from ....utils import BaseModel
+from .data_models import ElasticContainerRegistry
 from .hook_data import DockerHookData
 
 if TYPE_CHECKING:
@@ -82,61 +29,45 @@ class LoginArgs(BaseModel):
 
     """
 
-    def __init__(
-        self,
-        *,
-        context: Optional[CfnginContext] = None,
-        dockercfg_path: Optional[str] = None,
-        ecr: Optional[Union[bool, Dict[str, Optional[str]]]] = None,
-        email: Optional[str] = None,
-        password: str,
-        registry: Optional[str] = None,
-        username: Optional[str] = None,
-        **_: Any,
-    ) -> None:
-        """Instantiate class.
+    _ctx: Optional[CfnginContext] = Field(default=None, alias="context", exclude=True)
 
-        Args:
-            context: CFNgin context object.
-            dockercfg_path: Use a custom path for the Docker config file
-                (``$HOME/.docker/config.json`` if present, otherwise ``$HOME/.dockercfg``).
-            ecr: Information describing an ECR registry. This is used to construct
-                the registry URL. If providing a value for this field, do not provide
-                a value for ``registry``.
-            email: The email for the registry account.
-            password: The plaintext password for the registry account.
-            registry: URL to the registry (e.g. ``https://index.docker.io/v1/``).
-            username: The registry username.
-                Defaults to ``AWS`` if supplying ``ecr``.
+    dockercfg_path: Optional[str] = None
+    """Path to a non-default Docker config file."""
 
-        """
-        super().__init__(context=context)
-        self.dockercfg_path = self._validate_str(dockercfg_path, optional=True)
-        self.email = self._validate_str(email, optional=True)
-        self.password = cast(str, self._validate_str(password, required=True))
-        self.registry = self.determine_registry(
-            context=context, ecr=ecr, registry=registry
-        )
-        if not username:
-            self.username = cast(
-                str, ("AWS" if ecr else self._validate_str(username, required=True))
-            )
-        else:
-            self.username = cast(str, self._validate_str(username, required=True))
+    ecr: Optional[ElasticContainerRegistry] = Field(default=None, exclude=True)
+    """Information describing an ECR registry."""
 
-    @staticmethod
-    def determine_registry(
-        context: Optional[CfnginContext] = None,
-        ecr: Optional[Union[bool, Dict[str, Optional[str]]]] = None,
-        registry: Optional[str] = None,
-    ) -> Optional[str]:
-        """Determine repository URI."""
-        if registry:
-            return registry
-        if ecr:
+    email: Optional[str] = None
+    """The email for the registry account."""
+
+    password: str
+    """The plaintext password for the registry account."""
+
+    registry: Optional[str] = None
+    """URI of the registry to login to."""
+
+    username: str = "AWS"
+    """The registry username."""
+
+    @validator("ecr", pre=True, allow_reuse=True)
+    def _set_ecr(cls, v: Any, values: Dict[str, Any]) -> Any:
+        """Set the value of ``ecr``."""
+        if v and isinstance(v, dict):
             return ElasticContainerRegistry.parse_obj(
-                ecr if isinstance(ecr, dict) else {}, context=context  # type: ignore
-            ).fqn
+                {"context": values.get("context"), **v}
+            )
+        return v
+
+    @validator("registry", pre=True, always=True, allow_reuse=True)
+    def _set_registry(cls, v: Any, values: Dict[str, Any]) -> Any:
+        """Set the value of ``registry``."""
+        if v:
+            return v
+
+        ecr: Optional[ElasticContainerRegistry] = values.get("ecr")
+        if ecr:
+            return ecr.fqn
+
         return None
 
 
@@ -148,8 +79,7 @@ def login(*, context: CfnginContext, **kwargs: Any) -> DockerHookData:
     kwargs are parsed by :class:`~runway.cfngin.hooks.docker.LoginArgs`.
 
     """
-    kwargs.pop("provider", None)
-    args = LoginArgs.parse_obj(kwargs, context=context)
+    args = LoginArgs.parse_obj({"context": context, **kwargs})
     docker_hook_data = DockerHookData.from_cfngin_context(context)
     docker_hook_data.client.login(**args.dict())
     LOGGER.info("logged into %s", args.registry)

--- a/runway/cfngin/hooks/docker/data_models.py
+++ b/runway/cfngin/hooks/docker/data_models.py
@@ -4,270 +4,24 @@ These are makeshift data models for use until Runway v2 is realeased and pydanti
 can be used.
 
 """
+# pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
-from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    Iterable,
-    List,
-    NoReturn,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, cast
 
-from typing_extensions import Literal
+from docker.models.images import Image
+from pydantic import Field, root_validator
 
 from ....core.providers.aws import AccountDetails
-from ....utils import MutableMap
+from ....utils import BaseModel, MutableMap
 
 if TYPE_CHECKING:
-    from docker.models.images import Image
-
     from ....context import CfnginContext
-
-    Model = TypeVar("Model", bound="BaseModel")
 
 
 ECR_REPO_FQN_TEMPLATE = (
     "{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/{repo_name}"
 )
-
-
-class BaseModel:
-    """Base model."""
-
-    def __init__(
-        self, *, context: Optional[CfnginContext] = None, **_kwargs: Any
-    ) -> None:
-        """Instantiate class."""
-        self._ctx = context
-
-    def dict(self) -> Dict[str, Any]:
-        """Return object as a dict."""
-        return {k: v for k, v in self.__iter__() if not k.startswith("_")}
-
-    def find(self, query: str, default: Any = None, **kwargs: Any) -> Any:
-        """Find a value in the object."""
-        split_query = query.split(".")
-
-        if len(split_query) == 1:
-            return self.get(split_query[0], default, **kwargs)
-
-        nested_value = self.get(split_query[0])
-
-        if not nested_value:
-            if self.get(query):
-                return self.get(query)
-            return default
-
-        try:
-            nested_value = nested_value.find(
-                query=".".join(split_query[1:]), default=default, **kwargs
-            )
-            return nested_value
-        except (AttributeError, KeyError):
-            return default
-
-    def get(self, name: str, default: Any = None) -> Any:
-        """Get a value or return default if it is not found.
-
-        Attr:
-            name: The value to look for.
-            default: Returned if no other value is found.
-
-        """
-        return getattr(self, name, default)
-
-    @staticmethod
-    def _validate_bool(value: Any) -> bool:
-        """Validate a bool type attribute."""
-        if isinstance(value, bool):
-            return value
-        return bool(value)
-
-    @overload
-    @classmethod
-    def _validate_dict(cls, value: Dict[str, Any]) -> Dict[str, Any]:
-        ...
-
-    @overload
-    @classmethod
-    def _validate_dict(cls, value: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-        ...
-
-    @overload
-    @classmethod
-    def _validate_dict(
-        cls, value: Optional[Dict[str, Any]], optional: Literal[True]
-    ) -> Optional[Dict[str, Any]]:
-        ...
-
-    @overload
-    @classmethod
-    def _validate_dict(
-        cls, value: Dict[str, Any], optional: bool = ..., required: bool = ...
-    ) -> Dict[str, str]:
-        ...
-
-    @overload
-    @classmethod
-    def _validate_dict(
-        cls, value: None, optional: bool = ..., required: Literal[True] = ...
-    ) -> NoReturn:
-        ...
-
-    @overload
-    @classmethod
-    def _validate_dict(
-        cls, value: Literal[None], optional: Literal[True], required: Literal[False]
-    ) -> None:
-        ...
-
-    @classmethod
-    def _validate_dict(
-        cls,
-        value: Optional[Union[Dict[str, Any], Any]],
-        optional: bool = False,
-        required: bool = False,
-    ) -> Optional[Union[Dict[str, Any], NoReturn]]:
-        """Validate a Dict type attribute."""
-        if not value:
-            if required:
-                raise ValueError("Dict can't be empty or NoneType")
-            if not isinstance(value, dict):
-                if optional:
-                    return None
-                return {}
-        if isinstance(value, dict):
-            return value
-        return cls._validate_dict(dict(value), optional=optional, required=required)
-
-    @classmethod
-    def _validate_int(
-        cls, value: Any, optional: bool = False, required: bool = False
-    ) -> Optional[int]:
-        """Validate int type attribute."""
-        if not value and value != 0:
-            if required:
-                raise ValueError("int can't be NoneType")
-            if optional:
-                return None
-        if isinstance(value, int):
-            return value
-        return cls._validate_int(int(value or 0), optional=optional, required=required)
-
-    @classmethod
-    def _validate_list_str(
-        cls,
-        value: Union[List[str], Any],
-        optional: bool = False,
-        required: bool = False,
-    ) -> Optional[List[str]]:
-        """Validate a List[str] type attribute."""
-        if not value:
-            if required:
-                raise ValueError("List can't be empty or NoneType")
-            if not isinstance(value, list):
-                if optional:
-                    return None
-                return []
-        if isinstance(value, list):
-            if all(isinstance(i, str) for i in value):
-                return value
-            for i in value:
-                if not isinstance(i, str):
-                    raise TypeError(f"expected List[str] not List[{type(i).__name__}]")
-        return cls._validate_list_str(  # type: ignore
-            list(value), optional=optional, required=required
-        )
-
-    @staticmethod
-    def _validate_path(value: Any, must_exist: bool = False) -> Path:
-        """Validate a Path type attribute.
-
-        Args:
-            value: A Path object or string that can be converted into a Path object.
-            must_exist: Raise an error if the path provided does not exist.
-
-        """
-        if isinstance(value, str):
-            value = Path(value)
-        if not isinstance(value, Path):
-            raise TypeError(f"expected Union[Path, str] not {type(value).__name__}")
-        if must_exist and not value.exists():
-            raise ValueError(f"provided path does not exist: {value.resolve()}")
-        return value
-
-    @classmethod
-    def _validate_str(
-        cls, value: Any, optional: bool = False, required: bool = False
-    ) -> Optional[str]:
-        """Validate str type attribute."""
-        if not value:
-            if required:
-                raise ValueError("value can't be empty or NoneType")
-            if not isinstance(value, str) and optional:
-                return None
-        if isinstance(value, str):
-            return value
-        if isinstance(value, (dict, list, set, tuple)):
-            raise TypeError(f"value can't be {type(value).__name__}")  # type: ignore
-        return cls._validate_str(str(value), optional=optional, required=required)
-
-    @classmethod
-    def parse_obj(
-        cls: Type[Model], obj: Any, context: Optional[CfnginContext] = None
-    ) -> Model:
-        """Parse object."""
-        if not isinstance(obj, dict):
-            try:
-                obj = dict(obj)
-            except (TypeError, ValueError):
-                raise TypeError(
-                    f"{cls.__name__} expected dict not {obj.__class__.__name__}"
-                ) from None
-        return cls(context=context, **obj)
-
-    def __eq__(self, other: Any) -> bool:
-        """Evaluate equal comparison operator."""
-        if isinstance(other, self.__class__):
-            return self.dict() == other.dict()
-        return self.dict() == other
-
-    def __getitem__(self, name: str) -> bool:
-        """Implement evaluation of self[name].
-
-        Args:
-            name: The value to look for.
-
-        Raises:
-            KeyError: Object does not contain a field of the name provided.
-
-        """
-        return getattr(self, name)
-
-    def __iter__(self) -> Iterable[Tuple[str, Any]]:
-        """Iterate object."""
-        yield from self.__dict__.items()
-
-    def __setitem__(self, name: str, value: Any) -> None:
-        """Implement assignment to self[key].
-
-        Args:
-            name: Attribute name to associate with a value.
-            value: Value of a key/attribute.
-
-        """
-        setattr(self, name, value)
 
 
 class ElasticContainerRegistry(BaseModel):
@@ -284,37 +38,20 @@ class ElasticContainerRegistry(BaseModel):
     PUBLIC_URI_TEMPLATE: ClassVar[str] = "public.ecr.aws/{registry_alias}/"
     URI_TEMPLATE: ClassVar[str] = "{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/"
 
-    account_id: Optional[str]
-    alias: Optional[str]
-    region: Optional[str]
-    public: bool
+    _ctx: Optional[CfnginContext] = Field(default=None, alias="context", exclude=True)
+    """CFNgin context."""
 
-    def __init__(
-        self,
-        *,
-        account_id: Optional[str] = None,
-        alias: Optional[str] = None,
-        aws_region: Optional[str] = None,
-        context: Optional[CfnginContext] = None,
-        **kwargs: Any,
-    ) -> None:
-        """Instantiate class."""
-        super().__init__(context=context, **kwargs)
-        self.account_id = self._validate_str(account_id, optional=True)
-        self.alias = self._validate_str(alias, optional=True)
-        self.region = self._validate_str(aws_region, optional=True)
-        self.public = bool(self.alias)
+    account_id: Optional[str] = None
+    """AWS account ID that owns the registry being logged into."""
 
-        if not self.public:
-            if not self._ctx and not (self.account_id or self.region):
-                raise ValueError("context is required to resolve values")
-            if not self.region:
-                self.region = self._validate_str(
-                    self._ctx.env.aws_region if self._ctx else "us-east-1",
-                    required=True,
-                )
-            if not self.account_id:
-                self.account_id = AccountDetails(cast("CfnginContext", self._ctx)).id
+    alias: Optional[str] = None
+    """If it is a public repository, the alias of the repository."""
+
+    public: bool = True
+    """Whether the repository is public."""
+
+    region: Optional[str] = Field(default=None, alias="aws_region")
+    """AWS region where the registry is located."""
 
     @property
     def fqn(self) -> str:
@@ -325,28 +62,43 @@ class ElasticContainerRegistry(BaseModel):
             aws_account_id=self.account_id, aws_region=self.region
         )
 
+    @root_validator(allow_reuse=True, pre=True)
+    def _set_defaults(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Set default values based on other values."""
+        values.setdefault("public", bool(values.get("alias")))
+
+        if not values["public"]:
+            account_id = values.get("account_id")
+            ctx: Optional[CfnginContext] = values.get("context")
+            region = values.get("aws_region")
+            if not ctx and not (account_id or region):
+                raise ValueError("context is required to resolve values")
+            if ctx:
+                if not account_id:
+                    values["account_id"] = AccountDetails(ctx).id
+                if not region:
+                    values["aws_region"] = ctx.env.aws_region or "us-east-1"
+
+        return values
+
 
 class DockerImage(BaseModel):
     """Wrapper for :class:`docker.models.images.Image`."""
 
-    _repo: Optional[str]
     image: Image
+    _repo: Optional[str] = None
 
-    def __init__(self, *, image: Image, **kwargs: Any) -> None:
-        """Instantiate class."""
-        super().__init__(**kwargs)
-        self._repo = None
-        self.image = image
+    class Config:
+        """Model configuration."""
+
+        arbitrary_types_allowed = True
+        fields = {"_repo": {"exclude": True}}
+        underscore_attrs_are_private = True
 
     @property
     def id(self) -> str:
         """ID of the image."""
         return self.image.id
-
-    @id.setter
-    def id(self, value: str) -> None:
-        """Set the ID of the image."""
-        self.image.id = value  # type: ignore
 
     @property
     def repo(self) -> str:
@@ -355,20 +107,10 @@ class DockerImage(BaseModel):
             self._repo = self.image.attrs["RepoTags"][0].rsplit(":", 1)[0]
         return cast(str, self._repo)
 
-    @repo.setter
-    def repo(self, value: str) -> None:
-        """Set repository URI value."""
-        self._repo = value
-
     @property
     def short_id(self) -> str:
         """ID of the image truncated to 10 characters plus the ``sha256:`` prefix."""
         return self.image.short_id
-
-    @short_id.setter
-    def short_id(self, value: str) -> None:
-        """Set the ID of the image truncated to 10 characters plus the ``sha256:`` prefix."""
-        self.image.short_id = value  # type: ignore
 
     @property
     def tags(self) -> List[str]:
@@ -383,46 +125,13 @@ class DockerImage(BaseModel):
 
 
 class ElasticContainerRegistryRepository(BaseModel):
-    """AWS Elastic Container Registry (ECR) Repository.
+    """AWS Elastic Container Registry (ECR) Repository."""
 
-    Attributes:
-        name: The name of the repository.
-        registry: Information about an ECR registry.
+    name: str = Field(..., alias="repo_name")
+    """The name of the repository."""
 
-    """
-
-    name: str
     registry: ElasticContainerRegistry
-
-    def __init__(
-        self,
-        *,
-        account_id: Optional[str] = None,
-        aws_region: Optional[str] = None,
-        context: Optional[CfnginContext] = None,
-        registry_alias: Optional[str] = None,
-        repo_name: str,
-        **kwargs: Any,
-    ) -> None:
-        """Instantiace class.
-
-        Args:
-            account_id: AWS account ID.
-            aws_region: AWS region.
-            context: CFNgin context object.
-            registry_alias: Alias of a public ECR registry.
-            repo_name: Name of the ECR repository.
-
-        """
-        super().__init__(context=context, **kwargs)
-        self.name = cast(str, self._validate_str(repo_name, required=True))
-
-        self.registry = ElasticContainerRegistry(
-            account_id=account_id,
-            alias=registry_alias,
-            aws_region=aws_region,
-            context=context,
-        )
+    """Information about an ECR registry."""
 
     @property
     def fqn(self) -> str:

--- a/runway/cfngin/hooks/docker/image/_remove.py
+++ b/runway/cfngin/hooks/docker/image/_remove.py
@@ -3,14 +3,21 @@
 Replicates the functionality of the ``docker image remove`` CLI command.
 
 """
+# pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from docker.errors import ImageNotFound
+from pydantic import Field, validator
 
-from ..data_models import BaseModel, DockerImage, ElasticContainerRegistryRepository
+from .....utils import BaseModel
+from ..data_models import (
+    DockerImage,
+    ElasticContainerRegistry,
+    ElasticContainerRegistryRepository,
+)
 from ..hook_data import DockerHookData
 
 if TYPE_CHECKING:
@@ -20,83 +27,81 @@ LOGGER = logging.getLogger(__name__.replace("._", "."))
 
 
 class ImageRemoveArgs(BaseModel):
-    """Args passed to image.remove.
+    """Args passed to image.remove."""
 
-    Attributes:
-        force: Whether to force the removal of the image.
-        noprune: Whether to delete untagged parents.
-        repo: URI of a non Docker Hub repository where the image will be stored.
-        tags: List of tags to remove.
+    _ctx: Optional[CfnginContext] = Field(default=None, alias="context", export=False)
+
+    ecr_repo: Optional[ElasticContainerRegistryRepository] = None  # depends on _ctx
+    """AWS Elastic Container Registry repository information.
+    Providing this will automatically construct the repo URI.
+    If provided, do not provide ``repo``.
+
+    If using a private registry, only ``repo_name`` is required.
+    If using a public registry, ``repo_name`` and ``registry_alias``.
 
     """
 
-    force: bool
-    noprune: bool
-    repo: Optional[str]
-    tags: List[str]
+    force: bool = False
+    """Whether to force the removal of the image."""
 
-    def __init__(
-        self,
-        *,
-        ecr_repo: Optional[Dict[str, Any]] = None,
-        force: bool = False,
-        image: DockerImage = None,
-        noprune: bool = False,
-        repo: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-        **kwargs: Any,
-    ) -> None:
-        """Instantiate class.
+    image: Optional[DockerImage] = None
+    """Image to push."""
 
-        Args:
-            ecr_repo: AWS Elastic Container Registry repository information.
-                Providing this will automatically create the repo URI.
-                If provided, do not provide ``repo``.
-            force: Whether to force the removal of the image.
-            image: Image to push.
-            noprune: Whether to delete untagged parents.
-            repo: URI of a non Docker Hub repository where the image will be stored.
-                If providing one of the other repo values, leave this value empty.
-            tags: List of tags to remove.
+    noprune: bool = False
+    """Whether to delete untagged parents."""
 
-        """
-        super().__init__(**kwargs)
-        self.force = force
-        self.noprune = noprune
-        self.repo = self.determine_repo(
-            context=self._ctx, ecr_repo=ecr_repo, image=image, repo=repo
-        )
-        if image and not tags:
-            tags = image.tags
-        self.tags = cast(
-            List[str], self._validate_list_str(tags or ["latest"], required=True)
-        )
+    repo: Optional[str] = None  # depends on ecr_repo & image
+    """URI of a non Docker Hub repository where the image will be stored."""
 
-    @staticmethod
-    def determine_repo(
-        context: Optional[CfnginContext] = None,
-        ecr_repo: Optional[Dict[str, Optional[str]]] = None,
-        image: Optional[DockerImage] = None,
-        repo: Optional[str] = None,
-    ) -> Optional[str]:
-        """Determine repo URI.
+    tags: List[str] = []  # depends on image
+    """List of tags to remove."""
 
-        Args:
-            context: CFNgin context.
-            ecr_repo: AWS Elastic Container Registry options.
-            image: Docker image object.
-            repo: URI of a non Docker Hub repository.
-
-        """
-        if repo:
-            return repo
-        if isinstance(image, DockerImage):
-            return image.repo
-        if ecr_repo:
+    @validator("ecr_repo", pre=True, allow_reuse=True)
+    def _set_ecr_repo(cls, v: Any, values: Dict[str, Any]) -> Any:
+        """Set the value of ``ecr_repo``."""
+        if v and isinstance(v, dict):
             return ElasticContainerRegistryRepository.parse_obj(
-                ecr_repo, context=context
-            ).fqn
-        raise ValueError("a repo must be specified")
+                {
+                    "repo_name": v.get("repo_name"),
+                    "registry": ElasticContainerRegistry.parse_obj(
+                        {
+                            "account_id": v.get("account_id"),
+                            "alias": v.get("registry_alias"),
+                            "aws_region": v.get("aws_region"),
+                            "context": values.get("context"),
+                        }
+                    ),
+                }
+            )
+        return v
+
+    @validator("repo", pre=True, always=True, allow_reuse=True)
+    def _set_repo(cls, v: Optional[str], values: Dict[str, Any]) -> Optional[str]:
+        """Set the value of ``repo``."""
+        if v:
+            return v
+
+        image: Optional[DockerImage] = values.get("image")
+        if image:
+            return image.repo
+
+        ecr_repo: Optional[ElasticContainerRegistryRepository] = values.get("ecr_repo")
+        if ecr_repo:
+            return ecr_repo.fqn
+
+        return None
+
+    @validator("tags", pre=True, always=True, allow_reuse=True)
+    def _set_tags(cls, v: List[str], values: Dict[str, Any]) -> List[str]:
+        """Set the value of ``tags``."""
+        if v:
+            return v
+
+        image: Optional[DockerImage] = values.get("image")
+        if image:
+            return image.tags
+
+        return ["latest"]
 
 
 def remove(*, context: CfnginContext, **kwargs: Any) -> DockerHookData:
@@ -107,8 +112,7 @@ def remove(*, context: CfnginContext, **kwargs: Any) -> DockerHookData:
     kwargs are parsed by :class:`~runway.cfngin.hooks.docker.image.ImageRemoveArgs`.
 
     """
-    kwargs.pop("provider", None)  # not needed
-    args = ImageRemoveArgs.parse_obj(kwargs, context=context)
+    args = ImageRemoveArgs.parse_obj({"context": context, **kwargs})
     docker_hook_data = DockerHookData.from_cfngin_context(context)
     LOGGER.info("removing local image %s...", args.repo)
     for tag in args.tags:

--- a/tests/unit/cfngin/hooks/docker/image/test_remove.py
+++ b/tests/unit/cfngin/hooks/docker/image/test_remove.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from docker.errors import ImageNotFound
-from mock import MagicMock, call
+from docker.models.images import Image
+from mock import call
 
 from runway.cfngin.hooks.docker.data_models import (
     DockerImage,
+    ElasticContainerRegistry,
     ElasticContainerRegistryRepository,
 )
 from runway.cfngin.hooks.docker.hook_data import DockerHookData
@@ -34,13 +35,12 @@ def test_remove(
     """Test remove."""
     repo = "dkr.test.com/image"
     tags = ["latest", "oldest"]
-    mock_image = MagicMock(spec=DockerImage, tags=[f"{repo}:{tag}" for tag in tags])
-    mock_image.attrs = {"RepoTags": mock_image.tags}
-    args = ImageRemoveArgs(force=True, image=mock_image, tags=["latest", "oldest"])
+    image = DockerImage(image=Image({"RepoTags": [f"{repo}:{tag}" for tag in tags]}))
+    args = ImageRemoveArgs(force=True, image=image, tags=["latest", "oldest"])
     mocker.patch.object(ImageRemoveArgs, "parse_obj", return_value=args)
     mocker.patch.object(DockerHookData, "client", mock_docker_client)
     docker_hook_data = DockerHookData()
-    docker_hook_data.image = mock_image
+    docker_hook_data.image = image
     mock_from_cfngin_context = mocker.patch.object(
         DockerHookData, "from_cfngin_context", return_value=docker_hook_data
     )
@@ -49,9 +49,7 @@ def test_remove(
     )
     cfngin_context.hook_data["docker"] = docker_hook_data
     assert (
-        remove(
-            context=cfngin_context, force=args.force, image=mock_image, tags=args.tags
-        )
+        remove(context=cfngin_context, force=args.force, image=image, tags=args.tags)
         == docker_hook_data
     )
     mock_from_cfngin_context.assert_called_once_with(cfngin_context)
@@ -99,86 +97,49 @@ def test_remove_image_not_found(
 class TestImageRemoveArgs:
     """Test runway.cfngin.hooks.docker.image._remove.ImageRemoveArgs."""
 
-    def test_determine_repo(self) -> None:
-        """Test determine_repo."""
-        assert (
-            ImageRemoveArgs.determine_repo(
-                context=None, ecr_repo={"key": "val"}, image=None, repo="something"
-            )
-            == "something"
-        )
+    def test__set_ecr_repo_from_dict(self) -> None:
+        """Test _set_ecr_repo from Dict."""
+        args = {
+            "repo_name": "foo",
+            "account_id": "123",
+            "registry_alias": "bar",
+            "aws_region": "us-west-2",
+        }
+        obj = ImageRemoveArgs.parse_obj({"ecr_repo": args})
+        assert obj.ecr_repo
+        assert obj.ecr_repo.name == args["repo_name"]
+        assert obj.ecr_repo.registry.account_id == args["account_id"]
+        assert obj.ecr_repo.registry.alias == args["registry_alias"]
+        assert obj.ecr_repo.registry.region == args["aws_region"]
 
-    def test_determine_repo_ecr(self, mocker: MockerFixture) -> None:
-        """Test determine_repo ecr."""
+    def test__set_repo(self) -> None:
+        """Test _set_repo."""
+        assert ImageRemoveArgs(repo="something").repo == "something"
+        assert not ImageRemoveArgs().repo
+
+    def test__set_repo_ecr(self) -> None:
+        """Test _set_repo ECR."""
         repo = ElasticContainerRegistryRepository(
-            account_id="123456012", aws_region="us-east-1", repo_name="test"
+            repo_name="test",
+            registry=ElasticContainerRegistry(
+                account_id="123456789012", aws_region="us-east-1"
+            ),
         )
-        mocker.patch(
-            MODULE + ".ElasticContainerRegistryRepository",
-            parse_obj=MagicMock(return_value=repo),
-        )
-        assert (
-            ImageRemoveArgs.determine_repo(
-                context=None,
-                ecr_repo={
-                    "repo_name": repo.name,
-                    "account_id": repo.registry.account_id,
-                    "aws_region": repo.registry.region,
-                },
-                image=None,
-                repo=None,
-            )
-            == repo.fqn
-        )
+        assert ImageRemoveArgs(ecr_repo=repo).repo == repo.fqn
 
-    def test_determine_repo_image(self) -> None:
-        """Test determine_repo Image."""
-        repo = "dkr.test.com/image"
-        mock_image = MagicMock(spec=DockerImage, repo=repo)
-        assert (
-            ImageRemoveArgs.determine_repo(
-                context=None, ecr_repo={"key": "val"}, image=mock_image, repo=None
-            )
-            == repo
-        )
+    def test__set_repo_image(self, mocker: MockerFixture) -> None:
+        """Test _set_repo image."""
+        mocker.patch.object(Image, "reload")
+        image = DockerImage(image=Image({"RepoTags": ["foo:latest"]}))
+        assert ImageRemoveArgs(image=image).repo == image.repo
 
-    def test_determine_repo_none(self) -> None:
-        """Test determine_repo None."""
-        with pytest.raises(ValueError):
-            ImageRemoveArgs.determine_repo(
-                context=None, ecr_repo={}, image=None, repo=None
-            )
+    def test__set_tags(self) -> None:
+        """Test _set_tags."""
+        assert ImageRemoveArgs(tags=["foo"]).tags == ["foo"]
+        assert ImageRemoveArgs().tags == ["latest"]
 
-    def test_init_default(self, mocker: MockerFixture) -> None:
-        """Test init default values."""
-        mock_determine_repo = mocker.patch.object(
-            ImageRemoveArgs, "determine_repo", return_value="dkr.test.com/image"
-        )
-        obj = ImageRemoveArgs()
-        mock_determine_repo.assert_called_once_with(
-            context=None, ecr_repo=None, image=None, repo=None
-        )
-        assert obj.force is False
-        assert obj.noprune is False
-        assert obj.repo == mock_determine_repo.return_value
-        assert obj.tags == ["latest"]
-
-    def test_init_image(self, mocker: MockerFixture) -> None:
-        """Test init Image."""
-        repo = "dkr.test.com/image"
-        tags = ["latest", "oldest"]
-        mock_image = MagicMock(spec=DockerImage, repo=repo, tags=tags)
-        mock_determine_repo = mocker.patch.object(
-            ImageRemoveArgs, "determine_repo", return_value=repo
-        )
-        obj = ImageRemoveArgs(force=True, image=mock_image, noprune=True)
-        mock_determine_repo.assert_called_once_with(
-            context=None, ecr_repo=None, image=mock_image, repo=None
-        )
-        assert obj.force is True
-        assert obj.noprune is True
-        assert obj.repo == repo
-        assert obj.tags == tags
-
-        # ensure tags are not overwritten if provided
-        assert ImageRemoveArgs(image=mock_image, tags=["oldest"]).tags == ["oldest"]
+    def test__set_tags_image(self, mocker: MockerFixture) -> None:
+        """Test _set_tags image."""
+        mocker.patch.object(Image, "reload")
+        image = DockerImage(image=Image({"RepoTags": ["foo:bar"]}))
+        assert ImageRemoveArgs(image=image).tags == image.tags


### PR DESCRIPTION
# Summary

Replace pydantic stand-in with pydantic models for parsing hook arguments.

# Why This Is Needed

resolves #1164 

# What Changed

## Changed

- data models used to parse `runway.cfngin.hooks.docker` hook arguments are now pydantic data models
