### PR TITLE
remove the upper `troposphere` requirement to allow `>=4`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2375,7 +2375,7 @@ docs = ["dunamai", "jsx-lexer", "sphinx", "sphinx-github-changelog", "sphinx-rtd
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <4"
-content-hash = "575e6cbea3ac6ca3944186e15f0cf358c64336cff9b51ce7482ae9b0df870a61"
+content-hash = "2355c8a0593e1030da0c7f602608b34d1c1d5804b0d058ee6a6a65142d995a6c"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ sphinx-tabs = { version = "^3.2", optional = true }  # docs
 sphinxcontrib-apidoc = { version = "^0.3", optional = true }  # docs
 sphinxcontrib-programoutput = { version = "^0.17", optional = true }  # docs
 tomli = ">=1.2.2"
-troposphere = ">=2.4, <4"
+troposphere = ">=2.4"
 typing_extensions = "*"  # only really needed for < 3.8 but can still be used in >= 3.8
 urllib3 = "*"  # allow us to follow botocore's hard pinning without needing to update our own
 yamllint = "*"


### PR DESCRIPTION
# Why This Is Needed

To allow the use of `troposphere>=4.0.0` which adds type annotations.

# What Changed

## Changed

- changed troposphere requirement from `>=2.4, <4` to `>=2.4`
