### PR TITLE
update `rxref` lookup syntax, deprecate old syntax

### DIFF
--- a/docs/source/cfngin/lookups/rxref.rst
+++ b/docs/source/cfngin/lookups/rxref.rst
@@ -4,17 +4,29 @@
 rxref
 #####
 
-:Query Syntax: ``<stack-name>::<output-name>``
+:Query Syntax: ``<relative-stack-name>.<output-name>[::<arg>=<arg-val>, ...]``
 
 
-The rxref_ lookup type is very similar to the :ref:`xref lookup` type.
-Where the :ref:`xref lookup` type assumes you provided a fully qualified stack name, rxref_, like the :ref:`output lookup` expands and retrieves the output from the given Stack name within the current |namespace|, even if not defined in the CFNgin config you provided it.
+The rxref_ lookup type is very similar to the :ref:`CFNgin cfn lookup` lookup type.
+Where the :ref:`CFNgin cfn lookup` type assumes you provided a fully qualified stack name, rxref_, like the :ref:`output lookup` expands and retrieves the output from the given Stack name within the current |namespace|, even if not defined in the CFNgin config you provided it.
 
 Because there is no requirement to keep all stacks defined within the same CFNgin YAML config, you might need the ability to read outputs from other Stacks deployed by CFNgin into your same account under the same |namespace|.
 rxref_ gives you that ability.
 This is useful if you want to break up very large configs into smaller groupings.
 
 Also, unlike the :ref:`output lookup` type, rxref_ doesn't impact Stack requirements.
+
+
+.. versionchanged:: 2.7.0
+  The ``<relative-stack-name>::<output-name>`` syntax is deprecated to comply with Runway's lookup syntax.
+
+
+
+*********
+Arguments
+*********
+
+This Lookup supports all :ref:`Common Lookup Arguments`.
 
 
 
@@ -24,13 +36,15 @@ Example
 
 .. code-block:: yaml
 
-  # in example-us-east-1.env
-  namespace: MyNamespace
+  namespace: namespace
 
-  # in cfngin.yaml
-  ConfVariable: ${rxref my-stack::SomeOutput}
+  stacks:
+    - ...
+      variables:
+        ConfVariable0: ${rxref my-stack.SomeOutput}
+        # both of these lookups are functionally equivalent
+        ConfVariable1: ${cfn namespace-my-stack.SomeOutput}
 
-  # the above would effectively resolve to
-  ConfVariable: ${xref MyNamespace-my-stack::SomeOutput}
 
 Although possible, it is not recommended to use ``rxref`` for stacks defined within the same CFNgin YAML config.
+Doing so would require the use of :attr:`~cfngin.stack.required_by` or :attr:`~cfngin.stack.requires`.

--- a/runway/lookups/handlers/cfn.py
+++ b/runway/lookups/handlers/cfn.py
@@ -5,6 +5,7 @@ When specifying the output name, be sure to use the *Logical ID* of
 the output; not the *Export.Name*.
 
 """
+# pyright: reportIncompatibleMethodOverride=none
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
# Why This Is Needed

resolves #1192 

# What Changed

## Changed

- updated `rxref` lookup syntax to comply with Runway's lookup syntax
- `rxref` lookup now supports arguments
- deprecated legacy `rxref` syntax
