### PR TITLE
use pydantic data model to parse `cfngin.hooks.cleanup_s3` args

### DIFF
--- a/runway/cfngin/hooks/cleanup_s3.py
+++ b/runway/cfngin/hooks/cleanup_s3.py
@@ -6,26 +6,36 @@ from typing import TYPE_CHECKING, Any
 
 from botocore.exceptions import ClientError
 
+from ...utils import BaseModel
+
 if TYPE_CHECKING:
     from ...context import CfnginContext
 
 LOGGER = logging.getLogger(__name__)
 
 
-def purge_bucket(context: CfnginContext, *, bucket_name: str, **_: Any) -> bool:
+class PurgeBucketHookArgs(BaseModel):
+    """Hook arguments for ``purge_bucket``."""
+
+    bucket_name: str
+    """Name of the bucket to purge."""
+
+
+def purge_bucket(context: CfnginContext, *__args: Any, **kwargs: Any) -> bool:
     """Delete objects in bucket."""
+    args = PurgeBucketHookArgs.parse_obj(kwargs)
     session = context.get_session()
     s3_resource = session.resource("s3")
     try:
-        s3_resource.meta.client.head_bucket(Bucket=bucket_name)
+        s3_resource.meta.client.head_bucket(Bucket=args.bucket_name)
     except ClientError as exc:
         if exc.response["Error"]["Code"] == "404":
             LOGGER.info(
-                'bucket "%s" does not exist; unable to complete purge', bucket_name
+                'bucket "%s" does not exist; unable to complete purge', args.bucket_name
             )
             return True
         raise
 
-    bucket = s3_resource.Bucket(bucket_name)
+    bucket = s3_resource.Bucket(args.bucket_name)
     bucket.object_versions.delete()
     return True

--- a/tests/unit/cfngin/hooks/test_cleanup_s3.py
+++ b/tests/unit/cfngin/hooks/test_cleanup_s3.py
@@ -1,0 +1,43 @@
+"""Tests for runway.cfngin.hooks.cleanup_s3."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from botocore.exceptions import ClientError
+
+from runway.cfngin.hooks.cleanup_s3 import purge_bucket
+
+if TYPE_CHECKING:
+    from ...factories import MockCFNginContext
+
+
+def test_purge_bucket(cfngin_context: MockCFNginContext) -> None:
+    """Test purge_bucket."""
+    stub = cfngin_context.add_stubber("s3")
+
+    stub.add_response("head_bucket", {}, {"Bucket": "foo"})
+    stub.add_response("list_object_versions", {"DeleteMarkers": [], "Versions": []})
+    with stub:
+        assert purge_bucket(cfngin_context, bucket_name="foo")
+    stub.assert_no_pending_responses()
+
+
+def test_purge_bucket_does_not_exist(cfngin_context: MockCFNginContext) -> None:
+    """Test purge_bucket Bucket doesn't exist."""
+    stub = cfngin_context.add_stubber("s3")
+
+    stub.add_client_error("head_bucket", service_error_code="404")
+    with stub:
+        assert purge_bucket(cfngin_context, bucket_name="foo")
+    stub.assert_no_pending_responses()
+
+
+def test_purge_bucket_unhandled_exception(cfngin_context: MockCFNginContext) -> None:
+    """Test purge_bucket with unhandled exception."""
+    stub = cfngin_context.add_stubber("s3")
+
+    stub.add_client_error("head_bucket", service_error_code="403")
+    with stub, pytest.raises(ClientError):
+        purge_bucket(cfngin_context, bucket_name="foo")
+    stub.assert_no_pending_responses()


### PR DESCRIPTION
# Why This Is Needed

resolves #1167

# What Changed

## Added

- added a pydantic data model to parse `runway.cfngin.hooks.cleanup_s3` args
