### PR TITLE
use pydantic data model to parse `cfngin.hooks.staticsite` hook args

### DIFF
--- a/runway/cfngin/hooks/staticsite/auth_at_edge/client_updater.py
+++ b/runway/cfngin/hooks/staticsite/auth_at_edge/client_updater.py
@@ -7,12 +7,42 @@ distribution url + callback url paths.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from ...base import HookArgsBaseModel
 
 if TYPE_CHECKING:
     from .....context import CfnginContext
 
 LOGGER = logging.getLogger(__name__)
+
+
+class HookArgs(HookArgsBaseModel):
+    """Hook arguments."""
+
+    alternate_domains: List[str]
+    """A list of any alternate domains that need to be listed with the primary
+    distribution domain.
+
+    """
+
+    client_id: str
+    """Client ID."""
+
+    distribution_domain: str
+    """Distribution domain."""
+
+    oauth_scopes: List[str]
+    """A list of all available validation scopes for oauth."""
+
+    redirect_path_sign_in: str
+    """The redirect path after sign in."""
+
+    redirect_path_sign_out: str
+    """The redirect path after sign out."""
+
+    supported_identity_providers: List[str] = []
+    """Supported identity providers."""
 
 
 def get_redirect_uris(
@@ -25,54 +55,38 @@ def get_redirect_uris(
     }
 
 
-def update(
-    context: CfnginContext,
-    *,
-    alternate_domains: List[str],
-    client_id: str,
-    distribution_domain: str,
-    oauth_scopes: List[str],
-    redirect_path_sign_in: str,
-    redirect_path_sign_out: str,
-    supported_identity_providers: Optional[List[str]] = None,
-    **_: Any,
-) -> bool:
+def update(context: CfnginContext, *__args: Any, **kwargs: Any) -> bool:
     """Update the callback urls for the User Pool Client.
 
     Required to match the redirect_uri being sent which contains
     our distribution and alternate domain names.
 
+    Arguments parsed by
+    :class:`~runway.cfngin.hooks.staticsite.auth_at_edge.client_updater.HookArgs`.
+
     Args:
         context: The context instance.
-        alternate_domains: A list of any alternate domains
-            that need to be listed with the primary distribution domain.
-        client_id: CLient ID.
-        distribution_domain: Distribution domain.
-        oauth_scopes: A list of all available validation
-            scopes for oauth.
-        redirect_path_sign_in: The redirect path after sign in.
-        redirect_path_sign_out: The redirect path after sign out.
-        supported_identity_providers: Supported identity providers.
 
     """
+    args = HookArgs.parse_obj(kwargs)
     session = context.get_session()
     cognito_client = session.client("cognito-idp")
 
     # Combine alternate domains with main distribution
-    redirect_domains = alternate_domains + ["https://" + distribution_domain]
+    redirect_domains = args.alternate_domains + ["https://" + args.distribution_domain]
 
     # Create a list of all domains with their redirect paths
     redirect_uris = get_redirect_uris(
-        redirect_domains, redirect_path_sign_in, redirect_path_sign_out
+        redirect_domains, args.redirect_path_sign_in, args.redirect_path_sign_out
     )
     # Update the user pool client
     try:
         cognito_client.update_user_pool_client(
-            AllowedOAuthScopes=oauth_scopes,
+            AllowedOAuthScopes=args.oauth_scopes,
             AllowedOAuthFlows=["code"],
-            SupportedIdentityProviders=supported_identity_providers or [],
+            SupportedIdentityProviders=args.supported_identity_providers,
             AllowedOAuthFlowsUserPoolClient=True,
-            ClientId=client_id,
+            ClientId=args.client_id,
             CallbackURLs=redirect_uris["sign_in"],
             LogoutURLs=redirect_uris["sign_out"],
             UserPoolId=context.hook_data["aae_user_pool_id_retriever"]["id"],

--- a/runway/cfngin/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
+++ b/runway/cfngin/hooks/staticsite/auth_at_edge/user_pool_id_retriever.py
@@ -1,33 +1,38 @@
 """Retrieve the ID of the Cognito User Pool."""
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict
+
+from ...base import HookArgsBaseModel
 
 LOGGER = logging.getLogger(__name__)
 
 
-def get(
-    *,
-    created_user_pool_id: Optional[str] = None,
-    user_pool_arn: Optional[str] = None,
-    **_: Any,
-) -> Dict[str, Any]:
+class HookArgs(HookArgsBaseModel):
+    """Hook arguments."""
+
+    created_user_pool_id: str
+    """The ID of the created Cognito User Pool."""
+
+    user_pool_arn: str
+    """The ARN of the supplied User pool."""
+
+
+def get(*__args: Any, **kwargs: Any) -> Dict[str, Any]:
     """Retrieve the ID of the Cognito User Pool.
 
     The User Pool can either be supplied via an ARN or by being generated.
     If the user has supplied an ARN that utilize that, otherwise retrieve
     the generated id. Used in multiple pre_hooks for Auth@Edge.
 
-    Args:
-        user_pool_arn: The ARN of the supplied User pool.
-        created_user_pool_id: The ID of the created Cognito User Pool.
+    Arguments parsed by
+    :class:`~runway.cfngin.hooks.staticsite.auth_at_edge.user_pool_id_retriever.HookArgs`.
 
     """
-    context_dict = {"id": ""}
+    args = HookArgs.parse_obj(kwargs)
 
     # Favor a specific arn over a created one
-    if user_pool_arn:
-        context_dict["id"] = user_pool_arn.split("/")[-1:][0]
-    elif created_user_pool_id:
-        context_dict["id"] = created_user_pool_id
-
-    return context_dict
+    if args.user_pool_arn:
+        return {"id": args.user_pool_arn.split("/")[-1:][0]}
+    if args.created_user_pool_id:
+        return {"id": args.created_user_pool_id}
+    return {"id": ""}

--- a/runway/module/staticsite/options/models.py
+++ b/runway/module/staticsite/options/models.py
@@ -54,11 +54,9 @@ class RunwayStaticSiteExtraFileDataModel(ConfigProperty):
         cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Validate that content or file is provided."""
-        content = values.get("content")
-        file_val = values.get("file")
-        if content and file_val:
+        if all(i in values and values[i] for i in ["content", "file"]):
             raise ValueError("only one of content or file can be provided")
-        if not (content or file_val):
+        if not any(i in values for i in ["content", "file"]):
             raise ValueError("one of content or file must be provided")
         return values
 

--- a/runway/module/utils.py
+++ b/runway/module/utils.py
@@ -30,7 +30,7 @@ def format_npm_command_for_logging(command: List[str]) -> str:
     return " ".join(command)
 
 
-# type hint quated b/c pylint 2.11.1 raises unsubscriptable-object
+# type hint quoted b/c pylint 2.11.1 raises unsubscriptable-object
 def generate_node_command(
     command: str,
     command_opts: List[str],

--- a/runway/utils/__init__.py
+++ b/runway/utils/__init__.py
@@ -136,6 +136,8 @@ class JsonEncoder(json.JSONEncoder):
             return float(o)
         if isinstance(o, (datetime.datetime, datetime.date)):
             return o.isoformat()
+        if isinstance(o, _BaseModel):
+            return o.dict()
         return super().default(o)
 
 

--- a/tests/unit/cfngin/hooks/staticsite/test_cleanup.py
+++ b/tests/unit/cfngin/hooks/staticsite/test_cleanup.py
@@ -1,0 +1,94 @@
+"""Test runway.cfngin.hooks.staticsite.cleanup."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from runway._logging import LogLevels
+from runway.cfngin.hooks.staticsite.cleanup import (
+    REPLICATED_FUNCTION_OUTPUTS,
+    get_replicated_function_names,
+    warn,
+)
+
+if TYPE_CHECKING:
+    from mypy_boto3_cloudformation.type_defs import OutputTypeDef
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+    from ....factories import MockCFNginContext
+
+MODULE = "runway.cfngin.hooks.staticsite.cleanup"
+
+
+@pytest.mark.parametrize(
+    "outputs, expected",
+    [
+        ([], []),
+        (
+            [
+                {"OutputKey": i, "OutputValue": f"{i}Val"}
+                for i in REPLICATED_FUNCTION_OUTPUTS
+            ]
+            + [{"OutputKey": "foo", "OutputValue": "bar"}],
+            [f"{i}Val" for i in REPLICATED_FUNCTION_OUTPUTS],
+        ),
+    ],
+)
+def test_get_replicated_function_names(
+    expected: list[str], outputs: list[OutputTypeDef]
+) -> None:
+    """Test get_replicated_function_names."""
+    assert get_replicated_function_names(outputs) == expected
+
+
+def test_warn(
+    caplog: LogCaptureFixture, cfngin_context: MockCFNginContext, mocker: MockerFixture
+) -> None:
+    """Test warn."""
+    caplog.set_level(LogLevels.WARNING, MODULE)
+    outputs = [{"OutputKey": "foo", "OutputValue": "bar"}]
+    mock_get_func_names = mocker.patch(
+        f"{MODULE}.get_replicated_function_names", return_value=["foo", "foobar"]
+    )
+    stubber = cfngin_context.add_stubber("cloudformation")
+
+    stubber.add_response(
+        "describe_stacks",
+        {
+            "Stacks": [
+                {
+                    "CreationTime": datetime(2015, 1, 1),
+                    "Outputs": outputs,
+                    "StackName": f"{cfngin_context.namespace}-stack-name",
+                    "StackStatus": "CREATE_COMPLETE",
+                }
+            ]
+        },
+        {"StackName": f"{cfngin_context.namespace}-stack-name"},
+    )
+
+    with stubber:
+        assert warn(cfngin_context, stack_relative_name="stack-name")
+    stubber.assert_no_pending_responses()
+    mock_get_func_names.assert_called_once_with(outputs)
+
+    logs = "\n".join(caplog.messages)
+    assert "for x in foo foobar;" in logs
+
+
+def test_warn_ignore_client_error(
+    caplog: LogCaptureFixture, cfngin_context: MockCFNginContext
+) -> None:
+    """Test warn ignore ClientError."""
+    caplog.set_level(LogLevels.WARNING, MODULE)
+    stubber = cfngin_context.add_stubber("cloudformation")
+
+    stubber.add_client_error("describe_stacks")
+
+    with stubber:
+        assert warn(cfngin_context, stack_relative_name="stack-name")
+    stubber.assert_no_pending_responses()
+    assert not caplog.messages

--- a/tests/unit/cfngin/hooks/staticsite/test_upload_staticsite.py
+++ b/tests/unit/cfngin/hooks/staticsite/test_upload_staticsite.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 import pytest
 import yaml
@@ -17,303 +17,327 @@ from runway.cfngin.hooks.staticsite.upload_staticsite import (
     get_content_type,
     sync_extra_files,
 )
+from runway.module.staticsite.options.models import RunwayStaticSiteExtraFileDataModel
 
 if TYPE_CHECKING:
-    from runway.cfngin.hooks.staticsite.upload_staticsite import ExtraFileTypeDef
-
     from ....factories import MockCFNginContext
 
 
-class TestAutoDetectContentType:
-    """Test runway.cfngin.hooks.staticsite.upload_staticsite.auto_detect_content_type."""
-
-    @pytest.mark.parametrize(
-        "provided, expected",
-        [
-            ("prefix.test.json", "application/json"),
-            ("test.json", "application/json"),
-            ("test.yml", "text/yaml"),
-            ("test.yaml", "text/yaml"),
-            ("test.txt", None),
-            ("test", None),
-            (".test", None),
-        ],
-    )
-    def test_auto_detect_content_type(
-        self, provided: str, expected: Optional[str]
-    ) -> None:
-        """Test auto_detect_content_type."""
-        assert auto_detect_content_type(provided) == expected
+@pytest.mark.parametrize(
+    "provided, expected",
+    [
+        ("prefix.test.json", "application/json"),
+        ("test.json", "application/json"),
+        ("test.yml", "text/yaml"),
+        ("test.yaml", "text/yaml"),
+        ("test.txt", None),
+        ("test", None),
+        (".test", None),
+    ],
+)
+def test_auto_detect_content_type(provided: str, expected: Optional[str]) -> None:
+    """Test auto_detect_content_type."""
+    assert auto_detect_content_type(provided) == expected
 
 
-class TestGetContentType:
-    """Test runway.cfngin.hooks.staticsite.upload_staticsite.get_content_type."""
-
-    @pytest.mark.parametrize(
-        "provided, expected",
-        [
-            ({"name": "test.txt", "content_type": "text/plain"}, "text/plain"),
-            ({"name": "test.json"}, "application/json"),
-            ({"name": "test.txt"}, None),
-        ],
-    )
-    def test_get_content_type(
-        self, provided: ExtraFileTypeDef, expected: Optional[str]
-    ) -> None:
-        """Test get_content_type."""
-        assert get_content_type(provided) == expected
-
-
-class TestGetContent:
-    """Test runway.cfngin.hooks.staticsite.upload_staticsite.get_content."""
-
-    def test_json_content(self) -> None:
-        """Test json content is serialized."""
-        content = {"a": 0}
-
-        actual = get_content({"content_type": "application/json", "content": content})
-        expected = json.dumps(content)
-
-        assert actual == expected
-
-    def test_yaml_content(self) -> None:
-        """Test yaml content is serialized."""
-        content = {"a": 0}
-
-        actual = get_content({"content_type": "text/yaml", "content": content})
-        expected = yaml.safe_dump(content)
-
-        assert actual == expected
-
-    def test_unknown_content_type(self) -> None:
-        """Test content w/out content_type."""
-        with pytest.raises(ValueError):
-            get_content({"content": {"a": 0}})
-
-    def test_unsupported_content_type(self) -> None:
-        """Test content w/unsupported content."""
-        with pytest.raises(TypeError):
-            get_content({"content": 123})  # type: ignore
-
-
-class TestCalculateExtraFilesHash:
-    """Test runway.cfngin.hooks.staticsite.upload_staticsite.calculate_hash_of_extra_files."""
-
-    @pytest.mark.parametrize(
-        "a, b",
-        [
-            ({"name": "a"}, {"name": "b"}),
-            (
-                {"name": "test", "content_type": "a"},
-                {"name": "test", "content_type": "b"},
+@pytest.mark.parametrize(
+    "provided, expected",
+    [
+        (
+            RunwayStaticSiteExtraFileDataModel.construct(
+                content_type="text/plain", name="test.txt"
             ),
-            ({"name": "test", "content": "a"}, {"name": "test", "content": "b"}),
-        ],
+            "text/plain",
+        ),
+        (
+            RunwayStaticSiteExtraFileDataModel.construct(
+                name="test.txt", content_type="text/plain"
+            ),
+            "text/plain",
+        ),
+        (
+            RunwayStaticSiteExtraFileDataModel.construct(name="test.json"),
+            "application/json",
+        ),
+        (RunwayStaticSiteExtraFileDataModel.construct(name="test.txt"), None),
+    ],
+)
+def test_get_content_type(
+    provided: RunwayStaticSiteExtraFileDataModel, expected: Optional[str]
+) -> None:
+    """Test get_content_type."""
+    assert get_content_type(provided) == expected
+
+
+def test_get_content_json() -> None:
+    """Get content JSON."""
+    content = {"a": 0}
+
+    actual = get_content(
+        RunwayStaticSiteExtraFileDataModel(
+            content_type="application/json", content=content, name=""
+        )
     )
-    def test_calculate_hash_of_extra_files(
-        self, a: ExtraFileTypeDef, b: ExtraFileTypeDef
-    ) -> None:
-        """Test calculate_hash_of_extra_files."""
-        assert calculate_hash_of_extra_files([a]) != calculate_hash_of_extra_files([b])
+    expected = json.dumps(content)
+
+    assert actual == expected
 
 
-class TestSyncExtraFiles:
-    """Test runway.cfngin.hooks.staticsite.upload_staticsite.sync_extra_files."""
+def test_get_content_yaml() -> None:
+    """Get content YAML."""
+    content = {"a": 0}
 
-    def test_json_content(self, cfngin_context: MockCFNginContext) -> None:
-        """Test json content is put in s3."""
-        s3_stub = cfngin_context.add_stubber("s3")
-
-        content = {"a": 0}
-
-        s3_stub.add_response(
-            "put_object",
-            {},
-            {
-                "Bucket": "bucket",
-                "Key": "test.json",
-                "Body": json.dumps(content).encode(),
-                "ContentType": "application/json",
-            },
+    actual = get_content(
+        RunwayStaticSiteExtraFileDataModel(
+            content_type="text/yaml", content=content, name=""
         )
+    )
+    expected = yaml.safe_dump(content)
 
-        files: List[ExtraFileTypeDef] = [{"name": "test.json", "content": content}]
+    assert actual == expected
 
-        with s3_stub as stub:
-            assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == [
-                "test.json"
-            ]
-            stub.assert_no_pending_responses()
 
-    def test_yaml_content(self, cfngin_context: MockCFNginContext) -> None:
-        """Test yaml content is put in s3."""
-        s3_stub = cfngin_context.add_stubber("s3")
+def test_get_content_unknown() -> None:
+    """Get content unknown."""
+    with pytest.raises(ValueError):
+        get_content(RunwayStaticSiteExtraFileDataModel(content={"a": 0}, name=""))
 
-        content = {"a": 0}
 
-        s3_stub.add_response(
-            "put_object",
-            {},
-            {
-                "Bucket": "bucket",
-                "Key": "test.yaml",
-                "Body": yaml.safe_dump(content).encode(),
-                "ContentType": "text/yaml",
-            },
+def test_get_content_unsupported() -> None:
+    """Get content unknown."""
+    with pytest.raises(TypeError):
+        get_content(RunwayStaticSiteExtraFileDataModel(content=123, name=""))
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        (
+            RunwayStaticSiteExtraFileDataModel.construct(name="a"),
+            RunwayStaticSiteExtraFileDataModel.construct(name="b"),
+        ),
+        (
+            RunwayStaticSiteExtraFileDataModel.construct(name="test", content_type="a"),
+            RunwayStaticSiteExtraFileDataModel.construct(name="test", content_type="b"),
+        ),
+        (
+            RunwayStaticSiteExtraFileDataModel.construct(name="test", content="a"),
+            RunwayStaticSiteExtraFileDataModel.construct(name="test", content="b"),
+        ),
+    ],
+)
+def test_calculate_hash_of_extra_files(
+    a: RunwayStaticSiteExtraFileDataModel, b: RunwayStaticSiteExtraFileDataModel
+) -> None:
+    """Test calculate_hash_of_extra_files."""
+    assert calculate_hash_of_extra_files([a]) != calculate_hash_of_extra_files([b])
+
+
+def test_sync_extra_files_json_content(cfngin_context: MockCFNginContext) -> None:
+    """Test sync_extra_files json content is put in s3."""
+    s3_stub = cfngin_context.add_stubber("s3")
+
+    content = {"a": 0}
+
+    s3_stub.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "bucket",
+            "Key": "test.json",
+            "Body": json.dumps(content).encode(),
+            "ContentType": "application/json",
+        },
+    )
+
+    files = [RunwayStaticSiteExtraFileDataModel(name="test.json", content=content)]
+
+    with s3_stub as stub:
+        assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == [
+            "test.json"
+        ]
+        stub.assert_no_pending_responses()
+
+
+def test_sync_extra_files_yaml_content(cfngin_context: MockCFNginContext) -> None:
+    """Test sync_extra_files yaml content is put in s3."""
+    s3_stub = cfngin_context.add_stubber("s3")
+
+    content = {"a": 0}
+
+    s3_stub.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "bucket",
+            "Key": "test.yaml",
+            "Body": yaml.safe_dump(content).encode(),
+            "ContentType": "text/yaml",
+        },
+    )
+
+    files = [
+        RunwayStaticSiteExtraFileDataModel.construct(name="test.yaml", content=content)
+    ]
+
+    with s3_stub as stub:
+        assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == [
+            "test.yaml"
+        ]
+        stub.assert_no_pending_responses()
+
+
+def test_sync_extra_files_empty_content(cfngin_context: MockCFNginContext) -> None:
+    """Test sync_extra_files empty content is not uploaded."""
+    s3_stub = cfngin_context.add_stubber("s3")
+
+    with s3_stub as stub:
+        result = sync_extra_files(
+            cfngin_context,
+            "bucket",
+            extra_files=[
+                RunwayStaticSiteExtraFileDataModel.construct(
+                    name="test.yaml", content=""
+                )
+            ],
         )
