### PR TITLE
add python 3.10 to the matrix, remove 3.7

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,7 +88,7 @@ jobs:
     name: Lint Python
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
         #python-version: [3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -190,7 +190,7 @@ jobs:
     name: Test Python
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
         #python-version: [3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Add support for python v3.10 to GHA.

# Summary

Removing Python v3.7 and adding support for v3.10.

# Why This Is Needed

Runtime maintenance.

# What Changed


## Added

Python v3.10 to `cicd.yml`

## Removed

Python v3.7 from `cicd.yml`


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you updated documentation, as applicable?
