### PR TITLE
add `env` lookup to CFNgin, deprecate `envvar` lookup

### DIFF
--- a/docs/source/cfngin/lookups/cfn.rst
+++ b/docs/source/cfngin/lookups/cfn.rst
@@ -9,7 +9,7 @@ cfn
   This means that it must have been deployed using another Runway module, deployed from a config that is run before the one using it, deployed manually, or deployed in the same config using :attr:`~cfngin.stack.required`/:attr:`~cfngin.stack.required_by` to specify a dependency between the Stacks.
 
 
-:Query Syntax: ``<stack-name>.<output-name>``
+:Query Syntax: ``<stack-name>.<output-name>[::<arg>=<arg-val>, ...]``
 
 
 Retrieve a value from CloudFormation Stack Outputs.

--- a/docs/source/cfngin/lookups/env.rst
+++ b/docs/source/cfngin/lookups/env.rst
@@ -1,0 +1,42 @@
+.. _CFNgin env lookup:
+
+###
+env
+###
+
+:Query Syntax: ``<variable-name>[::<arg>=<arg-val>, ...]``
+
+
+Retrieve a value from an environment variable.
+
+The value is retrieved from a copy of the current environment variables that is saved to the context object.
+These environment variables are manipulated at runtime by Runway to fill in additional values such as ``DEPLOY_ENVIRONMENT`` and ``AWS_REGION`` to match the current execution.
+
+If the Lookup is unable to find an environment variable matching the provided query, the default value is returned or a :exc:`ValueError` is raised if a default value was not provided.
+
+
+.. here, versionadded refers to when it was added to the CFNgin registry
+.. versionadded:: 2.7.0
+
+
+
+*********
+Arguments
+*********
+
+This Lookup supports all :ref:`Common Lookup Arguments` but, the following have limited or no effect:
+
+- region
+
+
+
+*******
+Example
+*******
+
+.. code-block:: yaml
+
+  stacks:
+    - ...
+      variables:
+        Foo: ${env bar::default=foobar}

--- a/docs/source/cfngin/lookups/envvar.rst
+++ b/docs/source/cfngin/lookups/envvar.rst
@@ -3,7 +3,7 @@ envvar
 ######
 
 .. deprecated:: 2.7.0
-  Replaced by :ref:`CFNgin cfn lookup`
+  Replaced by :ref:`CFNgin env lookup`
 
 
 :Query Syntax: ``<variable-name>``

--- a/docs/source/cfngin/lookups/envvar.rst
+++ b/docs/source/cfngin/lookups/envvar.rst
@@ -2,6 +2,10 @@
 envvar
 ######
 
+.. deprecated:: 2.7.0
+  Replaced by :ref:`CFNgin cfn lookup`
+
+
 :Query Syntax: ``<variable-name>``
 
 

--- a/docs/source/cfngin/lookups/hook_data.rst
+++ b/docs/source/cfngin/lookups/hook_data.rst
@@ -4,7 +4,7 @@
 hook_data
 #########
 
-:Query Syntax: ``<hook.data_key>``
+:Query Syntax: ``<hook.data_key>[::<arg>=<arg-val>, ...]``
 
 
 When using hooks, you can have the hook store results in the :attr:`CfnginContext.hook_data <runway.context.CfnginContext.hook_data>` dictionary on the context by setting :attr:`~cfngin.hook.data_key` in the :class:`~cfngin.hook` config.

--- a/docs/source/cfngin/lookups/ssm.rst
+++ b/docs/source/cfngin/lookups/ssm.rst
@@ -2,7 +2,7 @@
 ssm
 ###
 
-:Query Syntax: ``<parameter>``
+:Query Syntax: ``<parameter>[::<arg>=<arg-val>, ...]``
 
 
 Retrieve a value from SSM Parameter Store.
@@ -24,7 +24,12 @@ Arguments
 
 This Lookup supports all :ref:`Common Lookup Arguments`.
 
-.. rubric:: Example
+
+
+*******
+Example
+*******
+
 .. code-block:: yaml
 
   stacks:

