### PR TITLE
Bugfix/remote uri path hyphen support

### DIFF
--- a/runway/core/components/_module_path.py
+++ b/runway/core/components/_module_path.py
@@ -37,7 +37,7 @@ class ModulePath:
     ARGS_REGEX: ClassVar[str] = r"(\?)(?P<args>.*)$"
     REMOTE_SOURCE_HANDLERS: ClassVar[Dict[str, Type[Source]]] = {"git": Git}
     SOURCE_REGEX: ClassVar[str] = r"(?P<source>[a-z]+)(\:\:)"
-    URI_REGEX: ClassVar[str] = r"(?P<uri>[a-z]+://[a-zA-Z0-9\./]+?(?=//|\?|$))"
+    URI_REGEX: ClassVar[str] = r"(?P<uri>[a-z]+://[a-zA-Z0-9\./-]+?(?=//|\?|$))"
 
     def __init__(
         self,

--- a/tests/unit/core/components/test_module_path.py
+++ b/tests/unit/core/components/test_module_path.py
@@ -38,6 +38,15 @@ TypeDefTestDefinition = TypedDict(
 
 TESTS: List[TypeDefTestDefinition] = [
     {
+        "definition": "git::git://github.com/onicagroup/foo/foo-bar.git",
+        "expected": {
+            "location": "./",
+            "arguments": {},
+            "source": "git",
+            "uri": "git://github.com/onicagroup/foo/foo-bar.git",
+        },
+    },
+    {
         "definition": "git::git://github.com/onicagroup/foo/bar.git",
         "expected": {
             "location": "./",


### PR DESCRIPTION
# Summary

Add support for hyphens in URIs of remote source paths.

# Why This Is Needed

URIs with hyphens will not work.

# What Changed

## Added

Unit test for hyphenated URIs

## Fixed

Path URI regex updated to include `-`

Closes #1989 


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you updated documentation, as applicable?
