### PR TITLE
use pydantic data model to parse `cfngin.hooks.ecs` args

### DIFF
--- a/runway/cfngin/hooks/ecs.py
+++ b/runway/cfngin/hooks/ecs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from pydantic import validator
 from typing_extensions import TypedDict
@@ -21,11 +21,11 @@ LOGGER = logging.getLogger(__name__)
 class CreateClustersHookArgs(BaseModel):
     """Hook arguments for ``create_clusters``."""
 
-    clusters: list[str]
+    clusters: List[str]
     """List of cluster names to create."""
 
     @validator("clusters", allow_reuse=True, pre=True)
-    def _convert_clusters(cls, v: Union[list[str], str]) -> list[str]:
+    def _convert_clusters(cls, v: Union[List[str], str]) -> List[str]:
         """Convert value of ``clusters`` from str to list."""
         if isinstance(v, str):
             return [v]
@@ -35,7 +35,7 @@ class CreateClustersHookArgs(BaseModel):
 class CreateClustersResponseTypeDef(TypedDict):
     """Response from create_clusters."""
 
-    clusters: dict[str, CreateClusterResponseTypeDef]
+    clusters: Dict[str, CreateClusterResponseTypeDef]
 
 
 def create_clusters(
@@ -50,7 +50,7 @@ def create_clusters(
     args = CreateClustersHookArgs.parse_obj(kwargs)
     ecs_client = context.get_session().client("ecs")
 
-    cluster_info: dict[str, Any] = {}
+    cluster_info: Dict[str, Any] = {}
     for cluster in args.clusters:
         LOGGER.debug("creating ECS cluster: %s", cluster)
         response = ecs_client.create_cluster(clusterName=cluster)

--- a/runway/cfngin/hooks/ecs.py
+++ b/runway/cfngin/hooks/ecs.py
@@ -1,16 +1,14 @@
-"""AWS ECS hook.
-
-A lot of this code exists to deal w/ the broken ECS connect_to_region
-function, and will be removed once this pull request is accepted:
-https://github.com/boto/boto/pull/3143
-
-"""
+"""AWS ECS hook."""
+# pylint: disable=no-self-argument,no-self-use
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Union
 
+from pydantic import validator
 from typing_extensions import TypedDict
+
+from ...utils import BaseModel
 
 if TYPE_CHECKING:
     from mypy_boto3_ecs.type_defs import CreateClusterResponseTypeDef
@@ -20,29 +18,41 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
+class CreateClustersHookArgs(BaseModel):
+    """Hook arguments for ``create_clusters``."""
+
+    clusters: list[str]
+    """List of cluster names to create."""
+
+    @validator("clusters", allow_reuse=True, pre=True)
+    def _convert_clusters(cls, v: Union[list[str], str]) -> list[str]:
+        """Convert value of ``clusters`` from str to list."""
+        if isinstance(v, str):
+            return [v]
+        return v
+
+
 class CreateClustersResponseTypeDef(TypedDict):
     """Response from create_clusters."""
 
-    clusters: Dict[str, CreateClusterResponseTypeDef]
+    clusters: dict[str, CreateClusterResponseTypeDef]
 
 
 def create_clusters(
-    context: CfnginContext, *, clusters: Union[List[str], str], **_: Any
+    context: CfnginContext, *__args: Any, **kwargs: Any
 ) -> CreateClustersResponseTypeDef:
     """Create ECS clusters.
 
     Args:
         context: CFNgin context object.
-        clusters: Names of clusters to create.
 
     """
-    conn = context.get_session().client("ecs")
-    if isinstance(clusters, str):
-        clusters = [clusters]
+    args = CreateClustersHookArgs.parse_obj(kwargs)
+    ecs_client = context.get_session().client("ecs")
 
-    cluster_info: Dict[str, Any] = {}
-    for cluster in clusters:
+    cluster_info: dict[str, Any] = {}
+    for cluster in args.clusters:
         LOGGER.debug("creating ECS cluster: %s", cluster)
-        response = conn.create_cluster(clusterName=cluster)
+        response = ecs_client.create_cluster(clusterName=cluster)
         cluster_info[response.get("cluster", {}).get("clusterName", "")] = response
     return {"clusters": cluster_info}


### PR DESCRIPTION
# Why This Is Needed

resolves #1170 

# What Changed

## Added

- added a pydantic data model to parse `runway.cfngin.hooks.ecs` args
