### PR TITLE
Fix for 2.6.9 install issues and removal of str2bool external library

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -212,6 +212,7 @@
         "filedes",
         "autodetected",
         "addoption",
-        "domparator"
+        "domparator",
+        "Fakhreddine"
     ]
 }

--- a/.vscode/dictionaries/local.txt
+++ b/.vscode/dictionaries/local.txt
@@ -279,7 +279,7 @@ somepath
 sourcer
 sphinxcontrib
 sssz
-strtobool
+str2bool
 stubber
 stubbers
 subcmd

--- a/poetry.lock
+++ b/poetry.lock
@@ -3239,17 +3239,6 @@ files = [
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
-name = "str2bool3"
-version = "1.0.2"
-description = "Convert string to boolean (Forked from SymonSoft/str2bool)"
-optional = false
-python-versions = "*"
-files = [
-    {file = "str2bool3-1.0.2-py3-none-any.whl", hash = "sha256:18d3fac572fc7372cc14ef0b7d39c6c8fb9d5f3c23a8666d99e4c692e2782334"},
-    {file = "str2bool3-1.0.2.tar.gz", hash = "sha256:7ec7b97d1a4646f7e62a58a98052c1df3a6ed22cae18e8b44dd9529c2faf7e2d"},
-]
-
-[[package]]
 name = "sympy"
 version = "1.11.1"
 description = "Computer algebra system (CAS) in Python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.12"
+python = ">=3.8, <4"
 
 # dependencies needed for building docs are included here.
 # they are marked as "optional" and are installed as the extra "docs".
@@ -73,7 +73,6 @@ yamllint = "*"
 pipenv = "2022.1.8"
 moto = "3.0.5"
 testfixtures = "^7.0.3"
-str2bool3 = "*"
 
 [tool.poetry.dev-dependencies]
 black = ">=22.1"

--- a/runway/cfngin/hooks/aws_lambda.py
+++ b/runway/cfngin/hooks/aws_lambda.py
@@ -159,9 +159,9 @@ def should_use_docker(dockerize_pip: DockerizePipArgTypeDef = None) -> bool:
     return False
 
 
-def str2bool(v):  # type: ignore
+def str2bool(v: str):
     """Return boolean value of string."""
-    return v.lower() in ("yes", "true", "t", "1", "on")
+    return v.lower() in ("yes", "true", "t", "1", "on", "y")
 
 
 def _zip_files(files: Iterable[str], root: str) -> Tuple[bytes, str]:

--- a/runway/context/_runway.py
+++ b/runway/context/_runway.py
@@ -5,8 +5,6 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
-from str2bool3 import str2bool as strtobool  # type: ignore
-
 from ..compat import cached_property
 from ..core.components import DeployEnvironment
 from ._base import BaseContext
@@ -18,6 +16,11 @@ if TYPE_CHECKING:
     from ..core.type_defs import RunwayActionTypeDef
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
+
+
+def str2bool(v: str):
+    """Return boolean value of string."""
+    return v.lower() in ("yes", "true", "t", "1", "on", "y")
 
 
 class RunwayContext(BaseContext):
@@ -65,7 +68,7 @@ class RunwayContext(BaseContext):
                 # catch False
                 return not colorize
             if colorize and isinstance(colorize, str):  # type: ignore
-                return not strtobool(colorize)
+                return not str2bool(colorize)
         except ValueError:
             pass  # likely invalid RUNWAY_COLORIZE value
         return not sys.stdout.isatty()

--- a/runway/lookups/handlers/base.py
+++ b/runway/lookups/handlers/base.py
@@ -33,9 +33,9 @@ LOGGER = logging.getLogger(__name__)
 TransformToTypeLiteral = Literal["bool", "str"]
 
 
-def str2bool(v):  # type: ignore
+def str2bool(v: str):
     """Return boolean value of string."""
-    return v.lower() in ("yes", "true", "t", "1", "on")
+    return v.lower() in ("yes", "true", "t", "1", "on", "y")
 
 
 class LookupHandler:

--- a/tests/unit/lookups/handlers/test_base.py
+++ b/tests/unit/lookups/handlers/test_base.py
@@ -157,7 +157,7 @@ class TestLookupHandler:
         assert isinstance(LookupHandler.transform("something", to_type=None), str)
 
     def test_transform_str_to_bool(self) -> None:
-        """String should be transformed using strtobool."""
+        """String should be transformed using str2bool."""
         result_true = LookupHandler.transform("true", to_type="bool")
         result_false = LookupHandler.transform("false", to_type="bool")
 


### PR DESCRIPTION
<!-- The title of the pull request should be a short description of what was done.  -->

<!-- You can remove any parts of this template not applicable to your Pull Request.  -->

# Summary

This fixes some issues that were introduced in https://github.com/onicagroup/runway/pull/2007 

# Why This Is Needed

The main fix in this PR adjusts the Poetry python dependency back to `<4` so it can install in Poetry environments without dependency errors.

# What Changed

1. Reverted the Python dependency change in `pyproject.toml`,
2. Removed Runway's previous dependency on the `str2bool` library. This was tackled elsewhere in Runway's code already with the following helper function:

```python
def str2bool(v: str):
    """Return boolean value of string."""
    return v.lower() in ("yes", "true", "t", "1", "on", "y")
```

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?
