### PR TITLE
Corrected docs for plan command

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -167,7 +167,7 @@ plan
 
 .. note:: Currently only supported for :ref:`index:AWS Cloud Development Kit (CDK)`, :ref:`index:CloudFormation & Troposphere`, and :ref:`index:Terraform`.
 
-.. command-output:: runway new --help
+.. command-output:: runway plan --help
 
 .. rubric:: Example
 .. code-block:: sh

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
-version = 1
-revision = 3
 requires-python = ">=3.12"
+revision = 3
+version = 1


### PR DESCRIPTION
It appears that there was a copy 'n' paste error in the docs. This is a single-line change that should cause the docs to have the correct command help output for `plan`, rather than `new`.

- [x] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
