### PR TITLE
use pydantic data model to parse `cfngin.hooks.iam` args

### DIFF
--- a/runway/cfngin/hooks/iam.py
+++ b/runway/cfngin/hooks/iam.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 from awacs import ecs
 from awacs.aws import Allow, Policy, Statement
 from awacs.helpers.trust import get_ecs_assumerole_policy
 from botocore.exceptions import ClientError
 
+from ...utils import BaseModel
 from . import utils
 
 if TYPE_CHECKING:
@@ -22,9 +23,53 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
+ECS_SERVICE_ROLE_NAME = "ecsServiceRole"
+ECS_SERVICE_ROLE_POLICY = Policy(
+    Version="2012-10-17",
+    Statement=[
+        Statement(
+            Effect=Allow,
+            Resource=["*"],
+            Action=[
+                ecs.CreateCluster,
+                ecs.DeregisterContainerInstance,
+                ecs.DiscoverPollEndpoint,
+                ecs.Poll,
+                ecs.Action("Submit*"),
+            ],
+        )
+    ],
+)
+
+
+class CreateEcsServiceRoleHookArgs(BaseModel):
+    """Hook arguments for ``create_ecs_service_role``."""
+
+    role_name: str = ECS_SERVICE_ROLE_NAME
+    """Name of the role to create."""
+
+
+class EnsureServerCertExistsHookArgs(BaseModel):
+    """Hook arguments for ``ensure_server_cert_exists``."""
+
+    cert_name: str
+    """Name of the certificate that should exist."""
+
+    path_to_certificate: Optional[str] = None
+    """Path to certificate file."""
+
+    path_to_chain: Optional[str] = None
+    """Path to chain file."""
+
+    path_to_private_key: Optional[str] = None
+    """Path to private key file."""
+
+    prompt: bool = True
+    """Whether to prompt to upload a certificate if one does not exist."""
+
 
 def create_ecs_service_role(
-    context: CfnginContext, *, role_name: str = "ecsServiceRole", **_: Any
+    context: CfnginContext, *__args: Any, **kwargs: Any
 ) -> bool:
     """Create ecsServiceRole IAM role.
 
@@ -32,39 +77,23 @@ def create_ecs_service_role(
 
     Args:
         context: Context instance. (passed in by CFNgin)
-        role_name: Name of the role to create.
 
     """
+    args = CreateEcsServiceRoleHookArgs.parse_obj(kwargs)
     client = context.get_session().client("iam")
 
     try:
         client.create_role(
-            RoleName=role_name,
+            RoleName=args.role_name,
             AssumeRolePolicyDocument=get_ecs_assumerole_policy().to_json(),
         )
     except ClientError as err:
         if "already exists" not in str(err):
             raise
-    policy = Policy(
-        Version="2012-10-17",
-        Statement=[
-            Statement(
-                Effect=Allow,
-                Resource=["*"],
-                Action=[
-                    ecs.CreateCluster,
-                    ecs.DeregisterContainerInstance,
-                    ecs.DiscoverPollEndpoint,
-                    ecs.Poll,
-                    ecs.Action("Submit*"),
-                ],
-            )
-        ],
-    )
     client.put_role_policy(
-        RoleName=role_name,
+        RoleName=args.role_name,
         PolicyName="AmazonEC2ContainerServiceRolePolicy",
-        PolicyDocument=policy.to_json(),
+        PolicyDocument=ECS_SERVICE_ROLE_POLICY.to_json(),
     )
     return True
 
@@ -115,9 +144,7 @@ def _get_cert_contents(kwargs: Dict[str, Any]) -> Dict[str, Any]:
 
         paths[key] = path
 
-    parameters = {
-        "ServerCertificateName": kwargs.get("cert_name"),
-    }
+    parameters: Dict[str, str] = {}
 
     for key, path in paths.items():
         if not path:
@@ -137,48 +164,50 @@ def _get_cert_contents(kwargs: Dict[str, Any]) -> Dict[str, Any]:
         elif key == "chain":
             parameters["CertificateChain"] = contents
 
