### PR TITLE
adding dirs_exist_ok=True

### DIFF
--- a/runway/blueprints/staticsite/staticsite.py
+++ b/runway/blueprints/staticsite/staticsite.py
@@ -353,7 +353,16 @@ class StaticSite(Blueprint):
         bucket = self.template.add_resource(
             s3.Bucket(
                 "Bucket",
-                AccessControl=(s3.Private if self.cf_enabled else s3.PublicRead),
+                # PublicAccessBlockConfiguration=s3.PublicAccessBlockConfiguration(
+                # )
+                PublicAccessBlockConfiguration=(
+                    s3.PublicAccessBlockConfiguration(BlockPublicAcls="true")
+                    if self.cf_enabled
+                    else s3.PublicAccessBlockConfiguration(BlockPublicAcls="false")
+                ),
+                OwnershipControls=s3.OwnershipControls(
+                    Rules=[s3.OwnershipControlsRule(ObjectOwnership="ObjectWriter")]
+                ),
                 LifecycleConfiguration=s3.LifecycleConfiguration(
                     Rules=[
                         s3.LifecycleRule(

--- a/runway/cfngin/hooks/staticsite/auth_at_edge/lambda_config.py
+++ b/runway/cfngin/hooks/staticsite/auth_at_edge/lambda_config.py
@@ -122,7 +122,9 @@ def write(
             # Copy the template code for the specific Lambda function
             # to the temporary folder
             shutil.copytree(
-                os.path.join(os.path.dirname(__file__), "templates", handler), dirpath
+                os.path.join(os.path.dirname(__file__), "templates", handler),
+                dirpath,
+                dirs_exist_ok=True,
             )
 
             # Save our dynamic configuration shared file to the


### PR DESCRIPTION

# Summary


# Why This Is Needed

auth_at_edge fails with python 3.8+.

# What Changed

## Fixed

Closes #1872 

# Checklist

- [x] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you updated documentation, as applicable?
