### PR TITLE
fix broken url in error when registering invalid CFNgin lookups

### DIFF
--- a/runway/cfngin/lookups/registry.py
+++ b/runway/cfngin/lookups/registry.py
@@ -54,7 +54,7 @@ def register_lookup_handler(
         LOGGER.debug("failed to validate lookup handler", exc_info=True)
     LOGGER.error(
         'lookup "%s" uses an unsupported format; to learn how to write '
-        "lookups visit %s/page/cfngin/lookups.html#writing-a-custom-lookup",
+        "lookups visit %s/page/cfngin/lookups/index.html#writing-a-custom-lookup",
         lookup_type,
         DOC_SITE,
     )


### PR DESCRIPTION
# Why This Is Needed

Page in documentation was moved.

> **NOTE:** A page redirect was also added to ReadTheDocs for backward compatibility.
