### PR TITLE
use pydantic data model to parse `cfngin.hooks.cleanup_ssm` args

### DIFF
--- a/runway/cfngin/hooks/cleanup_ssm.py
+++ b/runway/cfngin/hooks/cleanup_ssm.py
@@ -4,22 +4,30 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ...utils import BaseModel
+
 if TYPE_CHECKING:
     from ...context import CfnginContext
 
 LOGGER = logging.getLogger(__name__)
 
 
-def delete_param(context: CfnginContext, *, parameter_name: str, **_: Any) -> bool:
+class DeleteParamHookArgs(BaseModel):
+    """Hook arguments for ``delete_param``."""
+
+    parameter_name: str
+    """Name of the bucket to purge."""
+
+
+def delete_param(context: CfnginContext, *__args: Any, **kwargs: Any) -> bool:
     """Delete SSM parameter."""
-    if not parameter_name:
-        raise ValueError("Must specify `parameter_name` for delete_param hook.")
+    args = DeleteParamHookArgs.parse_obj(kwargs)
 
     session = context.get_session()
     ssm_client = session.client("ssm")
 
     try:
-        ssm_client.delete_parameter(Name=parameter_name)
+        ssm_client.delete_parameter(Name=args.parameter_name)
     except ssm_client.exceptions.ParameterNotFound:
-        LOGGER.info('parameter "%s" does not exist', parameter_name)
+        LOGGER.info('parameter "%s" does not exist', args.parameter_name)
     return True

--- a/tests/unit/cfngin/hooks/test_cleanup_ssm.py
+++ b/tests/unit/cfngin/hooks/test_cleanup_ssm.py
@@ -1,0 +1,27 @@
+"""Tests for runway.cfngin.hooks.cleanup_ssm."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from runway.cfngin.hooks.cleanup_ssm import delete_param
+
+if TYPE_CHECKING:
+    from ...factories import MockCFNginContext
+
+
+def test_delete_param(cfngin_context: MockCFNginContext) -> None:
+    """Test delete_param."""
+    stub = cfngin_context.add_stubber("ssm")
+
+    stub.add_response("delete_parameter", {}, {"Name": "foo"})
+    with stub:
+        assert delete_param(cfngin_context, parameter_name="foo")
+
+
+def test_delete_param_not_found(cfngin_context: MockCFNginContext) -> None:
+    """Test delete_param."""
+    stub = cfngin_context.add_stubber("ssm")
+
+    stub.add_client_error("delete_parameter", "ParameterNotFound")
+    with stub:
+        assert delete_param(cfngin_context, parameter_name="foo")


### PR DESCRIPTION
# Why This Is Needed

resolves #1168

# What Changed

## Added

- added a pydantic data model to parse `runway.cfngin.hooks.cleanup_ssm` args
