### PR TITLE
updated setup-poetry action version to support nodejs 16

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -64,7 +64,7 @@ jobs:
         id: setup-python
         with:
           python-version: 3.9
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3
         id: cache
         with:
@@ -107,7 +107,7 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3
         id: cache
         with:
@@ -133,7 +133,7 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3
         id: cache
         with:
@@ -164,7 +164,7 @@ jobs:
         id: setup-python
         with:
           python-version: 3.9
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3
         id: cache
         with:
@@ -211,7 +211,7 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3
         id: cache
         with:
@@ -258,7 +258,7 @@ jobs:
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
       - name: Install Dependencies (ubuntu)
         run: sudo apt-get update && sudo apt-get install sed -y
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/on-push-pyinstaller.yml
+++ b/.github/workflows/on-push-pyinstaller.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Dependencies (windows)
         if: matrix.os == 'windows-latest'
         run: choco install make sed
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -101,7 +101,7 @@ jobs:
       - name: Install Dependencies (windows)
         if: matrix.os == 'windows-latest'
         run: choco install make sed
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -162,7 +162,7 @@ jobs:
       - name: Install Dependencies (ubuntu)
         if: steps.check_distance.outcome == 'success'
         run: sudo apt-get update && sudo apt-get install sed tree -y
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Dependencies (windows)
         if: matrix.os == 'windows-latest'
         run: choco install make sed
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -96,7 +96,7 @@ jobs:
       - name: Install Dependencies (windows)
         if: matrix.os == 'windows-latest'
         run: choco install make sed
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -149,7 +149,7 @@ jobs:
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
       - name: Install Dependencies (ubuntu)
         run: sudo apt-get update && sudo apt-get install sed tree -y
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -237,7 +237,7 @@ jobs:
           for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
       - name: Install Dependencies (ubuntu)
         run: sudo apt-get update && sudo apt-get install sed -y
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -273,7 +273,7 @@ jobs:
         id: setup-python
         with:
           python-version: 3.8
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -340,7 +340,7 @@ jobs:
         id: setup-python
         with:
           python-version: 3.8
-      - uses: Gr1N/setup-poetry@v7
+      - uses: Gr1N/setup-poetry@v8
       - uses: actions/cache@v3.0.8
         id: cache
         with:


### PR DESCRIPTION

# Summary

Bump GHA version to support newer Node.js version.

# Why This Is Needed

Node.js v12 used in the v7 action is out of date.

# What Changed

`Gr1N/setup-poetry@v7` -> `Gr1N/setup-poetry@v8`


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you updated documentation, as applicable?