--- a/docs/source/lookups/cfn.rst
+++ b/docs/source/lookups/cfn.rst
@@ -10,7 +10,7 @@ cfn
   This means that the Stack must have been deployed by another module, run before the one using this Lookup, or it must have been created external to Runway.
 
 
-:Query Syntax: ``<stack-name>.<output-name>``
+:Query Syntax: ``<stack-name>.<output-name>[::<arg>=<arg-val>, ...]``
 
 
 Retrieve a value from CloudFormation Stack Outputs.

--- a/docs/source/lookups/env.rst
+++ b/docs/source/lookups/env.rst
@@ -5,7 +5,7 @@
 env
 ###
 
-:Query Syntax: ``<variable-name>``
+:Query Syntax: ``<variable-name>[::<arg>=<arg-val>, ...]``
 
 
 Retrieve a value from an environment variable.

--- a/docs/source/lookups/index.rst
+++ b/docs/source/lookups/index.rst
@@ -7,7 +7,7 @@ Lookups
 Runway Lookups allow the use of variables within the Runway config file.
 These variables can then be passed along to :ref:`deployments <runway-deployment>`, :ref:`modules <runway-module>` and :ref:`tests <runway-test>`.
 
-The syntax for a lookup is ``${<lookup-name> <query>::<arg-key>=<arg-value>}``.
+The syntax for a lookup is ``${<lookup-name> <query>::<arg>=<arg-val>}``.
 
 +---------------------------+-------------------------------------------------+
 | Component                 | Description                                     |
@@ -31,7 +31,7 @@ The syntax for a lookup is ``${<lookup-name> <query>::<arg-key>=<arg-value>}``.
 | ``::``                    | The separator between a query and optional      |
 |                           | arguments.                                      |
 +---------------------------+-------------------------------------------------+
-| ``<arg-key>=<arg-value>`` || An argument passed to a lookup.                |
+| ``<arg>=<arg-val>``       || An argument passed to a lookup.                |
 |                           || Multiple arguments can be passed to a lookup   |
 |                           |  by separating them with a                      |
 |                           || comma (``,``).                                 |

--- a/docs/source/lookups/random.string.rst
+++ b/docs/source/lookups/random.string.rst
@@ -4,7 +4,7 @@
 random.string
 #############
 
-:Query Syntax: ``<desired-length>``
+:Query Syntax: ``<desired-length>[::<arg>=<arg-val>, ...]``
 
 
 Generate a random string of the given length.

--- a/docs/source/lookups/ssm.rst
+++ b/docs/source/lookups/ssm.rst
@@ -5,7 +5,7 @@
 ssm
 ###
 
-:Query Syntax: ``<parameter>``
+:Query Syntax: ``<parameter>[::<arg>=<arg-val>, ...]``
 
 
 Retrieve a value from SSM Parameter Store.
@@ -27,7 +27,12 @@ Arguments
 
 This Lookup supports all :ref:`Common Lookup Arguments`.
 
-.. rubric:: Example
+
+
+*******
+Example
+*******
+
 .. code-block:: yaml
 
   deployment:

--- a/docs/source/lookups/var.rst
+++ b/docs/source/lookups/var.rst
@@ -5,7 +5,7 @@
 var
 ###
 
-:Query Syntax: ``<variable-name>``
+:Query Syntax: ``<variable-name>[::<arg>=<arg-val>, ...]``
 
 
 Retrieve a variable from the variables file or definition.

