### PR TITLE
update documentation URLs to reflect EoL of onica.com

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 To view our [Getting Started] guide for developers and [Contribution Requirements], please refer to the official [documentation].
 
-[contribution requirements]: https://docs.onica.com/projects/runway/page/developers/contributing.html
-[documentation]: https://docs.onica.com/projects/runway
-[getting started]: https://docs.onica.com/projects/runway/page/developers/getting_started.html
+[contribution requirements]: https://runway.readthedocs.io/page/developers/contributing.html
+[documentation]: https://runway.readthedocs.io
+[getting started]: https://runway.readthedocs.io/page/developers/getting_started.html

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,7 @@
 
 <!-- You can erase any parts of this template not applicable to your Pull Request. -->
 
-- [ ] Have you followed the guidelines in our [Contribution Requirements](https://docs.onica.com/projects/runway/page/developers/contributing.html)?
+- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
 - [ ] Does your submission pass tests?
 - [ ] Have you linted your code locally prior to submission?

--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ $ poetry run runway new
 
 ## Documentation
 
-See the [doc site](https://docs.onica.com/projects/runway) for full documentation.
+See the [doc site](https://runway.readthedocs.io) for full documentation.
 
-Quickstart documentation, including CloudFormation templates and walkthrough can be found [here](https://docs.onica.com/projects/runway/page/quickstart/index.html)
+Quickstart documentation, including CloudFormation templates and walkthrough can be found [here](https://runway.readthedocs.io/page/quickstart/index.html)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -134,7 +134,7 @@ Deploying Your First Module
     :caption: runway.yml
 
     ---
-    # See full syntax at https://docs.onica.com/projects/runway
+    # See full syntax at https://runway.readthedocs.io
     deployments:
       - modules:
           - nameofmyfirstmodulefolder
@@ -155,7 +155,7 @@ Deploying Your First Module
     :caption: runway.yml
 
     ---
-    # See full syntax at https://docs.onica.com/projects/runway
+    # See full syntax at https://runway.readthedocs.io
     deployments:
       - modules:
           - sampleapp.cfn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Topic :: Utilities",
 ]
 description = "Simplify infrastructure/app testing/deployment"
-documentation = "https://docs.onica.com/projects/runway"
+documentation = "https://runway.readthedocs.io"
 homepage = "https://github.com/onicagroup/runway"
 keywords = ["cli"]
 license = "Apache-2.0"

--- a/runway/_cli/commands/_docs.py
+++ b/runway/_cli/commands/_docs.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
 
-DOCS_URL = "https://docs.onica.com/projects/runway/"
+DOCS_URL = "https://runway.readthedocs.io/"
 
 
 @click.command("docs", short_help="open doc site")

--- a/runway/_cli/commands/_new.py
+++ b/runway/_cli/commands/_new.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__.replace("._", ".")))
 RUNWAY_YML = """---
-# See full syntax at https://docs.onica.com/projects/runway
+# See full syntax at https://runway.readthedocs.io
 deployments:
   - modules:
       - path: sampleapp.cfn
@@ -44,5 +44,5 @@ def new(ctx: click.Context, **_: Any) -> None:
     LOGGER.success("runway.yml generated")
     LOGGER.notice(
         "See addition getting started information at "
-        "https://docs.onica.com/projects/runway/page/getting_started.html"
+        "https://runway.readthedocs.io/page/getting_started.html"
     )

--- a/runway/_cli/main.py
+++ b/runway/_cli/main.py
@@ -65,7 +65,7 @@ class _CliGroup(click.Group):
 def cli(ctx: click.Context, **_: Any) -> None:
     """Runway CLI.
 
-    Full documentation available at https://docs.onica.com/projects/runway/
+    Full documentation available at https://runway.readthedocs.io/
 
     """
     opts = ctx.meta["global.options"]

--- a/runway/cfngin/blueprints/base.py
+++ b/runway/cfngin/blueprints/base.py
@@ -343,7 +343,7 @@ class Blueprint(DelCachedPropMixin):
                 "deprecated PARAMETERS or "
                 "LOCAL_PARAMETERS, rather than VARIABLES. "
                 "Please update your blueprints. See "
-                "https://docs.onica.com/projects/runway/page/cfngin/blueprints.html#variables "
+                "https://runway.readthedocs.io/page/cfngin/blueprints.html#variables "
                 "for additional information."
             )
 

--- a/runway/utils/__init__.py
+++ b/runway/utils/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from ..compat import Self
 
 AWS_ENV_VARS = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN")
-DOC_SITE = "https://docs.onica.com/projects/runway"
+DOC_SITE = "https://runway.readthedocs.io"
 EMBEDDED_LIB_PATH = str(Path(__file__).resolve().parent / "embedded")
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/integration/cli/commands/test_docs.py
+++ b/tests/integration/cli/commands/test_docs.py
@@ -12,7 +12,7 @@ from runway._cli import cli
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
-DOCS_URL = "https://docs.onica.com/projects/runway/"
+DOCS_URL = "https://runway.readthedocs.io/"
 
 
 @patch("click.launch")

--- a/tests/integration/cli/commands/test_new.py
+++ b/tests/integration/cli/commands/test_new.py
@@ -32,7 +32,7 @@ def test_new(cd_tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     assert caplog.messages == [
         "runway.yml generated",
         "See addition getting started information at "
-        "https://docs.onica.com/projects/runway/page/getting_started.html",
+        "https://runway.readthedocs.io/page/getting_started.html",
     ]
 
 


### PR DESCRIPTION
# Summary

> [!NOTE]
> - https://www.rackspace.com/newsroom/rackspace-acquire-onica-cloud-native-consulting-and-managed-services-company
> - https://www.rackspace.com/onica

Update documentation URLs to reflect the EoL of onica.com.
This also migrates our documentation from Read the **Docs for Business** to **Read the Docs Community**.

# What Changed

## Changed

- replaced [`docs.onica.com/projects/runway`](https://docs.onica.com/projects/runway) with [`runway.readthedocs.io`](https://runway.readthedocs.io)