+        assert isinstance(result, list)
+        assert not result
+        stub.assert_no_pending_responses()
 
-        files: List[ExtraFileTypeDef] = [{"name": "test.yaml", "content": content}]
 
-        with s3_stub as stub:
-            assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == [
-                "test.yaml"
-            ]
-            stub.assert_no_pending_responses()
+def test_sync_extra_files_file_reference(cfngin_context: MockCFNginContext) -> None:
+    """Test sync_extra_files file is uploaded."""
+    s3_stub = cfngin_context.add_stubber("s3")
 
-    def test_empty_content(self, cfngin_context: MockCFNginContext) -> None:
-        """Test empty content is not uploaded."""
-        s3_stub = cfngin_context.add_stubber("s3")
+    # This isn't ideal, but needed to get the correct stubbing.
+    # Stubber doesn't support 'upload_file' so we need to assume it delegates to 'put_object'.
+    # https://stackoverflow.com/questions/59303423/s3-boto3-stubber-doesnt-have-mapping-for-download-file
+    s3_stub.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "bucket",
+            "Key": "test",
+            # Don't want to make any more assumptions about how upload_file works
+            "Body": ANY,
+        },
+    )
 
-        with s3_stub as stub:
-            result = sync_extra_files(
-                cfngin_context,
-                "bucket",
-                extra_files=[{"name": "test.yaml", "content": {}}],
-            )
-            assert isinstance(result, list)
-            assert not result
-            stub.assert_no_pending_responses()
+    files = [
+        RunwayStaticSiteExtraFileDataModel.construct(name="test", file=".gitignore")
+    ]
 
