### PR TITLE
`docker.hook_data.DockerHookData` is now always truthy

### DIFF
--- a/runway/cfngin/hooks/docker/hook_data.py
+++ b/runway/cfngin/hooks/docker/hook_data.py
@@ -47,3 +47,7 @@ class DockerHookData(MutableMap):
         new_obj = cls()
         context.hook_data["docker"] = new_obj
         return new_obj
+
+    def __bool__(self) -> bool:
+        """Implement evaluation of instances as a bool."""
+        return True

--- a/tests/unit/cfngin/hooks/docker/test_hook_data.py
+++ b/tests/unit/cfngin/hooks/docker/test_hook_data.py
@@ -17,6 +17,10 @@ MODULE = "runway.cfngin.hooks.docker.hook_data"
 class TestDockerHookData:
     """Test runway.cfngin.hooks.docker._hook_data.DockerHookData."""
 
+    def test___bool__(self) -> None:
+        """Test __bool__."""
+        assert DockerHookData()
+
     def test_client(self, mocker: MockerFixture) -> None:
         """Test client."""
         mock_local_client = mocker.patch(MODULE + ".DockerClient")


### PR DESCRIPTION
# Why This Is Needed

`docker.hook_data.DockerHookData` is always falsey.

resolves #2401

# What Changed

## Changed

- `docker.hook_data.DockerHookData` is now always truthy so it can be easily distinguished from `None`
