### PR TITLE
use pydantic data model to parse `cfngin.hooks.route53` args

### DIFF
--- a/runway/cfngin/hooks/route53.py
+++ b/runway/cfngin/hooks/route53.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict
 
+from ...utils import BaseModel
 from ..utils import create_route53_zone
 
 if TYPE_CHECKING:
@@ -12,22 +13,26 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
+class CreateDomainHookArgs(BaseModel):
+    """Hook arguments for ``create_domain``."""
+
+    domain: str
+    """Domain name for the Route 53 hosted zone to be created.."""
+
+
 def create_domain(
-    context: CfnginContext, *, domain: Optional[str] = None, **_: Any
+    context: CfnginContext, *__args: Any, **kwargs: Any
 ) -> Dict[str, str]:
     """Create a domain within route53.
 
     Args:
         context: CFNgin context object.
-        domain: Domain name for the Route 53 hosted zone to be created.
 
     Returns:
         Dict containing ``domain`` and ``zone_id``.
 
     """
+    args = CreateDomainHookArgs.parse_obj(kwargs)
     client = context.get_session().client("route53")
-    if not domain:
-        LOGGER.error("domain argument or BaseDomain variable required but not provided")
-        return {}
-    zone_id = create_route53_zone(client, domain)
-    return {"domain": domain, "zone_id": zone_id}
+    zone_id = create_route53_zone(client, args.domain)
+    return {"domain": args.domain, "zone_id": zone_id}

--- a/tests/unit/cfngin/hooks/test_route53.py
+++ b/tests/unit/cfngin/hooks/test_route53.py
@@ -1,0 +1,33 @@
+"""Tests for runway.cfngin.hooks.route53."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from runway.cfngin.hooks.route53 import create_domain
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from ...factories import MockCFNginContext
+
+MODULE = "runway.cfngin.hooks.route53"
+
+
+def test_create_domain(
+    cfngin_context: MockCFNginContext, mocker: MockerFixture
+) -> None:
+    """Test create_domain."""
+    domain = "foo"
+    create_route53_zone = mocker.patch(
+        f"{MODULE}.create_route53_zone", return_value="bar"
+    )
+    _ = cfngin_context.add_stubber("route53")
+    assert create_domain(cfngin_context, domain=domain) == {
+        "domain": domain,
+        "zone_id": create_route53_zone.return_value,
+    }
+    # pylint: disable=protected-access
+    create_route53_zone.assert_called_once_with(
+        cfngin_context._boto3_test_client[f"route53.{cfngin_context.env.aws_region}"],
+        domain,
+    )


### PR DESCRIPTION
# Why This Is Needed

resolves #1173 

# What Changed

## Added

- added a pydantic data model to parse `runway.cfngin.hooks.route53` args
