### PR TITLE
Change the location of the runway.bat for users of Node Version Manager

### DIFF
--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -7,7 +7,7 @@ const tar = require('tar');
 // e.g. '../..' for 'runway'; '../../..' for `@onica/runway', etc
 let pathTraversal = '..'
 for (var i = 0; i < process.env.npm_package_name.split("/").length; i++) {
-    pathTraversal += '/..'
+  pathTraversal += '/..'
 }
 
 const basepath = `${path.resolve(process.cwd(), pathTraversal)}/node_modules`; // goes to the top level node_modules
@@ -87,12 +87,23 @@ fs.mkdir(`${moduleDir}/runway`, { recursive: true }, (err, data) => {
     } else {
       // determine correct bin path to use based on global/local install
       if (process.env.npm_config_global) {
-        binPath = path.resolve(process.env.APPDATA, './npm/runway.bat');
+        binPath = path.resolve(process.env.APPDATA, './npm');
+
+        // If using Node Version Manager (NVM), add the BAT file to a different directory
+        if (!fs.existsSync(binPath) && fs.existsSync(path.resolve(process.env.APPDATA, './nvm'))) {
+          binPath = path.resolve(process.env.APPDATA, './nvm');
+        }
       } else {
-        fs.mkdirSync(`${basepath}/.bin`, { recursive: true });
-        binPath = `${basepath}/.bin/runway.bat`;
+        binPath = path.resolve(basepath, './.bin');
       }
+
+      if (!fs.existsSync(binPath)) {
+        fs.mkdirSync(binPath, { recursive: true });
+      }
+
       // symlink does not work for windows so we need to use a bat file
+      binPath = path.resolve(binPath, 'runway.bat');
+
       // this will overwrite the file if it already exists so no fancy error handling needed
       fs.writeFile(binPath, `@"${moduleDir}/runway/runway-cli.exe" %*`, (err, data) => {
         if (err) throw err;


### PR DESCRIPTION
# Summary

A co-worker of mine running Windows and using the Node Version Manager (NVM) has been unable to install runway as a global NPM package. This problem ultimately is caused by the absence of the `%APPDATA%\npm\` directory where Runway is attempting to install a BAT file.

On each attempt to execute the `npm install --global @onica/serverless` command, this error occurred:

```
Error: ENOENT: no such file or directory, open 'C:\Users\yourname\AppData\Roaming\npm\runway.bat']
npm ERR!   errno: -4058,
npm ERR!   code: 'ENOENT',
npm ERR!   syscall: 'open',
npm ERR!   path: 'C:\\Users\\yourname\\AppData\\Roaming\\npm\\runway.bat'
npm ERR!
```

For those of us running Linux and OSX, the logic in the `postinstall.js` is different, since symlinks are possible. But for Windows users a BAT file is created to help ensure that the `runway` CLI can be found (as an aside, is there a reason that the `bin` prop isn't set in the `package.json`, as this is usually populated for NPM packages which are intended to be run as a CLI?).

For users who are working with multiple versions of NodeJs, a commonly installed tool is __NVM__ (Node Version Manager), which allows easy switching of Node versions. When NVM is installed it doesn't create an `npm/` directory off the `$APPDATA` folder, nor does it add it to the global `$PATH` variable. But it _does_ create an `nvm/` directory and add that to the `$PATH`. It's a slight difference, and only applicable because the `postinstall.js` logic is assuming that `npm/` will always exist whenever `$npm_config_global` has been set.

# Why This Is Needed

Windows users who are running Node Version Manager (aka, NVM) instead of one globally installed version of NodeJs don't necessarily have a `%APPDATA%\npm\` folder. Even if it is created, it isn't added to the global `%PATH%` during installation of NodeJs because the version manager (NVM) doesn't add it. Rather NVM creates a `%APPDATA%\nvm\` directory instead.

# What Changed

Check to see if the `%APPDATA%\npm\` directory is missing and simultaneously if the `%APPDATA%\nvm\` directory exists. If this is the case, assume the latter folder is the one where the `runway.bat` file should reside.