--- a/runway/cfngin/lookups/handlers/envvar.py
+++ b/runway/cfngin/lookups/handlers/envvar.py
@@ -46,7 +46,7 @@ class EnvvarLookup(LookupHandler):
                 conf_key: ENV_VALUE
 
         """
-        LOGGER.warning(f"${{envvar {value}}}: {cls.DEPRECATION_MSG}: ${{env {value}}}")
+        LOGGER.warning("${envvar %s}: %s: ${env %s}", value, cls.DEPRECATION_MSG, value)
         value = read_value_from_path(value)
 
         try:

--- a/runway/cfngin/lookups/handlers/envvar.py
+++ b/runway/cfngin/lookups/handlers/envvar.py
@@ -1,5 +1,6 @@
 """Environment variable lookup."""
 # pyright: reportIncompatibleMethodOverride=none
+import logging
 import os
 from typing import Any
 
@@ -8,10 +9,13 @@ from typing_extensions import Final, Literal
 from ....lookups.handlers.base import LookupHandler
 from ...utils import read_value_from_path
 
+LOGGER = logging.getLogger(__name__)
+
 
 class EnvvarLookup(LookupHandler):
     """Environment variable lookup."""
 
+    DEPRECATION_MSG = "envvar Lookup has been deprecated; use the env lookup instead"
     TYPE_NAME: Final[Literal["envvar"]] = "envvar"
     """Name that the Lookup is registered as."""
 
@@ -42,6 +46,7 @@ class EnvvarLookup(LookupHandler):
                 conf_key: ENV_VALUE
 
         """
+        LOGGER.warning(f"${{envvar {value}}}: {cls.DEPRECATION_MSG}: ${{env {value}}}")
         value = read_value_from_path(value)
 
         try:

--- a/runway/cfngin/lookups/registry.py
+++ b/runway/cfngin/lookups/registry.py
@@ -7,6 +7,7 @@ from typing import Dict, Type, Union, cast
 from ...lookups.handlers.base import LookupHandler
 from ...lookups.handlers.cfn import CfnLookup
 from ...lookups.handlers.ecr import EcrLookup
+from ...lookups.handlers.env import EnvLookup
 from ...lookups.handlers.random_string import RandomStringLookup
 from ...lookups.handlers.ssm import SsmLookup
 from ...utils import DOC_SITE, load_object_from_string
@@ -104,6 +105,7 @@ register_lookup_handler(CfnLookup.TYPE_NAME, CfnLookup)
 register_lookup_handler(DefaultLookup.TYPE_NAME, DefaultLookup)
 register_lookup_handler(DynamodbLookup.TYPE_NAME, DynamodbLookup)
 register_lookup_handler(EcrLookup.TYPE_NAME, EcrLookup)
+register_lookup_handler(EnvLookup.TYPE_NAME, EnvLookup)
 register_lookup_handler(EnvvarLookup.TYPE_NAME, EnvvarLookup)
 register_lookup_handler(FileLookup.TYPE_NAME, FileLookup)
 register_lookup_handler(HookDataLookup.TYPE_NAME, HookDataLookup)

--- a/runway/lookups/handlers/env.py
+++ b/runway/lookups/handlers/env.py
@@ -2,14 +2,14 @@
 # pyright: reportIncompatibleMethodOverride=none
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from typing_extensions import Final, Literal
 
 from .base import LookupHandler
 
 if TYPE_CHECKING:
-    from ...context import RunwayContext
+    from ...context import CfnginContext, RunwayContext
 
 
 class EnvLookup(LookupHandler):
@@ -20,7 +20,11 @@ class EnvLookup(LookupHandler):
 
     @classmethod
     def handle(  # pylint: disable=arguments-differ
-        cls, value: str, context: RunwayContext, *__args: Any, **__kwargs: Any
+        cls,
+        value: str,
+        context: Union[CfnginContext, RunwayContext],
+        *__args: Any,
+        **__kwargs: Any,
     ) -> Any:
         """Retrieve an environment variable.
 

--- a/tests/unit/cfngin/lookups/test_registry.py
+++ b/tests/unit/cfngin/lookups/test_registry.py
@@ -37,6 +37,7 @@ def test_autoloaded_lookup_handlers(mocker: MockerFixture) -> None:
         "default",
         "dynamodb",
         "ecr",
+        "env",
         "envvar",
         "file",
         "hook_data",


### PR DESCRIPTION
# Summary

The `env` lookup can now be used from CFNgin.

# Why This Is Needed

resolves #1188

# What Changed

## Changed

- the `env` lookup can now be used from CFNgin
- the `envvar` CFNgin lookup has been deprecated