+    if parameters and "cert_name" in kwargs:
+        parameters["ServerCertificateName"] = kwargs["cert_name"]
+
     return parameters
 
 
 def ensure_server_cert_exists(
-    context: CfnginContext, *, cert_name: str, prompt: bool = True, **kwargs: Any
+    context: CfnginContext, *__args: Any, **kwargs: Any
 ) -> Dict[str, str]:
     """Ensure server cert exists.
 
     Args:
         context: CFNgin context object.
-        cert_name: Name of the certificate that should exist.
-        prompt: Whether to prompt to upload a certificate if one does not exist.
 
     Returns:
         Dict containing ``status``, ``cert_name``, and ``cert_arn``.
 
     """
+    args = EnsureServerCertExistsHookArgs.parse_obj(kwargs)
     client = context.get_session().client("iam")
     status = "unknown"
     try:
-        response = client.get_server_certificate(ServerCertificateName=cert_name)
+        response = client.get_server_certificate(ServerCertificateName=args.cert_name)
         cert_arn = _get_cert_arn_from_response(response)
         status = "exists"
-        LOGGER.info("certificate exists: %s (%s)", cert_name, cert_arn)
+        LOGGER.info("certificate exists: %s (%s)", args.cert_name, cert_arn)
     except ClientError:
-        if prompt:
+        if args.prompt:
             upload = input(
-                f"Certificate '{cert_name}' wasn't found. Upload it now? (yes/no) "
+                f"Certificate '{args.cert_name}' wasn't found. Upload it now? (yes/no) "
             )
             if upload != "yes":
                 return {}
 
-        parameters = _get_cert_contents(kwargs)
+        parameters = _get_cert_contents(args.dict())
         if not parameters:
             return {}
         response = client.upload_server_certificate(**parameters)
         cert_arn = _get_cert_arn_from_response(response)
         status = "uploaded"
-        LOGGER.info("uploaded certificate: %s (%s)", cert_name, cert_arn)
+        LOGGER.info("uploaded certificate: %s (%s)", args.cert_name, cert_arn)
 
     return {
         "status": status,
-        "cert_name": cert_name,
+        "cert_name": args.cert_name,
         "cert_arn": cert_arn,
     }

--- a/tests/unit/cfngin/hooks/test_ecs.py
+++ b/tests/unit/cfngin/hooks/test_ecs.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from runway._logging import LogLevels
 from runway.cfngin.hooks.ecs import create_clusters
 
@@ -18,7 +16,6 @@ if TYPE_CHECKING:
 MODULE = "runway.cfngin.hooks.ecs"
 
 
-@pytest.mark.wip
 def test_create_clusters(
     caplog: LogCaptureFixture, cfngin_context: MockCFNginContext
 ) -> None:
