### PR TITLE
add linting & tests for python3.9

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,11 +1,11 @@
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 6
     wait_for_ci: false
   require_ci_to_pass: false
 
 comment:
-  after_n_builds: 2
+  after_n_builds: 6
 
 coverage:
   status:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -90,7 +90,7 @@ jobs:
     name: Lint Python
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-18.04, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -191,7 +191,7 @@ jobs:
     name: Test Python
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-18.04, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
 ]
 packages = [
   { include = "runway" },


### PR DESCRIPTION
# Summary

Linting and tests will now be run with python 3.7, 3.8, and 3.9.

Due to the limitation of dependencies (docker), 3.10 can't be added to the list at this time.
