### PR TITLE
add python 3.10 to the matrix, remove 3.7

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,7 +88,7 @@ jobs:
     name: Lint Python
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
         #python-version: [3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -190,7 +190,7 @@ jobs:
     name: Test Python
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
         #python-version: [3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Adding Python v3.10 to GHA workflow and remove Python 3.7.

# Summary


# Why This Is Needed

Maintenance of Python version support.

# What Changed


## Added

- Python v3.10 to GHA


## Removed

- Python v3.7 from GHA


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [ ] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
