### PR TITLE
resolve pydantic error in test_awslambda

### DIFF
--- a/tests/functional/cfngin/hooks/test_awslambda/test_runner.py
+++ b/tests/functional/cfngin/hooks/test_awslambda/test_runner.py
@@ -69,7 +69,7 @@ class AwslambdaStackOutputs(BaseModel):
     Runtime: str
 
     @root_validator(allow_reuse=True, pre=True)
-    def _convert_null_to_none(self, values: dict[str, Any]) -> dict[str, Any]:
+    def _convert_null_to_none(cls, values: dict[str, Any]) -> dict[str, Any]:  # noqa: N805
         """Convert ``null`` to ``NoneType``."""
 
         def _handle_null(v: Any) -> Any:


### PR DESCRIPTION
# Why This Is Needed

resolves #2459

# What Changed

## Fixed

- fixed issue caused by bad resolution of [N805](https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-method/)
