### PR TITLE
Fix for npm upload failure

### DIFF
--- a/.github/workflows/on-push-pyinstaller.yml
+++ b/.github/workflows/on-push-pyinstaller.yml
@@ -182,7 +182,7 @@ jobs:
         if: steps.check_distance.outcome == 'success'
         uses: actions/download-artifact@v3
         with:
-          name: pyinstaller-onefolder-ubuntu-22.04
+          name: pyinstaller-onefolder-ubuntu-latest
           path: artifacts
       - name: Download Artifacts (windows)
         if: steps.check_distance.outcome == 'success'

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Download Artifacts (ubuntu)
         uses: actions/download-artifact@v3
         with:
-          name: pyinstaller-onefolder-ubuntu-22.04
+          name: pyinstaller-onefolder-ubuntu-latest
           path: artifacts
       - name: Download Artifacts (windows)
         uses: actions/download-artifact@v3
@@ -311,7 +311,7 @@ jobs:
       - name: Download Artifacts (ubuntu)
         uses: actions/download-artifact@v3
         with:
-          name: pyinstaller-onefile-ubuntu-22.04
+          name: pyinstaller-onefile-ubuntu-latest
           path: artifacts
       - name: Download Artifacts (windows)
         uses: actions/download-artifact@v3


### PR DESCRIPTION
<!-- The title of the pull request should be a short description of what was done.  -->

<!-- You can remove any parts of this template not applicable to your Pull Request.  -->

# Summary

npm/S3 Runway installation uploads are broken due to the runner type change to `ubuntu-latest`. This PR adjusts naming in the npm/s3 upload steps to the new value.

# Why This Is Needed

Hopefully fixes npm/s3 release uploads.

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you updated documentation, as applicable?
