### PR TITLE
remove use of deprecated method when CFNgin gets stack changes

### DIFF
--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -1594,7 +1594,7 @@ class Provider(BaseProvider):
         for (
             output_name,
             output_params,
-        ) in stack.blueprint.get_output_definitions().items():
+        ) in stack.blueprint.output_definitions.items():
             if output_name not in self._outputs[stack.fqn]:
                 self._outputs[stack.fqn][
                     output_name

--- a/tests/functional/cfngin/hooks/test_awslambda/test_runner.py
+++ b/tests/functional/cfngin/hooks/test_awslambda/test_runner.py
@@ -149,6 +149,7 @@ def deploy_result(cli_runner: CliRunner) -> Generator[Result, None, None]:
     """Execute `runway deploy` with `runway destory` as a cleanup step."""
     yield cli_runner.invoke(cli, ["deploy"], env=ENV_VARS)
     assert cli_runner.invoke(cli, ["destroy"], env=ENV_VARS).exit_code == 0
+    shutil.rmtree(CURRENT_DIR / ".runway", ignore_errors=True)
     shutil.rmtree(CURRENT_DIR / "sample_app" / ".runway", ignore_errors=True)
     # remove .venv/ & *.lock from source code directories - more important for local testing
     (DOCKER_MYSQL_DIR / "Pipfile.lock").unlink(missing_ok=True)

--- a/tests/unit/cfngin/providers/aws/test_default.py
+++ b/tests/unit/cfngin/providers/aws/test_default.py
@@ -125,8 +125,8 @@ def generate_stack_object(
         outputs = {"FakeOutput": {"Value": {"Ref": "FakeResource"}}}
     mock_stack.name = stack_name
     mock_stack.fqn = stack_name
-    mock_stack.blueprint = MagicMock(["get_output_definitions"])
-    mock_stack.blueprint.get_output_definitions = MagicMock(return_value=outputs)
+    mock_stack.blueprint = MagicMock(["output_definitions"])
+    mock_stack.blueprint.output_definitions = outputs
     return mock_stack
 
 


### PR DESCRIPTION
# Summary

Update the use of a deprecated method when CFNgin is getting stack changes. It now uses the new attribute to access the same data.