### PR TITLE
fix issue causing terraform installation to fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args:

--- a/runway/cfngin/hooks/staticsite/upload_staticsite.py
+++ b/runway/cfngin/hooks/staticsite/upload_staticsite.py
@@ -300,7 +300,7 @@ def calculate_hash_of_extra_files(
     """
     file_hash = hashlib.md5()
 
-    for extra_file in sorted(extra_files, key=lambda extra_file: extra_file.name):
+    for extra_file in sorted(extra_files, key=lambda x: x.name):
         file_hash.update((extra_file.name + "\0").encode())
 
         if extra_file.content_type:

--- a/runway/env_mgr/tfenv.py
+++ b/runway/env_mgr/tfenv.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import tempfile
 import zipfile
-from distutils.version import LooseVersion
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -31,6 +30,7 @@ from urllib.request import urlretrieve
 import hcl
 import hcl2
 import requests
+from packaging.version import LegacyVersion
 from typing_extensions import Final
 
 from ..compat import cached_property
@@ -114,7 +114,7 @@ def get_available_tf_versions(include_prerelease: bool = False) -> List[str]:
     )["terraform"]
     tf_versions = sorted(
         [k for k, _v in tf_releases["versions"].items()],  # descending
-        key=LooseVersion,
+        key=LegacyVersion,
         reverse=True,
     )
     if include_prerelease:

--- a/tests/unit/env_mgr/test_tfenv.py
+++ b/tests/unit/env_mgr/test_tfenv.py
@@ -70,8 +70,8 @@ def test_get_available_tf_versions(mocker: MockerFixture) -> None:
     mock_requests.get.return_value = MagicMock(text=json.dumps(response))
     assert get_available_tf_versions() == ["0.12.0"]
     assert get_available_tf_versions(include_prerelease=True) == [
-        "0.12.0-beta",
         "0.12.0",
+        "0.12.0-beta",
     ]
 
 


### PR DESCRIPTION
# Why This Is Needed

resolves #1385 

# What Changed

## Changed

- changed use of deprecated `distutils.version.LooseVersion` in `runway.env_mgr.tfenv` to `packaging.version.LegacyVersion`
  - this results in prereleases of a version to be listed after the official release
- upgraded the version of `black` used by `pre-commit` to 22.3.0 to resolve incompatibility with `click >= 8.1.0`

## Fixed

- fixed an issue causing the gathering of available terraform versions to fail
