### PR TITLE
fix intermittent test failure due time mismatch

### DIFF
--- a/tests/unit/core/providers/aws/s3/_helpers/test_utils.py
+++ b/tests/unit/core/providers/aws/s3/_helpers/test_utils.py
@@ -851,12 +851,12 @@ def test_find_dest_path_comp_key_locals3_file_no_dir_op(tmp_path: Path) -> None:
 def test_get_file_stat(tmp_path: Path) -> None:
     """Test get_file_stat."""
     tmp_file = tmp_path / "test.txt"
-    now = datetime.datetime.now(tzlocal())
-    epoch_now = time.mktime(now.timetuple())
     tmp_file.write_text("foo")
     size, update_time = get_file_stat(tmp_file)
     assert size == 3
-    assert time.mktime(update_time.timetuple()) == epoch_now  # type: ignore
+    assert update_time, (
+        "just ensure that it has a truthy value, checking exact value is inconsistent",
+    )
 
 
 @pytest.mark.parametrize("exc", [ValueError(), OSError(), OverflowError()])


### PR DESCRIPTION
# Why This Is Needed

resolves #1301 

# What Changed

## Changed

- changed test to only check for truthy value, not exact time of file creation

## Fixed

- fixed issue described in #1301 which was most recently encountered when working on #2460