@@ -47,7 +44,6 @@ def test_create_clusters(
         assert f"creating ECS cluster: {cluster}" in caplog.messages
 
 
-@pytest.mark.wip
 def test_create_clusters_str(cfngin_context: MockCFNginContext) -> None:
     """Test create_clusters with ``clusters`` provided as str."""
     stub = cfngin_context.add_stubber("ecs")

--- a/tests/unit/cfngin/hooks/test_iam.py
+++ b/tests/unit/cfngin/hooks/test_iam.py
@@ -1,76 +1,222 @@
 """Tests for runway.cfngin.hooks.iam."""
 # pyright: basic
-import unittest
+from __future__ import annotations
 
-import boto3
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pytest
 from awacs.helpers.trust import get_ecs_assumerole_policy
 from botocore.exceptions import ClientError
-from moto import mock_iam
 
-from runway.cfngin.hooks.iam import _get_cert_arn_from_response, create_ecs_service_role
+from runway.cfngin.hooks.iam import (
+    ECS_SERVICE_ROLE_NAME,
+    ECS_SERVICE_ROLE_POLICY,
+    create_ecs_service_role,
+    ensure_server_cert_exists,
+)
 
-from ..factories import mock_context, mock_provider
+if TYPE_CHECKING:
+    from pathlib import Path
 
-REGION = "us-east-1"
+    from pytest_mock import MockerFixture
+
+    from ...factories import MockCFNginContext
+
+CREATE_DATE = datetime(2015, 1, 1)
+MODULE = "runway.cfngin.hooks.iam"
 
 
-class TestIAMHooks(unittest.TestCase):
-    """Tests for runway.cfngin.hooks.iam."""
+def test_create_ecs_service_role(cfngin_context: MockCFNginContext) -> None:
+    """Test create_ecs_service_role."""
+    stub = cfngin_context.add_stubber("iam")
 
-    def setUp(self) -> None:
-        """Run before tests."""
-        self.context = mock_context(namespace="fake")
-        self.provider = mock_provider(region=REGION)
+    stub.add_response(
+        "create_role",
+        {
+            "Role": {  # data required by botocore.stub
+                "Path": "/",
+                "RoleName": ECS_SERVICE_ROLE_NAME,
+                "RoleId": "0" * 16,
+                "Arn": f"arn:aws:iam::0123456879012:role/{ECS_SERVICE_ROLE_NAME}",
+                "CreateDate": CREATE_DATE,
+            }
+        },
+        {
+            "RoleName": ECS_SERVICE_ROLE_NAME,
+            "AssumeRolePolicyDocument": get_ecs_assumerole_policy().to_json(),
+        },
+    )
+    stub.add_response(
+        "put_role_policy",
+        {},
+        {
+            "RoleName": ECS_SERVICE_ROLE_NAME,
+            "PolicyName": "AmazonEC2ContainerServiceRolePolicy",
+            "PolicyDocument": ECS_SERVICE_ROLE_POLICY.to_json(),
+        },
+    )
 
-    def test_get_cert_arn_from_response(self) -> None:
-        """Test get cert arn from response."""
-        arn = "fake-arn"
-        # Creation response
-        response = {"ServerCertificateMetadata": {"Arn": arn}}
+    with stub:
+        assert create_ecs_service_role(cfngin_context)
+    stub.assert_no_pending_responses()
 
-        self.assertEqual(_get_cert_arn_from_response(response), arn)  # type: ignore
 
-        # Existing cert response
-        response = {"ServerCertificate": response}
-        self.assertEqual(_get_cert_arn_from_response(response), arn)  # type: ignore
+def test_create_ecs_service_role_already_exists(
+    cfngin_context: MockCFNginContext,
+) -> None:
+    """Test create_ecs_service_role already exists."""
+    stub = cfngin_context.add_stubber("iam")
 
-    def test_create_service_role(self) -> None:
-        """Test create service role."""
-        with mock_iam():
-            client = boto3.client("iam", region_name=REGION)
+    stub.add_client_error("create_role", service_message="already exists")
+    stub.add_response(
+        "put_role_policy",
+        {},
+        {
+            "RoleName": ECS_SERVICE_ROLE_NAME,
+            "PolicyName": "AmazonEC2ContainerServiceRolePolicy",
+            "PolicyDocument": ECS_SERVICE_ROLE_POLICY.to_json(),
+        },
+    )
 
-            role_name = "ecsServiceRole"
-            with self.assertRaises(ClientError):
-                client.get_role(RoleName=role_name)
+    with stub:
+        assert create_ecs_service_role(cfngin_context)
+    stub.assert_no_pending_responses()
 
-            self.assertTrue(
-                create_ecs_service_role(context=self.context, provider=self.provider)
-            )
 
-            role = client.get_role(RoleName=role_name)
+def test_create_ecs_service_role_raise_client_error(
+    cfngin_context: MockCFNginContext,
+) -> None:
+    """Test create_ecs_service_role raise ClientError."""
+    stub = cfngin_context.add_stubber("iam")
 
-            self.assertIn("Role", role)
-            self.assertEqual(role_name, role["Role"]["RoleName"])
-            policy_name = "AmazonEC2ContainerServiceRolePolicy"
-            client.get_role_policy(RoleName=role_name, PolicyName=policy_name)
+    stub.add_client_error("create_role", service_message="")
 
-    def test_create_service_role_already_exists(self) -> None:
-        """Test create service role already exists."""
-        with mock_iam():
-            client = boto3.client("iam", region_name=REGION)
-            role_name = "ecsServiceRole"
-            client.create_role(
-                RoleName=role_name,
-                AssumeRolePolicyDocument=get_ecs_assumerole_policy().to_json(),
-            )
+    with stub, pytest.raises(ClientError):
+        create_ecs_service_role(cfngin_context)
+    stub.assert_no_pending_responses()
 
-            self.assertTrue(
-                create_ecs_service_role(context=self.context, provider=self.provider)
-            )
 
-            role = client.get_role(RoleName=role_name)
+def test_ensure_server_cert_exists(
+    cfngin_context: MockCFNginContext, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Test ensure_server_cert_exists."""
+    cert_name = "foo"
+    arn = f"arn:aws:iam::0123456789012:certification/{cert_name}"
 
-            self.assertIn("Role", role)
-            self.assertEqual(role_name, role["Role"]["RoleName"])
-            policy_name = "AmazonEC2ContainerServiceRolePolicy"
-            client.get_role_policy(RoleName=role_name, PolicyName=policy_name)
+    certificate_path = tmp_path / "cert"
+    certificate_path.write_text("cert")
+
+    chain_path = tmp_path / "chain"
+    chain_path.write_text("cert chain")
+
+    private_key_path = tmp_path / "pem"
+    private_key_path.write_text("private key")
+
+    mocker.patch(
+        f"{MODULE}.input",
+        side_effect=[
+            "yes",
+            str(private_key_path),
+            str(chain_path),
+        ],
+    )
+    stub = cfngin_context.add_stubber("iam")
+
+    stub.add_client_error("get_server_certificate")
+    stub.add_response(
+        "upload_server_certificate",
+        {
+            "ServerCertificateMetadata": {
+                "Path": "/",
+                "ServerCertificateName": cert_name,
+                "ServerCertificateId": "0" * 16,
+                "Arn": arn,
+                "UploadDate": datetime(2015, 1, 1),
+                "Expiration": datetime(2015, 1, 1),
+            }
+        },
+        {
+            "ServerCertificateName": cert_name,
+            "CertificateBody": certificate_path.read_text(),
+            "PrivateKey": private_key_path.read_text(),
+            "CertificateChain": chain_path.read_text(),
+        },
+    )
+
+    with stub:
+        assert ensure_server_cert_exists(
+            cfngin_context,
+            cert_name=cert_name,
+            path_to_certificate=str(certificate_path),
+        )
+    stub.assert_no_pending_responses()
+
+
+def test_ensure_server_cert_exists_already_exists(
+    cfngin_context: MockCFNginContext,
+) -> None:
+    """Test ensure_server_cert_exists already exists."""
+    cert_name = "foo"
+    arn = f"arn:aws:iam::0123456789012:certification/{cert_name}"
+    stub = cfngin_context.add_stubber("iam")
+
+    stub.add_response(
+        "get_server_certificate",
+        {  # data required by botocore.stub
+            "ServerCertificate": {
+                "ServerCertificateMetadata": {
+                    "Path": "/",
+                    "ServerCertificateName": cert_name,
+                    "ServerCertificateId": "0" * 16,
+                    "Arn": arn,
+                },
+                "CertificateBody": "0",
+            }
+        },
+        {"ServerCertificateName": cert_name},
+    )
+
+    with stub:
+        assert ensure_server_cert_exists(cfngin_context, cert_name=cert_name) == {
+            "cert_arn": arn,
+            "cert_name": cert_name,
+            "status": "exists",
+        }
+    stub.assert_no_pending_responses()
+
+
+def test_ensure_server_cert_exists_no_prompt_no_parameters(
+    cfngin_context: MockCFNginContext, mocker: MockerFixture
+) -> None:
+    """Test ensure_server_cert_exists no prompt, not parameters."""
+    mocker.patch(
+        f"{MODULE}.input",
+        side_effect=["", "", ""],
+    )
+    stub = cfngin_context.add_stubber("iam")
+
+    stub.add_client_error("get_server_certificate")
+
+    with stub:
+        assert not ensure_server_cert_exists(
+            cfngin_context, cert_name="foo", prompt=False
+        )
+    stub.assert_no_pending_responses()
+
+
+def test_ensure_server_cert_exists_prompt_no(
+    cfngin_context: MockCFNginContext, mocker: MockerFixture
+) -> None:
+    """Test ensure_server_cert_exists prompt input no."""
+    mocker.patch(
+        f"{MODULE}.input",
+        side_effect=["no"],
+    )
+    stub = cfngin_context.add_stubber("iam")
+
+    stub.add_client_error("get_server_certificate")
+
+    with stub:
+        assert not ensure_server_cert_exists(cfngin_context, cert_name="foo")
+    stub.assert_no_pending_responses()


### PR DESCRIPTION
# Why This Is Needed

resolves #1171

# What Changed

## Added

- added a pydantic data model to parse `runway.cfngin.hooks.iam` args