-    def test_file_reference(self, cfngin_context: MockCFNginContext) -> None:
-        """Test file is uploaded."""
-        s3_stub = cfngin_context.add_stubber("s3")
+    with s3_stub as stub:
+        assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == ["test"]
+        stub.assert_no_pending_responses()
 
-        # This isn't ideal, but needed to get the correct stubbing.
-        # Stubber doesn't support 'upload_file' so we need to assume it delegates to 'put_object'.
-        # https://stackoverflow.com/questions/59303423/s3-boto3-stubber-doesnt-have-mapping-for-download-file
-        s3_stub.add_response(
-            "put_object",
-            {},
-            {
-                "Bucket": "bucket",
-                "Key": "test",
-                # Don't want to make any more assumptions about how upload_file works
-                "Body": ANY,
-            },
+
+def test_sync_extra_files_file_reference_with_content_type(
+    cfngin_context: MockCFNginContext,
+) -> None:
+    """Test sync_extra_files file is uploaded with the content type."""
+    s3_stub = cfngin_context.add_stubber("s3")
+
+    s3_stub.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "bucket",
+            "Key": "test.json",
+            "Body": ANY,
+            "ContentType": "application/json",
+        },
+    )
+
+    files = [
+        RunwayStaticSiteExtraFileDataModel.construct(
+            name="test.json", file=".gitignore"
         )
+    ]
 
