### PR TITLE
update ReadTheDocs config, fix duplicate object description warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,15 +5,17 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
 build:
-  image: latest
+  os: ubuntu-20.04
+  tools:
+    python: '3.9'
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/runway/cfngin/hooks/docker/_login.py
+++ b/runway/cfngin/hooks/docker/_login.py
@@ -18,16 +18,7 @@ LOGGER = logging.getLogger(__name__.replace("._", "."))
 
 
 class LoginArgs(BaseModel):
-    """Args passed to the docker.login hook.
-
-    Attributes:
-        dockercfg_path: Path to a non-default Docker config file.
-        email: The email for the registry account.
-        password: The plaintext password for the registry account.
-        registry: URI of the registry to login to.
-        username: The registry username.
-
-    """
+    """Args passed to the docker.login hook."""
 
     _ctx: Optional[CfnginContext] = Field(default=None, alias="context", exclude=True)
 

--- a/runway/cfngin/hooks/docker/data_models.py
+++ b/runway/cfngin/hooks/docker/data_models.py
@@ -25,15 +25,7 @@ ECR_REPO_FQN_TEMPLATE = (
 
 
 class ElasticContainerRegistry(BaseModel):
-    """AWS Elastic Container Registry.
-
-    Attributes:
-        account_id: AWS account ID that owns the registry being logged into.
-        alias: If it is a public repository, the alias of the repository.
-        public: Whether the repository is public.
-        region: AWS region where the registry is located.
-
-    """
+    """AWS Elastic Container Registry."""
 
     PUBLIC_URI_TEMPLATE: ClassVar[str] = "public.ecr.aws/{registry_alias}/"
     URI_TEMPLATE: ClassVar[str] = "{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/"


### PR DESCRIPTION
# Summary

Update the ReadTheDocs config to use the latest syntax for the `build` block. This also resolves for Sphinx warnings for duplicate object descriptions that were introduced by an earlier PR in this release.
