### PR TITLE
update `kms` lookup syntax, deprecate old syntax

### DIFF
--- a/docs/source/cfngin/lookups/kms.rst
+++ b/docs/source/cfngin/lookups/kms.rst
@@ -2,12 +2,27 @@
 kms
 ###
 
-:Query Syntax: ``[<region>@]<encrypted-blob>``
+:Query Syntax: ``<encrypted-blob>[::region=<region>, ...]``
 
 
 The kms_ lookup type decrypts its input value.
 
-As an example, if you have a database and it has a parameter called ``DBPassword`` that you don't want to store in plain text in your config (maybe because you want to check it into your version control system to share with the team), you could instead encrypt the value using ``kms``.
+As an example, if you have a database and it has a parameter called ``DBPassword`` that you don't want to store in plain text in your config (maybe because you want to check it into your version control system to share with the team), you could instead en
+crypt the value using ``kms``.
+
+
+.. versionchanged:: 2.7.0
+  The ``[<region>@]<encrypted-blob>`` syntax is deprecated to comply with Runway's lookup syntax.
+
+
+
+*********
+Arguments
+*********
+
+This Lookup supports all :ref:`Common Lookup Arguments` but, the following have limited or no effect:
+
+- default
 
 
 
@@ -15,28 +30,39 @@ As an example, if you have a database and it has a parameter called ``DBPassword
 Example
 *******
 
-.. code-block:: shell
+We use can use the aws cli to get the encrypted value for the string "PASSWORD" using the master key called 'myKey' in us-east-1.
 
-  # We use the aws cli to get the encrypted value for the string
-  # "PASSWORD" using the master key called 'myKey' in us-east-1
+.. code-block:: console
+
   $ aws --region us-east-1 kms encrypt --key-id alias/myKey \
       --plaintext "PASSWORD" --output text --query CiphertextBlob
 
   CiD6bC8t2Y<...encrypted blob...>
 
-  # With CFNgin we would reference the encrypted value like:
-  DBPassword: ${kms us-east-1@CiD6bC8t2Y<...encrypted blob...>}
+.. code-block:: yaml
 
-  # The above would resolve to
-  DBPassword: PASSWORD
+  namespace: example
 
-This requires that the person using CFNgin has access to the master key used to encrypt the value.
+  stacks:
+    - ...
+      variables:
+        # With CFNgin we would reference the encrypted value like:
+        DBPassword: ${kms CiD6bC8t2Y<...encrypted blob...>::region=us-east-1}
+        # The above would resolve to:
+        DBPassword: PASSWORD
+
+This requires that the credentials used by CFNgin have access to the master key used to encrypt the value.
 
 It is also possible to store the encrypted blob in a file (useful if the value is large) using the ``file://`` prefix, ie:
 
 .. code-block:: yaml
 
-  DockerConfig: ${kms file://dockercfg}
+  namespace: example
+
+  stacks:
+    - ...
+      variables:
+        DockerConfig: ${kms file://dockercfg}
 
 .. note::
-  Lookups resolve the path specified with ``file://`` relative to the location of the config file, not where the CFNgin command is run.
+  Lookups resolve the path specified with ``file://`` relative to the location of the config file, not the current working directory.

--- a/runway/cfngin/lookups/handlers/output.py
+++ b/runway/cfngin/lookups/handlers/output.py
@@ -46,7 +46,7 @@ class OutputLookup(LookupHandler):
             <relative-stack-name>::<OutputName>
 
         """
-        LOGGER.warning("${output %s}: %s", value, cls.DEPRECATION_MSG)
+        LOGGER.warning("${%s %s}: %s", cls.TYPE_NAME, value, cls.DEPRECATION_MSG)
         return deconstruct(value), {}
 
     @classmethod

--- a/runway/cfngin/lookups/handlers/rxref.py
+++ b/runway/cfngin/lookups/handlers/rxref.py
@@ -38,7 +38,7 @@ class RxrefLookup(LookupHandler):
             <relative-stack-name>::<OutputName>
 
         """
-        LOGGER.warning("${rxref %s}: %s", value, cls.DEPRECATION_MSG)
+        LOGGER.warning("${%s %s}: %s", cls.TYPE_NAME, value, cls.DEPRECATION_MSG)
         return deconstruct(value), {}
 
     @classmethod


### PR DESCRIPTION
# Why This Is Needed

resolves #1190 

# What Changed

## Changed

- updated `kms` lookup syntax to comply with Runway's lookup syntax
- `kms` lookup now supports arguments
- deprecated legacy `kms` syntax