-        files: List[ExtraFileTypeDef] = [{"name": "test", "file": ".gitignore"}]
+    with s3_stub as stub:
+        assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == [
+            "test.json"
+        ]
+        stub.assert_no_pending_responses()
 
-        with s3_stub as stub:
-            assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == [
-                "test"
-            ]
-            stub.assert_no_pending_responses()
 
-    def test_file_reference_with_content_type(
-        self, cfngin_context: MockCFNginContext
-    ) -> None:
-        """Test file is uploaded with the content type."""
-        s3_stub = cfngin_context.add_stubber("s3")
+def test_sync_extra_files_hash_unchanged(cfngin_context: MockCFNginContext) -> None:
+    """Test sync_extra_files upload is skipped if the has was unchanged."""
+    s3_stub = cfngin_context.add_stubber("s3")
+    ssm_stub = cfngin_context.add_stubber("ssm")
 
-        s3_stub.add_response(
-            "put_object",
-            {},
-            {
-                "Bucket": "bucket",
-                "Key": "test.json",
-                "Body": ANY,
-                "ContentType": "application/json",
-            },
+    extra = RunwayStaticSiteExtraFileDataModel.construct(name="test", content="test")
+    extra_hash = calculate_hash_of_extra_files([extra])
+
+    ssm_stub.add_response(
+        "get_parameter",
+        {"Parameter": {"Value": extra_hash}},
+        {"Name": "hash_nameextra"},
+    )
+
+    with s3_stub as s3_stub, ssm_stub as ssm_stub:
+        result = sync_extra_files(
+            cfngin_context,
+            "bucket",
+            extra_files=[extra],
+            hash_tracking_parameter="hash_name",
         )
+        assert isinstance(result, list)
+        assert not result
+        s3_stub.assert_no_pending_responses()
+        ssm_stub.assert_no_pending_responses()
 
-        files: List[ExtraFileTypeDef] = [{"name": "test.json", "file": ".gitignore"}]
 
-        with s3_stub as stub:
-            assert sync_extra_files(cfngin_context, "bucket", extra_files=files) == [
-                "test.json"
-            ]
-            stub.assert_no_pending_responses()
+def test_sync_extra_files_hash_updated(cfngin_context: MockCFNginContext) -> None:
+    """Test sync_extra_files extra files hash is updated."""
+    s3_stub = cfngin_context.add_stubber("s3")
+    ssm_stub = cfngin_context.add_stubber("ssm")
 
-    def test_hash_unchanged(self, cfngin_context: MockCFNginContext) -> None:
-        """Test upload is skipped if the has was unchanged."""
-        s3_stub = cfngin_context.add_stubber("s3")
-        ssm_stub = cfngin_context.add_stubber("ssm")
+    extra = RunwayStaticSiteExtraFileDataModel(
+        name="test", content="test", content_type="text/plain"
+    )
+    extra_hash = calculate_hash_of_extra_files([extra])
 
-        extra: ExtraFileTypeDef = {
-            "name": "test",
-            "content": "test",
-        }
-        extra_hash = calculate_hash_of_extra_files([extra])
+    ssm_stub.add_response(
+        "get_parameter",
+        {"Parameter": {"Value": "old value"}},
+        {"Name": "hash_nameextra"},
+    )
 
-        ssm_stub.add_response(
-            "get_parameter",
-            {"Parameter": {"Value": extra_hash}},
-            {"Name": "hash_nameextra"},
-        )
+    ssm_stub.add_response(
+        "put_parameter",
+        {},
+        {
+            "Name": "hash_nameextra",
+            "Description": ANY,
+            "Value": extra_hash,
+            "Type": "String",
+            "Overwrite": True,
+        },
+    )
 
-        with s3_stub as s3_stub, ssm_stub as ssm_stub:
-            result = sync_extra_files(
+    s3_stub.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "bucket",
+            "Key": "test",
+            "Body": "test".encode(),
+            "ContentType": "text/plain",
+        },
+    )
+
+    with s3_stub as s3_stub, ssm_stub as ssm_stub:
+        assert (
+            sync_extra_files(
                 cfngin_context,
                 "bucket",
                 extra_files=[extra],
                 hash_tracking_parameter="hash_name",
             )
-            assert isinstance(result, list)
-            assert not result
-            s3_stub.assert_no_pending_responses()
-            ssm_stub.assert_no_pending_responses()
-
-    def test_hash_updated(self, cfngin_context: MockCFNginContext) -> None:
-        """Test extra files hash is updated."""
-        s3_stub = cfngin_context.add_stubber("s3")
-        ssm_stub = cfngin_context.add_stubber("ssm")
-
-        extra: ExtraFileTypeDef = {
-            "name": "test",
-            "content": "test",
-            "content_type": "text/plain",
-        }
-        extra_hash = calculate_hash_of_extra_files([extra])
-
-        ssm_stub.add_response(
-            "get_parameter",
-            {"Parameter": {"Value": "old value"}},
-            {"Name": "hash_nameextra"},
+            == ["test"]
         )
-
-        ssm_stub.add_response(
-            "put_parameter",
-            {},
-            {
-                "Name": "hash_nameextra",
-                "Description": ANY,
-                "Value": extra_hash,
-                "Type": "String",
-                "Overwrite": True,
-            },
-        )
-
-        s3_stub.add_response(
-            "put_object",
-            {},
-            {
-                "Bucket": "bucket",
-                "Key": "test",
-                "Body": "test".encode(),
-                "ContentType": "text/plain",
-            },
-        )
-
-        with s3_stub as s3_stub, ssm_stub as ssm_stub:
-            assert (
-                sync_extra_files(
-                    cfngin_context,
-                    "bucket",
-                    extra_files=[extra],
-                    hash_tracking_parameter="hash_name",
-                )
-                == ["test"]
-            )
-            s3_stub.assert_no_pending_responses()
-            ssm_stub.assert_no_pending_responses()
+        s3_stub.assert_no_pending_responses()
+        ssm_stub.assert_no_pending_responses()


### PR DESCRIPTION
# Why This Is Needed

resolves #1166

# What Changed

## Added

- added a pydantic data model to parse `runway.cfngin.hooks.staticsite` args
