### PR TITLE
fix issue causing `plan` to incorrectly show params are being removed

### DIFF
--- a/runway/cfngin/actions/diff.py
+++ b/runway/cfngin/actions/diff.py
@@ -211,8 +211,13 @@ class Action(deploy.Action):
         tags = deploy.build_stack_tags(stack)
 
         try:
+            provider_stack = provider.get_stack(stack.fqn)
+        except exceptions.StackDoesNotExist:
+            provider_stack = None
+
+        try:
             stack.resolve(self.context, provider)
-            parameters = self.build_parameters(stack)
+            parameters = self.build_parameters(stack, provider_stack)
             outputs = provider.get_stack_changes(
                 stack, self._template(stack.blueprint), parameters, tags
             )

--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -1503,8 +1503,10 @@ class Provider(BaseProvider):
             # handling for orphaned changeset temp stacks
             if self.get_stack_status(stack_details) == self.REVIEW_STATUS:
                 raise exceptions.StackDoesNotExist(stack.fqn)
-            _old_template, old_params = self.get_stack_info(stack_details)
-            old_template: Dict[str, Any] = parse_cloudformation_template(_old_template)
+            old_template_raw, old_params = self.get_stack_info(stack_details)
+            old_template: Dict[str, Any] = parse_cloudformation_template(
+                old_template_raw
+            )
             change_type = "UPDATE"
         except exceptions.StackDoesNotExist:
             old_params: Dict[str, Union[List[str], str]] = {}

--- a/tests/unit/cfngin/actions/conftest.py
+++ b/tests/unit/cfngin/actions/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest fixtures and plugins."""
+# pyright: basic
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from mock import MagicMock
+
+from runway.cfngin.providers.aws.default import Provider
+
+if TYPE_CHECKING:
+    from mypy_boto3_cloudformation.type_defs import StackTypeDef
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(scope="function")
+def provider_get_stack(mocker: MockerFixture) -> MagicMock:
+    """Patches ``runway.cfngin.providers.aws.default.Provider.get_stack``."""
+    return_value: StackTypeDef = {
+        "CreationTime": datetime(2015, 1, 1),
+        "Description": "something",
+        "Outputs": [],
+        "Parameters": [],
+        "StackId": "123",
+        "StackName": "foo",
+        "StackStatus": "CREATE_COMPLETE",
+    }
+    return mocker.patch.object(Provider, "get_stack", return_value=return_value)

--- a/tests/unit/cfngin/actions/test_diff.py
+++ b/tests/unit/cfngin/actions/test_diff.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Optional
 
 import pytest
 from botocore.exceptions import ClientError
-from mock import MagicMock, patch
+from mock import MagicMock, Mock, patch
 
 from runway.cfngin.actions.diff import (
     Action,
@@ -18,13 +18,15 @@ from runway.cfngin.actions.diff import (
     diff_dictionaries,
     diff_parameters,
 )
+from runway.cfngin.exceptions import StackDoesNotExist
 from runway.cfngin.providers.aws.default import Provider
 from runway.cfngin.status import SkippedStatus
 
 from ..factories import MockProviderBuilder, MockThreadingEvent
 
 if TYPE_CHECKING:
-    from pytest import LogCaptureFixture, MonkeyPatch
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
 
     from ...factories import MockCFNginContext
 
@@ -82,11 +84,14 @@ class TestAction:
 
         assert action.bucket_name == bucket_name
 
-    def test_diff_stack_validationerror_template_too_large(
+    @pytest.mark.parametrize("stack_not_exist", [False, True])
+    def test__diff_stack_validationerror_template_too_large(
         self,
         caplog: LogCaptureFixture,
         cfngin_context: MockCFNginContext,
-        monkeypatch: MonkeyPatch,
+        mocker: MockerFixture,
+        provider_get_stack: MagicMock,
+        stack_not_exist: bool,
     ) -> None:
         """Test _diff_stack ValidationError - template too large."""
         caplog.set_level(logging.ERROR)
@@ -94,8 +99,12 @@ class TestAction:
         cfngin_context.add_stubber("cloudformation")
         cfngin_context.config.cfngin_bucket = ""
         expected = SkippedStatus("cfngin_bucket: existing bucket required")
-        provider = Provider(cfngin_context.get_session())  # type: ignore
-        mock_get_stack_changes = MagicMock(
+        mock_build_parameters = mocker.patch.object(
+            Action, "build_parameters", return_value=[]
+        )
+        mock_get_stack_changes = mocker.patch.object(
+            Provider,
+            "get_stack_changes",
             side_effect=ClientError(
                 {
                     "Error": {
@@ -104,22 +113,29 @@ class TestAction:
                     }
                 },
                 "create_change_set",
-            )
+            ),
         )
-        monkeypatch.setattr(provider, "get_stack_changes", mock_get_stack_changes)
-        stack = MagicMock()
-        stack.region = cfngin_context.env.aws_region
-        stack.name = "test-stack"
-        stack.fqn = "test-stack"
-        stack.blueprint.rendered = "{}"
-        stack.locked = False
-        stack.status = None
+        provider = Provider(cfngin_context.get_session())  # type: ignore
+        stack = MagicMock(
+            blueprint=Mock(rendered="{}"),
+            fqn="test-stack",
+            locked=False,
+            region=cfngin_context.env.aws_region,
+            status=None,
+        )
+        stack.name = "stack"
+
+        if stack_not_exist:
+            provider_get_stack.side_effect = StackDoesNotExist("test-stack")
 
         result = Action(
             context=cfngin_context,
             provider_builder=MockProviderBuilder(provider=provider),
             cancel=MockThreadingEvent(),  # type: ignore
         )._diff_stack(stack)
+        mock_build_parameters.assert_called_once_with(
+            stack, None if stack_not_exist else provider_get_stack.return_value
+        )
         mock_get_stack_changes.assert_called_once()
         assert result == expected
 


### PR DESCRIPTION
# Why This Is Needed

resolves #1234 

# What Changed

## Fixed

- fixed an issue causing CFNgin modules to incorrectly show parameters as being removed when using `runway plan`
