### PR TITLE
pin mysqlclient to prevent dependency failures

### DIFF
--- a/tests/functional/cfngin/hooks/test_awslambda/sample_app/src/docker_mysql/Pipfile
+++ b/tests/functional/cfngin/hooks/test_awslambda/sample_app/src/docker_mysql/Pipfile
@@ -4,6 +4,6 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-mysqlclient = "*"
+mysqlclient = "==2.1.1"
 
 [dev-packages]


### PR DESCRIPTION

# Summary

GHA failing due to dependency needs of the mysqlclient.

# Why This Is Needed

https://github.com/PyMySQL/mysqlclient/issues/620

# What Changed

Pinning mysql client to a version that doesn't have new dependencies required.



# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [ ] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
